### PR TITLE
Ajout de config pour microlearning

### DIFF
--- a/packages/@coorpacademy-app-player/src/services/progressions.js
+++ b/packages/@coorpacademy-app-player/src/services/progressions.js
@@ -27,14 +27,15 @@ export const createProgression = async progression => {
   const _id = generateId();
 
   const slides = await SlidesService.find();
-  const nextContent = computeNextStep(slides);
+  const nextContent = computeNextStep(progression.engine, slides, progression.state);
 
   progressions.set(_id, {
     ...progression,
     _id,
     state: {
-      nextContent,
-      slides: []
+      slides: [],
+      ...progression.state,
+      nextContent
     }
   });
 
@@ -49,14 +50,14 @@ export const createAnswer = async (progressionId, payload) => {
   const slides = await SlidesService.find();
 
   const action = pipe(
-    set('payload.isCorrect', checkAnswer({}, slide.question, answers)),
-    set('payload.nextContent', computeNextStep(slides, progression.state))
+    set('payload.isCorrect', checkAnswer(progression.engine, slide.question, answers)),
+    set('payload.nextContent', computeNextStep(progression.engine, slides, progression.state))
   )({
     type: 'answer',
     payload
   });
 
-  const p = update('state', state => updateState(state, [action]), progression);
+  const p = update('state', state => updateState(progression.engine, state, [action]), progression);
 
   progressions.set(progressionId, p);
 

--- a/packages/@coorpacademy-app-player/src/services/test/progressions.js
+++ b/packages/@coorpacademy-app-player/src/services/test/progressions.js
@@ -4,13 +4,18 @@ import isString from 'lodash/fp/isString';
 import isArray from 'lodash/fp/isArray';
 import {createProgression, findById, createAnswer, find} from '../progressions';
 
+const engine = {
+  ref: 'microlearning',
+  version: '1'
+};
+
 test('should return all progressions', async t => {
   const progressions = await find();
   t.true(isArray(progressions));
 });
 
 test('should create progression', async t => {
-  const {_id, state} = await createProgression({});
+  const {_id, state} = await createProgression({engine});
 
   t.true(isString(_id));
   t.true(isObject(state));
@@ -20,13 +25,13 @@ test('should create progression', async t => {
 });
 
 test('should find progression', async t => {
-  const progression = await createProgression({});
+  const progression = await createProgression({engine});
 
   t.deepEqual(await findById(progression._id), progression);
 });
 
 test('should add answer action', async t => {
-  const progression = await createProgression({});
+  const progression = await createProgression({engine});
   const progressionWithAnswer = await createAnswer(progression._id, {
     content: progression.state.nextContent,
     answers: ['bar']

--- a/packages/@coorpacademy-progression-engine/src/check-answer.js
+++ b/packages/@coorpacademy-progression-engine/src/check-answer.js
@@ -6,11 +6,8 @@ import sortBy from 'lodash/fp/sortBy';
 import isEqual from 'lodash/fp/isEqual';
 import identity from 'lodash/fp/identity';
 import toLower from 'lodash/fp/toLower';
-import {type Question, type AcceptedAnswers, type Answer} from './types';
-
-type CheckAnswerOptions = {
-  maxTypos?: number
-};
+import getConfig from './config';
+import type {Question, AcceptedAnswers, Answer, Engine, MicroLearningConfig} from './types';
 
 const sort = sortBy(identity);
 const normalize = (orderMatters: boolean, answer: Answer): Answer =>
@@ -30,10 +27,12 @@ function checkAnswerForQCM(
 }
 
 export default function checkAnswer(
-  options: CheckAnswerOptions,
+  engine: Engine,
   question: Question,
   givenAnswer: Array<string>
 ): boolean {
+  // eslint-disable-next-line no-unused-vars
+  const config = (getConfig(engine): MicroLearningConfig); // TODO use config
   const allowedAnswers = question.content.answers;
   switch (question.type) {
     case 'qcm':

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step.js
@@ -2,8 +2,9 @@
 import map from 'lodash/fp/map';
 import sample from 'lodash/fp/sample';
 import without from 'lodash/fp/without';
-import {type State, type Slide, type Content} from './types';
+import type {State, Slide, Content, Engine, MicroLearningConfig} from './types';
 import {hasFinished, isAlive} from './util';
+import getConfig from './config';
 
 const defaultState = {
   lives: 1,
@@ -20,9 +21,11 @@ const defaultState = {
 };
 
 export default function computeNextStep(
+  engine: Engine,
   slidePool: Array<Slide>,
   state: State = defaultState
 ): Content {
+  const config = (getConfig(engine): MicroLearningConfig);
   const {slides = []} = state;
   // if no more lives, return failure endpoint
   if (!isAlive(state)) {
@@ -33,7 +36,7 @@ export default function computeNextStep(
   }
 
   // if all slides answered and still alive return success endpoint
-  if (hasFinished(4, state)) {
+  if (hasFinished(config.slidesToComplete, state)) {
     return {
       ref: 'successExitNode',
       type: 'success'

--- a/packages/@coorpacademy-progression-engine/src/config/index.js
+++ b/packages/@coorpacademy-progression-engine/src/config/index.js
@@ -1,0 +1,19 @@
+// @flow
+import find from 'lodash/fp/find';
+import type {Config, Engine} from '../types';
+import microlearning from './microlearning';
+
+const engineConfigurations = {
+  microlearning
+};
+
+export default function getEngineConfig(engine: Engine): Config {
+  const engineConfiguration = engineConfigurations[engine.ref];
+  if (!engineConfiguration) {
+    throw new Error(`Unknown engine ${engine.ref}`);
+  }
+  return (
+    find({version: engine.version}, engineConfiguration.configurations) ||
+    engineConfiguration.defaultConfiguration
+  );
+}

--- a/packages/@coorpacademy-progression-engine/src/config/microlearning.js
+++ b/packages/@coorpacademy-progression-engine/src/config/microlearning.js
@@ -1,0 +1,16 @@
+// @flow
+import uniqBy from 'lodash/fp/uniqBy';
+import type {MicroLearningConfig} from '../types';
+
+const configurations: Array<MicroLearningConfig> = [
+  {version: '1', lives: 1, maxTypos: 2, slidesToComplete: 4}
+];
+
+if (configurations.length !== uniqBy('version', configurations).length) {
+  throw new Error('Config has conflicting version numbers');
+}
+
+export default {
+  configurations,
+  defaultConfiguration: configurations[0]
+};

--- a/packages/@coorpacademy-progression-engine/src/create-progression.js
+++ b/packages/@coorpacademy-progression-engine/src/create-progression.js
@@ -1,0 +1,39 @@
+// @flow
+import getConfig from './config';
+import type {Content, Progression, Slide, State, EngineType} from './types';
+import computeNextStep from './compute-next-step';
+
+export default function createProgression(
+  engineType: EngineType,
+  content: Content,
+  slidePool: Array<Slide>
+): Progression {
+  const config = getConfig({ref: engineType, version: 'latest'});
+  const engine = {
+    ref: engineType,
+    version: config.version
+  };
+  const initialState: State = {
+    lives: config.lives,
+    isCorrect: true,
+    slides: [],
+    step: {
+      current: 0,
+      total: 4
+    },
+    content: undefined,
+    nextContent: {
+      type: 'slide',
+      ref: 'unknown_ref'
+    }
+  };
+  initialState.nextContent = computeNextStep(engine, slidePool, initialState);
+
+  return {
+    content,
+    initialState,
+    state: initialState,
+    actions: [],
+    engine
+  };
+}

--- a/packages/@coorpacademy-progression-engine/src/index.js
+++ b/packages/@coorpacademy-progression-engine/src/index.js
@@ -2,5 +2,6 @@
 import computeNextStep from './compute-next-step';
 import checkAnswer from './check-answer';
 import updateState from './update-state';
+import createProgression from './create-progression';
 
-export {computeNextStep, checkAnswer, updateState};
+export {computeNextStep, checkAnswer, updateState, createProgression};

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer.qcm-drag.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer.qcm-drag.js
@@ -1,9 +1,12 @@
 // @flow
 import test from 'ava';
 import checkAnswer from '../check-answer';
-import {type QCMQuestion, type AcceptedAnswers} from '../types';
+import type {QCMQuestion, AcceptedAnswers} from '../types';
 
-const options = Object.freeze({});
+const engine = {
+  ref: 'microlearning',
+  version: 'latest'
+};
 
 function createQuestion(answers: AcceptedAnswers): QCMQuestion {
   return {
@@ -21,15 +24,15 @@ test('should return true when the given answer is in the accepted answers', t =>
     ['answer1', 'answer4']
   ]);
 
-  t.true(checkAnswer(options, question, ['answer1', 'answer3']));
-  t.true(checkAnswer(options, question, ['answer2', 'answer4']));
-  t.true(checkAnswer(options, question, ['answer1', 'answer4']));
+  t.true(checkAnswer(engine, question, ['answer1', 'answer3']));
+  t.true(checkAnswer(engine, question, ['answer2', 'answer4']));
+  t.true(checkAnswer(engine, question, ['answer1', 'answer4']));
 });
 
 test('should return true even when the given answer does not have the same case as the accepted answers', t => {
   const question = createQuestion([['answer2']]);
 
-  t.true(checkAnswer(options, question, ['ANSWER2']));
+  t.true(checkAnswer(engine, question, ['ANSWER2']));
 });
 
 test('should return false when the given answer is in the accepted answers but values but in a different order', t => {
@@ -39,9 +42,9 @@ test('should return false when the given answer is in the accepted answers but v
     ['answer1', 'answer4']
   ]);
 
-  t.false(checkAnswer(options, question, ['answer3', 'answer1']));
-  t.false(checkAnswer(options, question, ['answer4', 'answer2']));
-  t.false(checkAnswer(options, question, ['answer4', 'answer1']));
+  t.false(checkAnswer(engine, question, ['answer3', 'answer1']));
+  t.false(checkAnswer(engine, question, ['answer4', 'answer2']));
+  t.false(checkAnswer(engine, question, ['answer4', 'answer1']));
 });
 
 test('should return false when the given answer is not in the accepted answers', t => {
@@ -51,11 +54,11 @@ test('should return false when the given answer is not in the accepted answers',
     ['answer1', 'answer4']
   ]);
 
-  t.false(checkAnswer(options, question, ['answer2', 'answer3']));
+  t.false(checkAnswer(engine, question, ['answer2', 'answer3']));
 });
 
 test("should return false when the given answer isn't but resembles the accepted answers", t => {
   const question = createQuestion([['answer2']]);
 
-  t.false(checkAnswer(options, question, ['answe2r']));
+  t.false(checkAnswer(engine, question, ['answe2r']));
 });

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer.qcm.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer.qcm.js
@@ -1,9 +1,12 @@
 // // @flow
 import test from 'ava';
 import checkAnswer from '../check-answer';
-import {type QCMQuestion, type AcceptedAnswers} from '../types';
+import type {QCMQuestion, AcceptedAnswers} from '../types';
 
-const options = Object.freeze({});
+const engine = {
+  ref: 'microlearning',
+  version: 'latest'
+};
 
 function createQuestion(answers: AcceptedAnswers): QCMQuestion {
   return {
@@ -21,15 +24,15 @@ test('should return true when the given answer is in the accepted answers', t =>
     ['answer1', 'answer4']
   ]);
 
-  t.true(checkAnswer(options, question, ['answer1', 'answer3']));
-  t.true(checkAnswer(options, question, ['answer2', 'answer4']));
-  t.true(checkAnswer(options, question, ['answer1', 'answer4']));
+  t.true(checkAnswer(engine, question, ['answer1', 'answer3']));
+  t.true(checkAnswer(engine, question, ['answer2', 'answer4']));
+  t.true(checkAnswer(engine, question, ['answer1', 'answer4']));
 });
 
 test('should return true even when the given answer does not have the same case as the accepted answers', t => {
   const question = createQuestion([['answer2']]);
 
-  t.true(checkAnswer(options, question, ['ANSWER2']));
+  t.true(checkAnswer(engine, question, ['ANSWER2']));
 });
 
 test('should return true when the given answer is in the accepted answers but values are in a different order', t => {
@@ -39,9 +42,9 @@ test('should return true when the given answer is in the accepted answers but va
     ['answer1', 'answer4']
   ]);
 
-  t.true(checkAnswer(options, question, ['answer3', 'answer1']));
-  t.true(checkAnswer(options, question, ['answer4', 'answer2']));
-  t.true(checkAnswer(options, question, ['answer4', 'answer1']));
+  t.true(checkAnswer(engine, question, ['answer3', 'answer1']));
+  t.true(checkAnswer(engine, question, ['answer4', 'answer2']));
+  t.true(checkAnswer(engine, question, ['answer4', 'answer1']));
 });
 
 test('should return false when the given answer is not in the accepted answers', t => {
@@ -51,11 +54,11 @@ test('should return false when the given answer is not in the accepted answers',
     ['answer1', 'answer4']
   ]);
 
-  t.false(checkAnswer(options, question, ['answer2', 'answer3']));
+  t.false(checkAnswer(engine, question, ['answer2', 'answer3']));
 });
 
 test("should return false when the given answer isn't but resembles the accepted answers", t => {
   const question = createQuestion([['answer2']]);
 
-  t.false(checkAnswer(options, question, ['answe2r']));
+  t.false(checkAnswer(engine, question, ['answe2r']));
 });

--- a/packages/@coorpacademy-progression-engine/src/test/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/test/compute-next-step.js
@@ -3,65 +3,53 @@ import test from 'ava';
 import computeNextStep from '../compute-next-step';
 import slides from './fixtures/slides';
 
-test('should return a new slide when user has no progression state', t => {
-  const nextStep = computeNextStep(slides);
-  t.truthy(nextStep.ref);
-  t.is(nextStep.type, 'slide');
-});
-
 test('should return a new slide when user is still alive', t => {
-  const progression = Object.freeze({
-    state: {
-      nextContent: {
-        ref: '1.A1.1',
-        type: 'slide'
-      },
-      lives: 1,
-      isCorrect: true,
-      slides: ['1.A1.1'],
-      step: {
-        current: 1,
-        total: 4
-      }
+  const engine = {
+    ref: 'microlearning',
+    version: '1'
+  };
+  const state = Object.freeze({
+    nextContent: {
+      ref: '1.A1.1',
+      type: 'slide'
     },
-    content: {
-      ref: '1.A1',
-      type: 'chapter'
-    },
-    actions: []
+    lives: 1,
+    isCorrect: true,
+    slides: ['1.A1.1'],
+    step: {
+      current: 1,
+      total: 4
+    }
   });
 
-  const nextStep = computeNextStep(slides, progression.state);
+  const nextStep = computeNextStep(engine, slides, state);
   t.not(nextStep.ref, '1.A1.1');
 });
 
 test('should return the fail endpoint, when progressions state no more lives', t => {
-  const progression = Object.freeze({
-    state: {
-      content: {
-        ref: '1.A1.1',
-        type: 'slide'
-      },
-      nextContent: {
-        ref: '1.A1.2',
-        type: 'slide'
-      },
-      lives: 0,
-      isCorrect: false,
-      slides: ['1.A1.1', '1.A1.2'],
-      step: {
-        current: 2,
-        total: 4
-      }
-    },
+  const engine = {
+    ref: 'microlearning',
+    version: '1'
+  };
+  const state = Object.freeze({
     content: {
-      ref: '1.A1',
-      type: 'chapter'
+      ref: '1.A1.1',
+      type: 'slide'
     },
-    actions: []
+    nextContent: {
+      ref: '1.A1.2',
+      type: 'slide'
+    },
+    lives: 0,
+    isCorrect: false,
+    slides: ['1.A1.1', '1.A1.2'],
+    step: {
+      current: 2,
+      total: 4
+    }
   });
 
-  const nextStep = computeNextStep(slides, progression.state);
+  const nextStep = computeNextStep(engine, slides, state);
   t.deepEqual(nextStep, {
     ref: 'failExitNode',
     type: 'failure'
@@ -69,32 +57,29 @@ test('should return the fail endpoint, when progressions state no more lives', t
 });
 
 test('should return the success endpoint when progression state has answered all slides', t => {
-  const progression = Object.freeze({
-    state: {
-      content: {
-        ref: '1.A1.2',
-        type: 'slide'
-      },
-      nextContent: {
-        ref: '1.A1.4',
-        type: 'slide'
-      },
-      lives: 1,
-      isCorrect: true,
-      slides: ['1.A1.1', '1.A1.3', '1.A1.2', '1.A1.4'],
-      step: {
-        current: 4,
-        total: 4
-      }
-    },
+  const engine = {
+    ref: 'microlearning',
+    version: '1'
+  };
+  const state = Object.freeze({
     content: {
-      ref: '1.A1',
-      type: 'chapter'
+      ref: '1.A1.2',
+      type: 'slide'
     },
-    actions: []
+    nextContent: {
+      ref: '1.A1.4',
+      type: 'slide'
+    },
+    lives: 1,
+    isCorrect: true,
+    slides: ['1.A1.1', '1.A1.3', '1.A1.2', '1.A1.4'],
+    step: {
+      current: 4,
+      total: 4
+    }
   });
 
-  const nextStep = computeNextStep(slides, progression.state);
+  const nextStep = computeNextStep(engine, slides, state);
   t.deepEqual(nextStep, {
     ref: 'successExitNode',
     type: 'success'

--- a/packages/@coorpacademy-progression-engine/src/test/create-progression.js
+++ b/packages/@coorpacademy-progression-engine/src/test/create-progression.js
@@ -1,0 +1,42 @@
+// @flow
+import test from 'ava';
+import times from 'lodash/fp/times';
+import uniq from 'lodash/fp/uniq';
+import type {Content} from '../types';
+import createProgression from '../create-progression';
+import slides from './fixtures/slides';
+
+const content: Content = Object.freeze({
+  type: 'chapter',
+  ref: '1.A1',
+  version: '1.0.0'
+});
+
+test('should throw if the engine type is unknown', t => {
+  // $FlowFixMe (this case can't occur due to Flow, but we should still handle it in the tests)
+  t.throws(() => createProgression('idontexist', content, slides), 'Unknown engine idontexist');
+});
+
+test('should return a new progression for microlearning', t => {
+  const progression = createProgression('microlearning', content, slides);
+
+  t.deepEqual(progression.content, content);
+  t.deepEqual(progression.actions, []);
+  t.deepEqual(progression.engine, {ref: 'microlearning', version: '1'});
+  t.deepEqual(progression.initialState, progression.state);
+  t.true(progression.initialState.lives === 1);
+  t.true(progression.initialState.isCorrect);
+  t.deepEqual(progression.initialState.slides, []);
+  t.deepEqual(progression.initialState.step, {current: 0, total: 4});
+  t.falsy(progression.initialState.content);
+  t.true(progression.initialState.nextContent.type === 'slide');
+  t.true(typeof progression.initialState.nextContent.ref === 'string');
+});
+
+test('should return a random starting slide', t => {
+  const startingSlides = times(i => i, 50)
+    .map(() => createProgression('microlearning', content, slides))
+    .map(progression => progression.initialState.nextContent.ref);
+
+  t.true(uniq(startingSlides).length >= 2);
+});

--- a/packages/@coorpacademy-progression-engine/src/test/index.js
+++ b/packages/@coorpacademy-progression-engine/src/test/index.js
@@ -1,6 +1,6 @@
 // @flow
 import test from 'ava';
-import {checkAnswer, computeNextStep, updateState} from '..';
+import {checkAnswer, computeNextStep, updateState, createProgression} from '..';
 
 test('should export checkAnswer', t => {
   t.is(typeof checkAnswer, 'function');
@@ -12,4 +12,8 @@ test('should export computeNextStep', t => {
 
 test('should export updateState', t => {
   t.is(typeof updateState, 'function');
+});
+
+test('should export createProgression', t => {
+  t.is(typeof createProgression, 'function');
 });

--- a/packages/@coorpacademy-progression-engine/src/test/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/test/update-state.js
@@ -4,6 +4,11 @@ import omit from 'lodash/fp/omit';
 import updateState from '../update-state';
 import type {Action, State} from '../types';
 
+const engine = {
+  ref: 'microlearning',
+  version: '1'
+};
+
 test('should update state when answering a question correctly', t => {
   const state: State = Object.freeze({
     content: undefined,
@@ -36,7 +41,7 @@ test('should update state when answering a question correctly', t => {
   });
 
   const omitChangedFields = omit(['slides', 'isCorrect', 'content', 'nextContent', 'step']);
-  const newState = updateState(state, [action]);
+  const newState = updateState(engine, state, [action]);
 
   t.true(
     newState.isCorrect,
@@ -100,7 +105,7 @@ test('should update state when answering a question incorrectly', t => {
     'nextContent',
     'step'
   ]);
-  const newState = updateState(state, [action]);
+  const newState = updateState(engine, state, [action]);
 
   t.true(newState.lives === 0, '`lives` should have been decremented');
   t.false(
@@ -162,7 +167,7 @@ test("should throw if the state's nextContent is not the same as the action's co
   });
 
   t.throws(
-    () => updateState(state, [action]),
+    () => updateState(engine, state, [action]),
     'The content of the progression state does not match the content of the given answer'
   );
 });

--- a/packages/@coorpacademy-progression-engine/src/types.js
+++ b/packages/@coorpacademy-progression-engine/src/types.js
@@ -29,10 +29,16 @@ export type Action = {
   }
 };
 
+export type Engine = {
+  ref: 'microlearning',
+  version: string
+};
+
 export type Progression = {
   content: Content,
   state: State,
-  actions: Array<Action>
+  actions: Array<Action>,
+  engine: Engine
 };
 
 export type Answer = Array<string>;
@@ -52,3 +58,12 @@ export type Slide = {
   chapter_id: string,
   question: Question
 };
+
+export type MicroLearningConfig = {
+  version: string,
+  lives: number,
+  maxTypos: number,
+  slidesToComplete: number
+};
+
+export type Config = MicroLearningConfig;

--- a/packages/@coorpacademy-progression-engine/src/types.js
+++ b/packages/@coorpacademy-progression-engine/src/types.js
@@ -29,13 +29,16 @@ export type Action = {
   }
 };
 
+export type EngineType = 'microlearning';
+
 export type Engine = {
-  ref: 'microlearning',
+  ref: EngineType,
   version: string
 };
 
 export type Progression = {
   content: Content,
+  initialState: State,
   state: State,
   actions: Array<Action>,
   engine: Engine


### PR DESCRIPTION
- Création d'une config pour microlearning
- Utilisation de cette config dans les différentes fonctions
- Ajout d'un paramètre `engine` dans les différentes fonctions (changement **CASSANT**)
- Dans checkAnswer, remplacement du paramètre `options` par la paramètre `engine` indiqué ci-dessus (changement **CASSANT**)
- Ajout d'une fonction createProgression qui créé une nouvelle progression avec un initialState avec des champs remplis)
- Remplacement des valeurs codés en dur par des valeurs trouvées dans la config (`lives`, `maxTypos`, `slidesToComplete`, `step.total`)

PR associées (pending publication de ceci):
- Mise à jour MOOC : https://github.com/CoorpAcademy/coorpacademy/pull/11327
- Mise à jour API progression : https://github.com/CoorpAcademy/api-progression/pull/14