### PR TITLE
bump eslint 2.2.0 + lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-preset-stage-1": "^6.3.13",
     "compression-webpack-plugin": "0.2.0",
     "css-loader": "^0.23.0",
-    "eslint": "^2.2.0",
+    "eslint": "~2.2.0",
     "eslint-plugin-ava": "0.0.1",
     "eslint-plugin-jsx": "0.0.2",
     "express": "^4.13.3",

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -6,4 +6,4 @@ export default (renderer) => {
   const useRenderer = (component) => partial(component, renderer);
   const bundle = mapValues(components, useRenderer);
   return {...bundle};
-}
+};


### PR DESCRIPTION
This addresses the eslint+estraverse issue (eslint/eslint#5476).
We can bump the version once a solid conclusion has been reached.

note about `~` vs `^` http://stackoverflow.com/a/22345808
