### PR TITLE
Update postcss-loader to version 0.9.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "json-loader": "^0.5.4",
     "lodash": "^4.6.1",
     "nyc": "^6.1.1",
-    "postcss-loader": "^0.8.2",
+    "postcss-loader": "^0.9.0",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",
     "style-loader": "^0.13.0",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[postcss-loader](https://www.npmjs.com/package/postcss-loader) just published its new version 0.9.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of postcss-loader – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 11 commits .
- [`52e7a21`](https://github.com/postcss/postcss-loader/commit/52e7a21c104caa485678c7edf9ca5d07ba8cb09b) `Release 0.9 version`
- [`de033ea`](https://github.com/postcss/postcss-loader/commit/de033ea6dc756a7af74b34d118d7b6b03810fa1b) `Update dependencies`
- [`e4970d6`](https://github.com/postcss/postcss-loader/commit/e4970d6ae551bb8fe90dc4f38a5adb18f65d88c7) `Allow to override syntax in query string`
- [`7059767`](https://github.com/postcss/postcss-loader/commit/7059767e818ffe71b4a0b09aebf056f13da15bff) `Respect holy 80 symbols line`
- [`0231cba`](https://github.com/postcss/postcss-loader/commit/0231cbab7674bea3801004a44bd3e290efdc2b5c) `Merge pull request #59 from jenius/master`
- [`8e7ae53`](https://github.com/postcss/postcss-loader/commit/8e7ae5379d0974c50c2c1cef92ac7fbccc67b227) `Update dependencies`
- [`6c15025`](https://github.com/postcss/postcss-loader/commit/6c15025b3cf006b1e17fa0ed8a0d1c0a5a1ccf4e) `Update README.md`
- [`9b4d616`](https://github.com/postcss/postcss-loader/commit/9b4d616727538beaf081fa41bfe8f46b1c3f8a32) `Fix order of plugins in README`
- [`ac56fc6`](https://github.com/postcss/postcss-loader/commit/ac56fc648c0e99ef24baf0bcdaacfc8942cfa321) `Merge pull request #61 from wesleyb-io/update-reamde-to-include-install-instructions`
- [`01ad389`](https://github.com/postcss/postcss-loader/commit/01ad3891ff1a451d7782f55fa6abfc9a976e2803) `Update README.md to include install instructions`
- [`523249a`](https://github.com/postcss/postcss-loader/commit/523249ae74bd4f087951779553a6d56e0d7f429b) `add capability to pass other options as function`

See the [full diff](https://github.com/postcss/postcss-loader/compare/f533137b61cd50c71160f5621e3be3886f21bb10...52e7a21c104caa485678c7edf9ca5d07ba8cb09b).
