### PR TITLE
(components) Add locales folder

### DIFF
--- a/packages/@coorpacademy-components/locales/index.js
+++ b/packages/@coorpacademy-components/locales/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  en: require('./en/global.json'),
+  fr: require('./fr/global.json')
+};

--- a/packages/@coorpacademy-components/package.json
+++ b/packages/@coorpacademy-components/package.json
@@ -7,7 +7,7 @@
   "files": [
     "lib",
     "es",
-    "README.md"
+    "locales"
   ],
   "scripts": {
     "start": "npm run generate:demo && BABEL_ENV=commonjs babel-node demo/index.js",


### PR DESCRIPTION
(@coorpacademy-components)

Publication du dossier `locales` avec un fichier d'index dans le package @coorpacademy/components. 

C'est utilisé dans l'app-backoffice mais n'a pas été gardé lorsque les components sont passés en v3.
