### PR TITLE
babel-plugin-transform-react-jsx@6.8.0 breaks build 🚨

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "babel-core": "^6.7.0",
     "babel-eslint": "^6.0.0",
     "babel-loader": "^6.2.4",
-    "babel-plugin-transform-react-jsx": "^6.6.5",
+    "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-1": "^6.5.0",
     "compression-webpack-plugin": "^0.3.1",


### PR DESCRIPTION
Hello :wave:

:rotating_light::rotating_light::rotating_light:

[babel-plugin-transform-react-jsx](https://www.npmjs.com/package/babel-plugin-transform-react-jsx) just published its new version 6.8.0, which **is covered by your current version range**. After updating it in your project **the build went from success to failure**.

This means **your software is now malfunctioning**, because of this update. Use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:
