### PR TITLE
Change link implementation

### DIFF
--- a/src/@coorpacademy/components/atom/link/index.js
+++ b/src/@coorpacademy/components/atom/link/index.js
@@ -1,3 +1,4 @@
+import identity from 'lodash/fp/identity';
 import {checker, createValidate} from '../../util/validation';
 import {pushToHistory} from '../../util/navigation';
 
@@ -11,12 +12,14 @@ const conditions = checker.shape({
 
 export default (treant, options = {}) => {
   const {h} = treant;
+  const {history: {createHref = identity} = {}} = options;
   const onClick = pushToHistory(options);
 
   const Link = (props, children) => (
     <a
       {...props}
-      onClick={onClick}
+      href={createHref(props.href)}
+      onClick={onClick(props)}
     >
       {children}
     </a>

--- a/src/@coorpacademy/components/molecule/catalog-cta/index.js
+++ b/src/@coorpacademy/components/molecule/catalog-cta/index.js
@@ -51,14 +51,14 @@ export default (treant, options = {}) => {
           />
         </div>
         <HoverFill>
-          <Link className={style.try} href={linkTry}>
+          <a className={style.try} href={linkTry}>
             {startLearning}
-          </Link>
+          </a>
         </HoverFill>
         <HoverFill>
-          <Link className={style.buy} href={linkBuy}>
+          <a className={style.buy} href={linkBuy}>
             {premium}
-          </Link>
+          </a>
         </HoverFill>
       </div>
     );

--- a/src/@coorpacademy/components/util/navigation.js
+++ b/src/@coorpacademy/components/util/navigation.js
@@ -7,15 +7,14 @@ const isModifiedEvent = event => !!(event.metaKey || event.altKey || event.ctrlK
 
 export const pushToHistory = ({history = {}}) => {
   if (!has('push', history)) {
-    return () => {};
+    return () => () => {};
   }
 
-  return event => {
-    if (!has('target.href', event) || event.defaultPrevented || isModifiedEvent(event) || !isLeftClickEvent(event)) {
+  return ({href} = {}) => event => {
+    if (!href || event.defaultPrevented || isModifiedEvent(event) || !isLeftClickEvent(event)) {
       return;
     }
-
     event.preventDefault();
-    history.push(event.target.href);
+    history.push(href);
   };
 };

--- a/src/@coorpacademy/components/util/test/navigation.js
+++ b/src/@coorpacademy/components/util/test/navigation.js
@@ -22,23 +22,23 @@ test('should push to history navigation event', t => {
       push: href => t.is(href, '/foo')
     }
   };
-  const eventOptions = {
+  const props = {
     href: '/foo'
   };
   const onClick = pushToHistory(options);
-  const event = createEvent(eventOptions);
+  const event = createEvent(props);
 
-  onClick(event);
+  onClick(props)(event);
 });
 
 test('should not do anything if history is not in the options', t => {
-  const eventOptions = {
+  const props = {
     href: '/foo'
   };
   const onClick = pushToHistory({});
-  const event = createEvent(eventOptions);
+  const event = createEvent(props);
 
-  onClick(event);
+  onClick(props)(event);
 });
 
 test('should not do anything if event does not contain a target href', t => {
@@ -49,7 +49,7 @@ test('should not do anything if event does not contain a target href', t => {
   };
   const onClick = pushToHistory(options);
 
-  onClick({});
+  onClick({})({});
 });
 
 test('should not do anything if event is prevented', t => {
@@ -59,14 +59,14 @@ test('should not do anything if event is prevented', t => {
     }
   };
 
-  const eventOptions = {
+  const props = {
     href: '/foo',
     defaultPrevented: true
   };
   const onClick = pushToHistory(options);
-  const event = createEvent(eventOptions);
+  const event = createEvent(props);
 
-  onClick(event);
+  onClick(props)(event);
 });
 
 test('should not do anything if event is mouse click but not left click', t => {
@@ -76,14 +76,14 @@ test('should not do anything if event is mouse click but not left click', t => {
     }
   };
 
-  const eventOptions = {
+  const props = {
     href: '/foo',
     button: 1
   };
   const onClick = pushToHistory(options);
-  const event = createEvent(eventOptions);
+  const event = createEvent(props);
 
-  onClick(event);
+  onClick(props)(event);
 });
 
 test('should not do anything if event is mouse click used with keyboard modifiers', t => {
@@ -93,12 +93,16 @@ test('should not do anything if event is mouse click used with keyboard modifier
     }
   };
 
+  const props = {
+    href: '/foo'
+  };
+
   const createEventWithModifier = modifier =>
-    createEvent({href: '/foo', [modifier]: true});
+    createEvent({...props, [modifier]: true});
 
   const onClick = pushToHistory(options);
-  onClick(createEventWithModifier('altKey'));
-  onClick(createEventWithModifier('metaKey'));
-  onClick(createEventWithModifier('ctrlKey'));
-  onClick(createEventWithModifier('shiftKey'));
+  onClick(props)(createEventWithModifier('altKey'));
+  onClick(props)(createEventWithModifier('metaKey'));
+  onClick(props)(createEventWithModifier('ctrlKey'));
+  onClick(props)(createEventWithModifier('shiftKey'));
 });


### PR DESCRIPTION
À cause du changement du basename de transifex, on a besoin d'utiliser `useBasename` d'`history`. Donc toutes les URL doivent être contruite à partir de l'instance pour rajouter le bon `basename`.

```
const history = useBasename(useQueries(createHistory))({
  basename: '/basename'
});

history.createHref('/page'); // '/basename/page'

<Link href="/page"/> // => <a href="/basename/page"/>
// onClick
history.push('/page') // => navigation vers /basename/page
```

Pour les liens qui sortent de l'app, on utilisera un `<a/>` le temps de trouver la bonne technique pour les différencier.
