### PR TITLE
ava@0.15.2 breaks build 🚨

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@coorpacademy/eslint-plugin-coorpacademy": "^1.1.1",
     "angular": "^1.5.2",
     "autoprefixer": "^6.3.3",
-    "ava": "^0.15.0",
+    "ava": "^0.15.2",
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.0",
     "babel-eslint": "^6.0.0",


### PR DESCRIPTION
Hello :wave:

:rotating_light::rotating_light::rotating_light:

[ava](https://www.npmjs.com/package/ava) just published its new version 0.15.2, which **is covered by your current version range**. After updating it in your project **the build went from success to failure**.

This means **your software is now malfunctioning**, because of this update. Use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 5 commits .
- [`19625c9`](https://github.com/avajs/ava/commit/19625c9dd1bde2cbbe323f79e393b083ba2ccb78) `0.15.2`
- [`94ef905`](https://github.com/avajs/ava/commit/94ef9053391206beb3907af8b72e4802455f0100) `use currently-unhandled`
- [`63b4782`](https://github.com/avajs/ava/commit/63b478221fa7c74e009aafe97bab9837cd1e0f45) `0.15.1`
- [`ab3418f`](https://github.com/avajs/ava/commit/ab3418fe62e1bcf2514b127ee340574027c507a3) `Prevent suppression of defaults in ava-files (#878)`
- [`abd8bd2`](https://github.com/avajs/ava/commit/abd8bd2370d3f431068001eb89d12ce00808466c) `minor tweaks`

See the [full diff](https://github.com/avajs/ava/compare/c9c00d626e4c7f1fe7ff31eea763ff9b6983032c...19625c9dd1bde2cbbe323f79e393b083ba2ccb78).
