### PR TITLE
Update ava to version 0.15.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@coorpacademy/eslint-plugin-coorpacademy": "^1.1.1",
     "angular": "^1.5.2",
     "autoprefixer": "^6.3.3",
-    "ava": "^0.14.0",
+    "ava": "^0.15.0",
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.0",
     "babel-eslint": "^6.0.0",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[ava](https://www.npmjs.com/package/ava) just published its new version 0.15.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of ava – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 92 commits .
- [`c9c00d6`](https://github.com/avajs/ava/commit/c9c00d626e4c7f1fe7ff31eea763ff9b6983032c) `0.15.0`
- [`7486dcb`](https://github.com/avajs/ava/commit/7486dcba83a9f4e9e059b6f6626798b9f528ff76) `add test.failing and add cb to test.serial (#866)`
- [`77b55e5`](https://github.com/avajs/ava/commit/77b55e57ae6c31d4be1e2b55cc45512284c70f78) `Move images to media folder.`
- [`463dbd4`](https://github.com/avajs/ava/commit/463dbd4d1910fe5b97050f85107f70730683ac49) `bump update-notifier. (#869)`
- [`bc11e08`](https://github.com/avajs/ava/commit/bc11e0828e2b69bdcce81ef43a9b9090db1d8f7f) `Fix AppVeyor Badge (leave it pointing to Sindre's account).`
- [`6f83264`](https://github.com/avajs/ava/commit/6f8326434f07ead9b51bc69c8beabeb9b8187dfa) `document always hook with fail fast flag (#858)`
- [`1d51231`](https://github.com/avajs/ava/commit/1d512315bc14a639155d0197b06d5ac966ba3770) `fix warning message`
- [`a499523`](https://github.com/avajs/ava/commit/a499523660206afcec72cd99148c8a49745ab106) `Drop unused`silent`option from`lib/fork.js`. (#864)`
- [`a543b9f`](https://github.com/avajs/ava/commit/a543b9f7c21a84ed4091e0c30587941152c3a4d2) `revert npm link fix. (#859)`
- [`0ef6dc4`](https://github.com/avajs/ava/commit/0ef6dc4f09dccc3f95336f8f63de59445fdeb93a) `Fix "Test files must be run with the AVA CLI" warning. (#862)`
- [`e01ee00`](https://github.com/avajs/ava/commit/e01ee00a2d9d4d84f18c9f85c38fc6b27ce09445) `Pass shared caches to`globby`. (#860)`
- [`3763109`](https://github.com/avajs/ava/commit/37631098b456e1275bf46c4ffea47b583cf86278) `Avoid running the same file multiple times (#856)`
- [`178175f`](https://github.com/avajs/ava/commit/178175f0eab288439ffc1a12112331fcd5a9fdfb) `add output for failing tests (#837)`
- [`ea9c752`](https://github.com/avajs/ava/commit/ea9c75271f885db1cfd630656259eed6166ef8d9) `added missing todo definition for typescript (#846)`
- [`f35da7e`](https://github.com/avajs/ava/commit/f35da7e10df6d2abf74ac9af3dd1ac8d8903bf7e) `RunStatus#prefixTitle should remove this.base only if it occurs at the beginning of the path (#844)`

There are 92 commits in total. See the [full diff](https://github.com/avajs/ava/compare/1e0b1c14475fde7eb6d4c3109d2af3958b77704f...c9c00d626e4c7f1fe7ff31eea763ff9b6983032c).
