### PR TITLE
check-answer: For basic questions, handle when question.content.maxTypos is null

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/check-answer.js
+++ b/packages/@coorpacademy-progression-engine/src/check-answer.js
@@ -1,9 +1,10 @@
 // @flow
-import _ from 'lodash/fp';
 import map from 'lodash/fp/map';
 import pipe from 'lodash/fp/pipe';
 import some from 'lodash/fp/some';
 import sortBy from 'lodash/fp/sortBy';
+import flatten from 'lodash/fp/flatten';
+import reverse from 'lodash/fp/reverse';
 import toLower from 'lodash/fp/toLower';
 import isEqual from 'lodash/fp/isEqual';
 import identity from 'lodash/fp/identity';
@@ -47,7 +48,7 @@ function containsAnswer(
   // Get the non-space characters surrounding the answer and make sure that there are not too many.
   const limit = config.answerBoundaryLimit;
   const [first, second] = givenAnswer.split(allowedAnswer);
-  const indexOfSpaceInFirst = _.reverse(first).indexOf(' ');
+  const indexOfSpaceInFirst = reverse(first).indexOf(' ');
   const indexOfSpaceInSecond = second.indexOf(' ');
 
   return (
@@ -63,13 +64,13 @@ function checkAnswerForBasic(
 ): boolean {
   const allowedAnswers = question.content.answers;
   const comparableGivenAnswer = normalizeBasic(givenAnswer);
-  const fm = new FuzzyMatching(_.flatten(allowedAnswers));
-  const maxTypos = question.content.maxTypos !== undefined
+  const fm = new FuzzyMatching(flatten(allowedAnswers));
+  const maxTypos = question.content.maxTypos === 0
     ? question.content.maxTypos
-    : config.maxTypos;
+    : question.content.maxTypos || config.maxTypos;
   return (
     checkFuzzyAnswer(maxTypos, fm, comparableGivenAnswer[0]) ||
-    _.some(
+    some(
       allowedAnswer =>
         containsAnswer(config, normalizeBasic(allowedAnswer)[0], comparableGivenAnswer[0]),
       allowedAnswers

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer.basic.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer.basic.js
@@ -8,7 +8,7 @@ const engine = {
   version: 'latest'
 };
 
-function createQuestion(answers: AcceptedAnswers, maxTypos?: number): BasicQuestion {
+function createQuestion(answers: AcceptedAnswers, maxTypos?: ?number): BasicQuestion {
   return {
     type: 'basic',
     content: {
@@ -92,6 +92,20 @@ test('should consider the max number of typos from the slide before the one in t
   t.true(checkAnswer(engineWithTypos, question, ['foooooooooooo']));
   t.false(checkAnswer(engineWithTypos, question, ['foooooooooooa']));
   t.false(checkAnswer(engineWithTypos, question, ['fooooooooooaa']));
+});
+
+test('should use the number of typos from the config if the one in question equals null', t => {
+  const question = createQuestion([['foooooooooooo']], null);
+  const engineWithTypos = {
+    ref: 'microlearning',
+    version: 'allow_typos_3'
+  };
+
+  t.true(checkAnswer(engineWithTypos, question, ['foooooooooooo']));
+  t.true(checkAnswer(engineWithTypos, question, ['foooooooooooa']));
+  t.true(checkAnswer(engineWithTypos, question, ['fooooooooooaa']));
+  t.true(checkAnswer(engineWithTypos, question, ['foooooooooaaa']));
+  t.false(checkAnswer(engineWithTypos, question, ['foooooooaaaaa']));
 });
 
 test('should return true when the given answer contains an accepted answer', t => {

--- a/packages/@coorpacademy-progression-engine/src/types.js
+++ b/packages/@coorpacademy-progression-engine/src/types.js
@@ -87,7 +87,7 @@ export type QCMQuestion = {
 export type BasicQuestion = {
   type: 'basic',
   content: {
-    maxTypos?: number,
+    maxTypos?: ?number,
     answers: AcceptedAnswers
   }
 };


### PR DESCRIPTION
Correction du fuzzy-matching sur le MOOC.
Parfois (probablement tout le temps en fait), la valeur de maxTypos écrite dans la question (`question.content.maxTypos`) est null (ou mis à null par défaut lorsqu'absent).

Lorsqu'on récupérait cela, on prenait cette valeur là, qui faisait comme si on avait mis `maxTypos` à 0, d'où un fuzzy matching qui ne marchait pas.

Reste à faire : Publier et bumper dans le MOOC.