### PR TITLE
Refacto updateState

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step.js
@@ -8,6 +8,7 @@ import {hasFinished, isAlive} from './util';
 const defaultState = {
   lives: 4,
   slides: [],
+  isCorrect: true,
   nextContent: {
     ref: '',
     type: ''

--- a/packages/@coorpacademy-progression-engine/src/test/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/test/update-state.js
@@ -1,26 +1,81 @@
 // @flow
 import test from 'ava';
+import omit from 'lodash/fp/omit';
 import updateState from '../update-state';
 import type {Action, State} from '../types';
 
-test('should return the given state untouched (TMP)', t => {
+test('should update state when answering a question correctly', t => {
   const state: State = Object.freeze({
+    content: undefined,
     nextContent: {
       ref: '1.A1.1',
       type: 'slide'
     },
     lives: 1,
-    slides: []
+    slides: [],
+    isCorrect: true
   });
 
   const action: Action = Object.freeze({
     type: 'answer',
     payload: {
+      content: {
+        ref: '1.A1.1',
+        type: 'slide'
+      },
       nextContent: {
         ref: '1.A1.2',
         type: 'slide'
       },
+      isCorrect: true
+    }
+  });
+
+  const omitChangedFields = omit(['slides', 'isCorrect', 'content', 'nextContent']);
+  const newState = updateState(state, [action]);
+
+  t.true(
+    newState.isCorrect,
+    '`isCorrect` should reflect the `isCorrect` field from the action payload'
+  );
+  t.deepEqual(newState.slides, ['1.A1.1'], 'answered slide should have been stored in `slides`');
+  t.deepEqual(
+    newState.content,
+    state.nextContent,
+    '`content` should be updated to be the previous `nextContent`'
+  );
+  t.deepEqual(
+    newState.nextContent,
+    action.payload.nextContent,
+    "`nextContent` should be updated to be the action's `nextContent`"
+  );
+  t.deepEqual(
+    omitChangedFields(newState),
+    omitChangedFields(state),
+    'Some fields that should not have been touched have been modified'
+  );
+});
+
+test('should update state when answering a question incorrectly', t => {
+  const state: State = Object.freeze({
+    content: undefined,
+    nextContent: {
+      ref: '1.A1.2',
+      type: 'slide'
+    },
+    lives: 1,
+    slides: ['1.A1.4'],
+    isCorrect: true
+  });
+
+  const action: Action = Object.freeze({
+    type: 'answer',
+    payload: {
       content: {
+        ref: '1.A1.2',
+        type: 'slide'
+      },
+      nextContent: {
         ref: '1.A1.1',
         type: 'slide'
       },
@@ -28,10 +83,65 @@ test('should return the given state untouched (TMP)', t => {
     }
   });
 
-  t.deepEqual(updateState(state, [action]), {
-    ...state,
-    lives: 0,
-    slides: ['1.A1.1'],
-    ...action.payload
+  const omitChangedFields = omit(['lives', 'slides', 'isCorrect', 'content', 'nextContent']);
+  const newState = updateState(state, [action]);
+
+  t.true(newState.lives === 0, '`lives` should have been decremented');
+  t.false(
+    newState.isCorrect,
+    '`isCorrect` should reflect the `isCorrect` field from the action payload'
+  );
+  t.deepEqual(
+    newState.slides,
+    ['1.A1.4', '1.A1.2'],
+    'answered slide should have been stored in `slides`'
+  );
+  t.deepEqual(
+    newState.content,
+    state.nextContent,
+    '`content` should be updated to be the previous `nextContent`'
+  );
+  t.deepEqual(
+    newState.nextContent,
+    action.payload.nextContent,
+    "`nextContent` should be updated to be the action's `nextContent`"
+  );
+  t.deepEqual(
+    omitChangedFields(newState),
+    omitChangedFields(state),
+    'Some fields that should not have been touched have been modified'
+  );
+});
+
+test("should throw if the state's nextContent is not the same as the action's content", t => {
+  const state: State = Object.freeze({
+    content: undefined,
+    nextContent: {
+      ref: '1.A1.2',
+      type: 'slide'
+    },
+    lives: 1,
+    slides: ['1.A1.4'],
+    isCorrect: true
   });
+
+  const action: Action = Object.freeze({
+    type: 'answer',
+    payload: {
+      content: {
+        ref: '1.A1.200',
+        type: 'slide'
+      },
+      nextContent: {
+        ref: '1.A1.1',
+        type: 'slide'
+      },
+      isCorrect: true
+    }
+  });
+
+  t.throws(
+    () => updateState(state, [action]),
+    'The content of the progression state does not match the content of the given answer'
+  );
 });

--- a/packages/@coorpacademy-progression-engine/src/types.js
+++ b/packages/@coorpacademy-progression-engine/src/types.js
@@ -10,6 +10,7 @@ export type State = {
   content?: Content,
   nextContent: Content,
   lives: number,
+  isCorrect: boolean,
   slides: Array<string>
 };
 

--- a/packages/@coorpacademy-progression-engine/src/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/update-state.js
@@ -1,30 +1,96 @@
 // @flow
+import map from 'lodash/fp/map';
+import pipe from 'lodash/fp/pipe';
 import concat from 'lodash/fp/concat';
 import reduce from 'lodash/fp/reduce';
+import update from 'lodash/fp/update';
 import isEqual from 'lodash/fp/isEqual';
-import type {Action, State} from './types';
+import type {Action, State, Content} from './types';
 
-function reduceAction(state: State, action: Action): State {
-  const {type, payload} = action;
-
-  switch (type) {
-    case 'answer': {
-      const {content, nextContent, isCorrect} = payload;
-      const {slides = [], lives = 0} = state;
-      if (!isEqual(state.nextContent, content)) throw new Error();
-      return {
-        ...state,
-        content,
-        nextContent,
-        isCorrect,
-        slides: concat([state.nextContent.ref], slides),
-        lives: isCorrect ? lives : lives - 1
-      };
-    }
+function isCorrect(state: boolean = false, action: Action): boolean {
+  switch (action.type) {
+    case 'answer':
+      return action.payload.isCorrect;
     default:
       return state;
   }
 }
+
+function slides(array: Array<string> = [], action: Action): Array<string> {
+  switch (action.type) {
+    case 'answer':
+      return concat(array, [action.payload.content.ref]);
+    default:
+      return array;
+  }
+}
+
+function lives(amount: number = 1, action: Action): number {
+  switch (action.type) {
+    case 'answer':
+      return action.payload.isCorrect ? amount : amount - 1;
+    default:
+      return amount;
+  }
+}
+
+function content(c: Content, action: Action): Content {
+  switch (action.type) {
+    case 'answer':
+      return action.payload.content;
+    default:
+      return c;
+  }
+}
+
+function nextContent(c: Content, action: Action): Content {
+  switch (action.type) {
+    case 'answer':
+      return action.payload.nextContent;
+    default:
+      return c;
+  }
+}
+
+function validator(state: State, action: Action) {
+  switch (action.type) {
+    case 'answer':
+      if (!isEqual(state.nextContent, action.payload.content)) {
+        throw new Error(
+          'The content of the progression state does not match the content of the given answer'
+        );
+      }
+      break;
+  }
+}
+
+const mapWithKey = map.convert({cap: false});
+
+function combineReducers(
+  validate: Function, // eslint-disable-line flowtype/no-weak-types
+  fnMap: {[string]: Function} // eslint-disable-line flowtype/no-weak-types
+): (State, Action) => State {
+  // eslint-disable-next-line flowtype/require-return-type
+  const fns = mapWithKey((fn, key) => {
+    return (action: Action) => (state: State): State => {
+      const newState = update(key, value => fn(value, action), state);
+      return (newState: State);
+    };
+  }, fnMap);
+
+  return (state: State, action: Action): State => {
+    validate(state, action);
+    return pipe(...map(fn => fn(action), fns))(state);
+  };
+}
+
+const reduceAction = combineReducers(validator, {
+  isCorrect,
+  slides,
+  lives,
+  content,
+  nextContent
+});
 
 const updateState: (state: State, actions: Array<Action>) => State = reduce(reduceAction);
 


### PR DESCRIPTION
- Refactorisation de updateState pour que ce soit un peu plus dans le style Redux.
- Rajout de tests sur updateState

Je ne suis pas sûr d'aimer tant que ça le nouveau format (c'est beaucoup plus verbeux et, pour le moment au moins, moins centralisé par type d'action).
Je n'ai finalement pas utilisé redux, car ça demande d'avoir de données des valeurs initiales dans les reducers, ce qui ne s'applique pas à notre cas et devient vite chiant et perturbant avec des données complexes et obligatoires.