### PR TITLE
Adds context support

### DIFF
--- a/packages/@coorpacademy-treantjs-adapter-angular/demo/index.js
+++ b/packages/@coorpacademy-treantjs-adapter-angular/demo/index.js
@@ -21,8 +21,8 @@ app.use(
 app.get('*', (req, res) => {
   res.send(`
     <body ng-app="app" ng-controller="main">
-      <input ng-model="props.children"/>
-      <coorp-title props="props"></coorp-title>
+      <input ng-model="props.children" />
+      <coorp-display-value props="props" context="context"></coorp-display-value>
       <script type="text/javascript" src="/dist/angular.js"></script>
     </body>
   `);

--- a/packages/@coorpacademy-treantjs-adapter-angular/package.json
+++ b/packages/@coorpacademy-treantjs-adapter-angular/package.json
@@ -46,6 +46,7 @@
     "babel-preset-stage-1": "^6.5.0",
     "cross-env": "^4.0.0",
     "express": "^4.14.0",
+    "prop-types": "^15.5.8",
     "rimraf": "^2.6.1",
     "webpack": "^2.1.0-beta.24",
     "webpack-dev-middleware": "^1.4.0",

--- a/packages/@coorpacademy-treantjs-adapter-angular/src/index.js
+++ b/packages/@coorpacademy-treantjs-adapter-angular/src/index.js
@@ -4,24 +4,14 @@ import ReactDOM from 'react-dom';
 
 const DefaultProvider = props => props.children;
 
-const _link = ($rootScope, $i18next, scope, element, Provider, Component) => {
-  const translate = (token, data) => $i18next(`coorponents:${token}`, data);
-
+const link = (Provider, Component) => (scope, element, attrs) => {
   const update = vTree => {
     ReactDOM.render(vTree, element[0]);
   };
 
-  const refresh = props => {
-    if (props === undefined)
-      return;
-
-    const options = {
-      skin: $rootScope.skin,
-      translate
-    };
-
+  const refresh = (context = {}, props = {}) => {
     const vTree = (
-      <Provider {...options}>
+      <Provider {...context}>
         <Component {...props} />
       </Provider>
     );
@@ -29,30 +19,25 @@ const _link = ($rootScope, $i18next, scope, element, Provider, Component) => {
     update(vTree);
   };
 
-  $rootScope.$watch('skin', () => refresh(scope.props, $rootScope.skin), true);
-  scope.$watch('props', () => refresh(scope.props, $rootScope.skin), true);
+  scope.$watch('context', () => refresh(scope.context, scope.props), true);
+  scope.$watch('props', () => refresh(scope.context, scope.props), true);
 
   scope.$on('$destroy', () => window.angular.element(element).remove());
 };
 
 const createDirective = (app, componentName, Provider, Component) => {
-  const directive = ($rootScope, $i18next) => {
-    const link = (scope, element, attrs) => {
-      _link($rootScope, $i18next, scope, element, Provider, Component);
-    };
-
+  const directive = () => {
     return {
       restrict: 'E',
-      link,
+      link: link(Provider, Component),
       scope: {
-        props: '='
+        props: '=',
+        context: '='
       }
     };
   };
 
   app.directive(componentName, [
-    '$rootScope',
-    '$i18next',
     directive
   ]);
 };


### PR DESCRIPTION
Maintenant, on injecte le context de la même manière que les props.
```html
<coorp-display-value props="props" context="context"></coorp-display-value>
```

Ce supprime la spécification du code au mooc.
On ne répère plus le `skin` de `$rootScope`, ni `translate` de `$i18n`.