### PR TITLE
eslint@2.10.0 breaks build 🚨

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "coveralls": "^2.11.8",
     "css-loader": "^0.23.0",
     "eslint": "^2.10.0",
+    "eslint-plugin-ava": "^2.3.1",
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",


### PR DESCRIPTION
Hello :wave:

:rotating_light::rotating_light::rotating_light:

[eslint](https://www.npmjs.com/package/eslint) just published its new version 2.10.0, which **is covered by your current version range**. After updating it in your project **the build went from success to failure**.

This means **your software is now malfunctioning**, because of this update. Use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 56 commits .
- [`8b78697`](https://github.com/eslint/eslint/commit/8b78697f1c2f20fda8a4ec53819be76be3de2193) `2.10.0`
- [`b299e2d`](https://github.com/eslint/eslint/commit/b299e2d5794226dfba94c0db06f99ce9e8663cdf) `Build: package.json and changelog update for 2.10.0`
- [`098cd9c`](https://github.com/eslint/eslint/commit/098cd9cb0929485e9ed4a95f600c3ef8eba1d84c) `Docs: Distinguish examples in rules under Stylistic Issues part 4 (#6136)`
- [`805742c`](https://github.com/eslint/eslint/commit/805742ca2bfe9c770f9eaaaa51a5d5dc49e5f492) `Docs: Clarify JSX option usage (#6132)`
- [`10b0933`](https://github.com/eslint/eslint/commit/10b0933ee793c3a85276444c965dcdfd8e32a429) `Fix: Optimize no-irregular-whitespace for the common case (fixes #6116) (#6117)`
- [`36bec90`](https://github.com/eslint/eslint/commit/36bec90bd3cfb3b1661496263ff193036822e968) `Docs: linkify URLs in development-environment.md (#6150)`
- [`29c401a`](https://github.com/eslint/eslint/commit/29c401acdee03140b3268e6c1f477834092a22c7) `Docs: Convert rules in index under Removed from list to table (#6091)`
- [`e13e696`](https://github.com/eslint/eslint/commit/e13e6961b9ff6b2847f9a8753154e28ccfeda37b) `Fix:`_`and`$`in isES5Constructor (fixes #6085) (#6094)`
- [`67916b9`](https://github.com/eslint/eslint/commit/67916b9bde7a2790490a44d0191a5983bc9351d0) `Fix:`no-loop-func`crashed (fixes #6130) (#6138)`
- [`d311a62`](https://github.com/eslint/eslint/commit/d311a6229353e2b4e11c3339a6caed689c50e3e2) `Fix: Sort fixes consistently even if they overlap (fixes #6124) (#6133)`
- [`6294459`](https://github.com/eslint/eslint/commit/6294459bb675bdeac1a6bb0961f227bc049fdc75) `Docs: Correct syntax for default ignores and`.eslintignore`example (#6118)`
- [`067db14`](https://github.com/eslint/eslint/commit/067db143b140b04c4813a204d91adb9e19530bcc) `Fix: Replace`assert.deepEqual`by`lodash.isEqual`(fixes #6111) (#6112)`
- [`52fdf04`](https://github.com/eslint/eslint/commit/52fdf0409a7d77ab0f31323c6f3adb37b5c17552) `Fix:`no-multiple-empty-lines`duplicate errors at BOF (fixes #6113) (#6114)`
- [`e6f56da`](https://github.com/eslint/eslint/commit/e6f56dab6b50caa5e515fe8a8534f92249c6c469) `Docs: Document`--ignore-pattern`(#6120)`
- [`ef739cd`](https://github.com/eslint/eslint/commit/ef739cd521aaef0f378d7ae5310cbf653ef9ab8e) `Fix: Merge various command line configs at the same time (fixes #6104) (#6108)`

There are 56 commits in total. See the [full diff](https://github.com/eslint/eslint/compare/d8887638a9eaeeda6ea09f7d625d1bc57ea7f436...8b78697f1c2f20fda8a4ec53819be76be3de2193).
