### PR TITLE
babel-core@6.8.0 breaks build 🚨

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "autoprefixer": "^6.3.3",
     "ava": "^0.14.0",
     "babel-cli": "^6.6.5",
-    "babel-core": "^6.7.0",
+    "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-react-jsx": "^6.6.5",
@@ -74,6 +74,8 @@
     "babel": "inherit"
   },
   "dependencies": {
+    "babel-cli": "^6.8.0",
+    "babel-plugin-transform-react-jsx": "^6.8.0",
     "d3": "^3.5.16",
     "nvd3": "^1.8.2"
   }


### PR DESCRIPTION
Hello :wave:

:rotating_light::rotating_light::rotating_light:

[babel-core](https://www.npmjs.com/package/babel-core) just published its new version 6.8.0, which **is covered by your current version range**. After updating it in your project **the build went from success to failure**.

This means **your software is now malfunctioning**, because of this update. Use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:
