### PR TITLE
Support des questions qcmDrag

### DIFF
--- a/packages/@coorpacademy-app-player/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-app-player/src/actions/ui/answers.js
@@ -38,8 +38,12 @@ const newState = (state = [], questionType, newValue) => {
 };
 
 export const editAnswer = (state, questionType, progressionId, newValue) => {
+  const type = ANSWER_EDIT[questionType];
+  if (!type) {
+    throw new Error('Unknown question type "bar"');
+  }
   return {
-    type: ANSWER_EDIT[questionType],
+    type,
     meta: {
       progressionId
     },

--- a/packages/@coorpacademy-app-player/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-app-player/src/actions/ui/answers.js
@@ -8,6 +8,7 @@ import {toggleAccordion} from './corrections';
 export const ANSWER_EDIT = {
   qcm: '@@answer/EDIT_QCM',
   qcmGraphic: '@@answer/EDIT_QCM_GRAPHIC',
+  qcmDrag: '@@answer/EDIT_QCM_DRAG',
   template: '@@answer/EDIT_TEMPLATE',
   basic: '@@answer/EDIT_BASIC'
 };
@@ -16,6 +17,7 @@ const newState = (state = [], questionType, newValue) => {
   switch (questionType) {
     case 'qcm':
     case 'qcmGraphic':
+    case 'qcmDrag':
       if (!newValue.label) return state;
 
       if (includes(newValue.label, state)) {

--- a/packages/@coorpacademy-app-player/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-app-player/src/actions/ui/answers.js
@@ -31,9 +31,6 @@ const newState = (state = [], questionType, newValue) => {
 
     case 'template':
       return newValue;
-
-    default:
-      return state;
   }
 };
 

--- a/packages/@coorpacademy-app-player/src/actions/ui/test/answers.edit-answer.js
+++ b/packages/@coorpacademy-app-player/src/actions/ui/test/answers.edit-answer.js
@@ -4,13 +4,23 @@ import {ANSWER_EDIT, editAnswer} from '../answers';
 const macro = (t, state, inputType, input, expected) => {
   const action = editAnswer(state, inputType, '0', input);
 
+  t.not(action.type, undefined);
   t.is(action.type, ANSWER_EDIT[inputType]);
   t.is(action.meta.progressionId, '0');
   t.deepEqual(action.payload, expected);
 };
 
-test('should return initiate state if undefined', macro, undefined, 'qcm', {label: 'bar'}, ['bar']);
-test('should check questionType or return same state', macro, ['foo'], 'bar', {}, ['foo']);
+test('should throw an error if questionType is unknown', t => {
+  return t.throws(
+    () => editAnswer(['some answer'], 'bar', '0', ['some new answer']),
+    'Unknown question type "bar"'
+  );
+});
+
+test('should return initial state if state is undefined', macro, undefined, 'qcm', {label: 'bar'}, [
+  'bar'
+]);
+
 test('should add a qcm choice', macro, ['foo'], 'qcm', {label: 'bar'}, ['foo', 'bar']);
 test('should remove a qcm choice', macro, ['foo'], 'qcm', {label: 'foo'}, []);
 test('should check qcm has answer.label or return same state', macro, ['foo'], 'qcm', {}, ['foo']);

--- a/packages/@coorpacademy-app-player/src/actions/ui/test/answers.edit-answer.js
+++ b/packages/@coorpacademy-app-player/src/actions/ui/test/answers.edit-answer.js
@@ -27,5 +27,9 @@ test(
   {},
   ['foo']
 );
+test('should add a qcmDrag choice', macro, ['foo'], 'qcmDrag', {label: 'bar'}, ['foo', 'bar']);
+test('should check qcmDrag has answer.label or return same state', macro, ['foo'], 'qcmDrag', {}, [
+  'foo'
+]);
 test('should edit a template answer', macro, ['foo'], 'template', ['bar', 'foo'], ['bar', 'foo']);
 test('should edit a basic answer', macro, ['foo'], 'basic', 'bar', ['bar']);

--- a/packages/@coorpacademy-app-player/src/services/slides.data.json
+++ b/packages/@coorpacademy-app-player/src/services/slides.data.json
@@ -369,13 +369,13 @@
           "src": []
         }
       },
-      "medias":[
+      "medias": [
         {
           "type": "img",
           "_id": "593eb72a187bd18c01283591",
           "subtitles": [],
           "posters": [],
-          "src":[
+          "src": [
             {
               "mimeType": "image/jpeg",
               "url": "https://api-staging.coorpacademy.com/api-service/medias?h=400&w=400&q=90&url=https://static.coorpacademy.com/content/ijoinchanel/en/slides/1B2_Q6/1B2-Q6-canap-v1.jpg",
@@ -885,6 +885,149 @@
               }
             ]
           }
+        ]
+      }
+    }
+  },
+  {
+    "_id": "9.C7.6",
+    "klf": "Savoir cliquer sur les vrais réponses",
+    "tips": "Des tips",
+    "chapter_id": "9.C7",
+    "chapter_ref": "9.C7",
+    "authors": [],
+    "context": {
+      "media": {
+        "subtitles": [],
+        "posters": [],
+        "src": []
+      }
+    },
+    "meta": {
+      "updatedAt": "2016-06-30T13:52:16.648Z",
+      "createdAt": "2017-02-09T12:46:40.315Z"
+    },
+    "lessons": [
+      {
+        "type": "video",
+        "mimeType": "application/vimeo",
+        "videoId": "127157752",
+        "description": "Le paiment dématérialisé : dernière étape du rapprochement virtuel/réel",
+        "poster": "//static.coorpacademy.com/content/digital/fr/miniatures/video_miniature.jpg",
+        "_id": "5978690a48a0ff240092f3a5",
+        "subtitles": [],
+        "posters": [],
+        "views": {
+          "fromLesson": 4
+        },
+        "src": []
+      }
+    ],
+    "question": {
+      "type": "qcmDrag",
+      "header": "Cliquez sur les réponses vrais (n'importe quel ordre)",
+      "explanation": "Cliquez sur les bonnes réponses pour les déplacer dans la seconde colonne.",
+      "clue": "clue",
+      "content": {
+        "matchOrder": false,
+        "maxTypos": null,
+        "choices": [
+          {
+            "label": "Vrai 1",
+            "value": "sli_NkaegcmAY~o.choice_01"
+          },
+          {
+            "label": "Vrai 2",
+            "value": "sli_NkaegcmAY~o.choice_02"
+          },
+          {
+            "label": "Faux 1",
+            "value": "sli_NkaegcmAY~o.choice_03"
+          },
+          {
+            "label": "Faux 2",
+            "value": "sli_NkaegcmAY~o.choice_04"
+          },
+          {
+            "label": "Faux 3",
+            "value": "sli_NkaegcmAY~o.choice_05"
+          }
+        ],
+        "answers": [
+          [
+            "Vrai 2",
+            "Vrai 1"
+          ]
+        ],
+        "media": {
+          "subtitles": [],
+          "posters": [],
+          "src": []
+        }
+      },
+      "medias": []
+    }
+  },
+  {
+    "_id": "8.B2.2",
+    "klf": "Savoir cliquer sur les vrais réponses dans un ordre donné",
+    "tips": "Des tips",
+    "chapter_id": "8.B2",
+    "chapter_ref": "8.B2",
+    "authors": [],
+    "lessons": [
+      {
+        "type": "video",
+        "mimeType": "application/vimeo",
+        "videoId": "127718777",
+        "description": "Chiffres-clés du multi-écran",
+        "poster": "//static.coorpacademy.com/content/digital/fr/miniatures/video_miniature.jpg",
+        "_id": "5978690b48a0ff240092f4a3",
+        "subtitles": [],
+        "posters": [],
+        "views": {
+          "fromList": 63,
+          "fromLesson": 20
+        },
+        "src": []
+      }
+    ],
+    "question": {
+      "type": "qcmDrag",
+      "header": "Cliquez sur les réponses vrais dans l'ordre des numéros",
+      "explanation": "Cliquez sur les réponses dans le bon ordre.",
+      "clue": "clue",
+      "content": {
+        "matchOrder": true,
+        "maxTypos": null,
+        "choices": [
+          {
+            "label": "Vrai 1",
+            "value": "sli_VyZmMYQCFWj.choice_01"
+          },
+          {
+            "label": "Vrai 2",
+            "value": "sli_VyZmMYQCFWj.choice_02"
+          },
+          {
+            "label": "Vrai 3",
+            "value": "sli_VyZmMYQCFWj.choice_03"
+          },
+          {
+            "label": "Faux 1",
+            "value": "sli_VyZmMYQCFWj.choice_04"
+          },
+          {
+            "label": "Faux 2",
+            "value": "sli_VyZmMYQCFWj.choice_05"
+          }
+        ],
+        "answers": [
+          [
+            "Vrai 1",
+            "Vrai 2",
+            "Vrai 3"
+          ]
         ]
       }
     }

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/test/answer.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/test/answer.js
@@ -1,11 +1,11 @@
 import test from 'ava';
 import isFunction from 'lodash/fp/isFunction';
 import identity from 'lodash/fp/identity';
-import reduce from 'lodash/fp/reduce';
 import creategetAnswerProps from '../answer';
 import {ANSWER_EDIT} from '../../../actions/ui/answers';
 import basic from './fixtures/slides/basic';
 import qcm from './fixtures/slides/qcm';
+import qcmDrag from './fixtures/slides/qcmDrag';
 import qcmGraphic from './fixtures/slides/qcmGraphic';
 import template from './fixtures/slides/template';
 
@@ -17,7 +17,7 @@ test('should create initial qcm props', t => {
   const state = {};
   const props = getAnswerProps(state, qcm);
   t.is(props.type, 'qcm');
-  t.is(reduce((acc, answer) => acc && answer.selected, true)(props.answers), false);
+  t.true(props.answers.every(answer => answer.selected === false));
 });
 
 test('should create edited qcm props', t => {
@@ -30,14 +30,16 @@ test('should create edited qcm props', t => {
 
   const props = getAnswerProps(state, qcm);
   t.is(props.type, 'qcm');
-  t.is(reduce((acc, answer) => acc && answer.selected, true)(props.answers), false);
+  t.is(props.answers.length, 4);
   t.is(props.answers[0].title, 'Case 1');
-  t.is(props.answers[0].selected, true);
+  t.true(props.answers[0].selected);
   t.is(props.answers[1].title, 'Case 2');
-  t.is(props.answers[1].selected, false);
+  t.false(props.answers[1].selected);
   t.is(props.answers[2].title, 'Case 3');
-  t.is(props.answers[2].selected, true);
-  t.is(isFunction(props.answers[0].onClick), true);
+  t.true(props.answers[2].selected);
+  t.is(props.answers[3].title, 'Case 4');
+  t.false(props.answers[3].selected);
+  t.true(isFunction(props.answers[0].onClick));
 });
 
 test('should create edited template props', t => {
@@ -57,10 +59,10 @@ test('should create edited template props', t => {
   t.is(props.answers[0].name, 'inp81438');
   t.is(props.answers[0].placeholder, 'Type here');
   t.is(props.answers[0].value, 'foo');
-  t.is(typeof props.answers[0].onChange, 'function');
+  t.true(isFunction(props.answers[0].onChange));
   t.is(props.answers[1].type, 'select');
   t.is(props.answers[1].name, 'sel31191');
-  t.is(typeof props.answers[1].onChange, 'function');
+  t.true(isFunction(props.answers[1].onChange));
   const selectOptions = props.answers[1].options;
   t.true(Array.isArray(selectOptions));
   t.is(selectOptions.length, 2);
@@ -114,6 +116,32 @@ test('should create action: edit-answer-qcm', t => {
   t.is(action.meta.progressionId, '1234');
 });
 
+test('should create initial qcmGraphic props', t => {
+  const state = {};
+  const props = getAnswerProps(state, qcmGraphic);
+  t.is(props.type, 'qcmGraphic');
+  t.is(props.answers.length, 2);
+  t.true(props.answers.every(answer => answer.selected === false));
+});
+
+test('should create edited qcmGraphic props', t => {
+  const state = {
+    ui: {
+      answers: {'1234': {value: ['Vrai']}},
+      current: {progressionId: '1234'}
+    }
+  };
+
+  const props = getAnswerProps(state, qcmGraphic);
+  t.is(props.type, 'qcmGraphic');
+  t.is(props.answers.length, 2);
+  t.is(props.answers[0].title, 'Vrai');
+  t.true(props.answers[0].selected);
+  t.is(props.answers[1].title, 'Faux');
+  t.false(props.answers[1].selected);
+  t.true(isFunction(props.answers[0].onClick));
+});
+
 test('should create action: edit-answer-qcmGraphic', t => {
   const state = {
     ui: {
@@ -130,29 +158,77 @@ test('should create action: edit-answer-qcmGraphic', t => {
   t.is(action.meta.progressionId, '1234');
 });
 
-test('should create initial qcmGraphic props', t => {
+test('should create initial qcmDrag props', t => {
   const state = {};
-  const props = getAnswerProps(state, qcmGraphic);
-  t.is(props.type, 'qcmGraphic');
-  t.is(reduce((acc, answer) => acc && answer.selected, true)(props.answers), false);
+  const props = getAnswerProps(state, qcmDrag);
+  t.is(props.type, 'qcmDrag');
+  t.is(props.answers.length, 3);
+  t.is(props.answers[0].title, "L'ordinateur");
+  t.false(props.answers[0].selected);
+  t.true(isFunction(props.answers[0].onClick));
+  t.is(props.answers[1].title, 'La tablette');
+  t.false(props.answers[1].selected);
+  t.true(isFunction(props.answers[1].onClick));
+  t.is(props.answers[2].title, 'Le smartphone');
+  t.false(props.answers[2].selected);
+  t.true(isFunction(props.answers[2].onClick));
 });
 
-test('should create edited qcmGraphic props', t => {
+test('should create edited qcmDrag props', t => {
   const state = {
     ui: {
-      answers: {'1234': {value: ['Vrai']}},
+      answers: {'1234': {value: ['Le smartphone', "L'ordinateur"]}},
       current: {progressionId: '1234'}
     }
   };
 
-  const props = getAnswerProps(state, qcmGraphic);
-  t.is(props.type, 'qcmGraphic');
-  t.is(reduce((acc, answer) => acc && answer.selected, true)(props.answers), false);
-  t.is(props.answers[0].title, 'Vrai');
-  t.is(props.answers[0].selected, true);
-  t.is(props.answers[1].title, 'Faux');
-  t.is(props.answers[1].selected, false);
-  t.is(isFunction(props.answers[0].onClick), true);
+  const props = getAnswerProps(state, qcmDrag);
+  t.is(props.type, 'qcmDrag');
+  t.is(props.answers.length, 3);
+
+  t.is(props.answers[0].title, "L'ordinateur");
+  t.true(props.answers[0].selected);
+  t.is(props.answers[0].order, 1);
+  t.true(isFunction(props.answers[0].onClick));
+  t.is(props.answers[1].title, 'La tablette');
+  t.false(props.answers[1].selected);
+  t.true(isFunction(props.answers[1].onClick));
+  t.is(props.answers[2].title, 'Le smartphone');
+  t.true(props.answers[2].selected);
+  t.is(props.answers[2].order, 0);
+  t.true(isFunction(props.answers[2].onClick));
+});
+
+test('should create action: edit-answer-qcmDrag (answer selection)', t => {
+  const state = {
+    ui: {
+      answers: {'1234': {value: ['Le smartphone', "L'ordinateur"]}},
+      current: {progressionId: '1234'}
+    }
+  };
+
+  const props = getAnswerProps(state, qcmDrag);
+  const action = props.answers[1].onClick();
+
+  t.is(action.type, ANSWER_EDIT.qcmDrag);
+  t.deepEqual(action.payload, ['Le smartphone', "L'ordinateur", 'La tablette']);
+  t.is(action.meta.progressionId, '1234');
+});
+
+test('should create action: edit-answer-qcmDrag (answer removal)', t => {
+  const state = {
+    ui: {
+      answers: {'1234': {value: ['Le smartphone', "L'ordinateur"]}},
+      current: {progressionId: '1234'}
+    }
+  };
+
+  const props = getAnswerProps(state, qcmDrag);
+  const action = props.answers[2].onClick();
+
+  t.is(action.type, ANSWER_EDIT.qcmDrag);
+  t.deepEqual(action.payload, ["L'ordinateur"]);
+  t.is(action.meta.progressionId, '1234');
 });
 
 test('should create action: edit-answer-template', t => {

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/test/fixtures/slides/qcmDrag.json
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/test/fixtures/slides/qcmDrag.json
@@ -1,0 +1,56 @@
+{
+  "_id": "8.B2.2",
+  "klf": "Le smartphone est l'appareil le plus utilisé devant l'écran de télévision. Viennent ensuite l'ordinateur et la tablette.",
+  "tips": "En moyenne, les utilisateurs de smartphones passent 147 minutes chaque jour sur leur appareil.",
+  "chapter_id": "8.B2",
+  "chapter_ref": "8.B2",
+  "authors": [],
+  "lessons": [
+    {
+      "type": "video",
+      "mimeType": "application/vimeo",
+      "videoId": "127718777",
+      "description": "Chiffres-clés du multi-écran",
+      "poster": "//static.coorpacademy.com/content/digital/fr/miniatures/video_miniature.jpg",
+      "_id": "5978690b48a0ff240092f4a3",
+      "subtitles": [],
+      "posters": [],
+      "views": {
+        "fromList": 63,
+        "fromLesson": 20
+      },
+      "src": []
+    }
+  ],
+  "question": {
+    "type": "qcmDrag",
+    "header": "Classez ces appareils connectés du plus au moins utilisé devant la télévision.",
+    "explanation": "Cliquez sur les réponses dans le bon ordre.",
+    "clue": "clue",
+    "content": {
+      "matchOrder": true,
+      "maxTypos": null,
+      "choices": [
+        {
+          "label": "L'ordinateur",
+          "value": "sli_VyZmMYQCFWj.choice_01"
+        },
+        {
+          "label": "La tablette",
+          "value": "sli_VyZmMYQCFWj.choice_02"
+        },
+        {
+          "label": "Le smartphone",
+          "value": "sli_VyZmMYQCFWj.choice_03"
+        }
+      ]
+    },
+    "answers": [
+      [
+        "Le smartphone",
+        "L'ordinateur",
+        "La tablette"
+      ]
+    ]
+  }
+}

--- a/packages/@coorpacademy-components/src/molecule/answer/index.js
+++ b/packages/@coorpacademy-components/src/molecule/answer/index.js
@@ -25,7 +25,7 @@ const Answer = props => {
     const {type} = model;
 
     switch (type) {
-      case 'picker':
+      case 'qcmDrag':
         return <Picker {...model} />;
       case 'qcm':
         return <Qcm {...model} />;
@@ -54,7 +54,7 @@ const Answer = props => {
 Answer.propTypes = {
   model: PropTypes.shape({
     type: PropTypes.oneOf([
-      'picker',
+      'qcmDrag',
       'qcm',
       'qcmGraphic',
       'freeText',

--- a/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/picker.js
+++ b/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/picker.js
@@ -5,7 +5,7 @@ const answerProps = Picker.props;
 export default {
   props: {
     model: {
-      type: 'picker',
+      type: 'qcmDrag',
       ...answerProps
     }
   }

--- a/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
+++ b/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
@@ -169,7 +169,9 @@ function matchGivenAnswerToQuestion(
       return matchAnswerForUnorderedQCM(allowedAnswers, givenAnswer);
     }
     case 'qcmDrag': {
-      return matchAnswerForOrderedQCM(allowedAnswers, givenAnswer);
+      return question.content.matchOrder
+        ? matchAnswerForOrderedQCM(allowedAnswers, givenAnswer)
+        : matchAnswerForUnorderedQCM(allowedAnswers, givenAnswer);
     }
     default:
       return [[]];

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-drag.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-drag.js
@@ -1,6 +1,6 @@
 // @flow
 import test from 'ava';
-import type {QCMQuestion, AcceptedAnswers} from '../types';
+import type {QCMDragQuestion, AcceptedAnswers} from '../types';
 import {assertCorrect, assertIncorrect} from './helpers/assert-check-answer-correctness';
 
 const engine = {
@@ -8,35 +8,88 @@ const engine = {
   version: 'latest'
 };
 
-function createQuestion(answers: AcceptedAnswers): QCMQuestion {
+function createQuestion(matchOrder: boolean, answers: AcceptedAnswers): QCMDragQuestion {
   return {
     type: 'qcmDrag',
     content: {
+      matchOrder,
       answers
     }
   };
 }
 
-test('should return true when the given answer is in the accepted answers', t => {
-  const question = createQuestion([
-    ['answer1', 'answer3'],
-    ['answer2', 'answer4'],
-    ['answer1', 'answer4']
-  ]);
+[true, false].forEach((bool: boolean) => {
+  test(`should return true when the given answer is in the accepted answers (matchOrder=${bool.toString()})`, t => {
+    const question = createQuestion(bool, [
+      ['answer1', 'answer3'],
+      ['answer2', 'answer4'],
+      ['answer1', 'answer4']
+    ]);
 
-  assertCorrect(t, engine, question, ['answer1', 'answer3']);
-  assertCorrect(t, engine, question, ['answer2', 'answer4']);
-  assertCorrect(t, engine, question, ['answer1', 'answer4']);
+    assertCorrect(t, engine, question, ['answer1', 'answer3']);
+    assertCorrect(t, engine, question, ['answer2', 'answer4']);
+    assertCorrect(t, engine, question, ['answer1', 'answer4']);
+  });
+
+  test(`should return true even when the given answer does not have the same case as the accepted answers (matchOrder=${bool.toString()})`, t => {
+    const question = createQuestion(bool, [['answer2']]);
+
+    assertCorrect(t, engine, question, ['ANSWER2']);
+  });
+
+  test(`should return false when the given answer is not in the accepted answers (matchOrder=${bool.toString()})`, t => {
+    const question = createQuestion(bool, [
+      ['answer1', 'answer3'],
+      ['answer2', 'answer4'],
+      ['answer1', 'answer4']
+    ]);
+
+    assertIncorrect(t, engine, question, ['answer1', 'answer2'], [true, false]);
+    if (bool) {
+      assertIncorrect(t, engine, question, ['answer2', 'answer1'], [true, false]);
+      assertIncorrect(t, engine, question, ['answer3', 'answer4'], [false, true]);
+    } else {
+      assertIncorrect(t, engine, question, ['answer2', 'answer1'], [false, true]);
+      assertIncorrect(t, engine, question, ['answer3', 'answer4'], [true, false]);
+    }
+  });
+
+  test(`should return false when the given answer has more elements that the accepted answers (matchOrder=${bool.toString()})`, t => {
+    const question = createQuestion(bool, [
+      ['answer1', 'answer3'],
+      ['answer2', 'answer4'],
+      ['answer1', 'answer4']
+    ]);
+
+    assertIncorrect(t, engine, question, ['answer1', 'answer3', 'answer2'], [true, true, false]);
+    if (bool) {
+      assertIncorrect(t, engine, question, ['answer1', 'answer5', 'answer3'], [true, false, false]);
+    } else {
+      assertIncorrect(t, engine, question, ['answer1', 'answer5', 'answer3'], [true, false, true]);
+    }
+  });
+
+  test(`should return false when the given answer has less elements that the accepted answers (matchOrder=${bool.toString()})`, t => {
+    const question = createQuestion(bool, [
+      ['answer1', 'answer3'],
+      ['answer2', 'answer4'],
+      ['answer1', 'answer4']
+    ]);
+
+    assertIncorrect(t, engine, question, ['answer1'], [true]);
+    assertIncorrect(t, engine, question, ['answer2'], [true]);
+    assertIncorrect(t, engine, question, ['answer5'], [false]);
+  });
+
+  test(`should return false when the given answer is different but looks like the accepted answers (matchOrder=${bool.toString()})`, t => {
+    const question = createQuestion(bool, [['answer2']]);
+
+    assertIncorrect(t, engine, question, ['answe2r'], [false]);
+  });
 });
 
-test('should return true even when the given answer does not have the same case as the accepted answers', t => {
-  const question = createQuestion([['answer2']]);
-
-  assertCorrect(t, engine, question, ['ANSWER2']);
-});
-
-test('should return false when the given answer is in the accepted answers but values but in a different order', t => {
-  const question = createQuestion([
+test('should return false when the given answer is in the accepted answers but values but in a different order (matchOrder=true)', t => {
+  const question = createQuestion(true, [
     ['answer1', 'answer3'],
     ['answer2', 'answer4'],
     ['answer1', 'answer4']
@@ -47,43 +100,14 @@ test('should return false when the given answer is in the accepted answers but v
   assertIncorrect(t, engine, question, ['answer4', 'answer1'], [false, false]);
 });
 
-test('should return false when the given answer is not in the accepted answers', t => {
-  const question = createQuestion([
+test('should return true when the given answer is in the accepted answers but values but in a different order (matchOrder=false)', t => {
+  const question = createQuestion(false, [
     ['answer1', 'answer3'],
     ['answer2', 'answer4'],
     ['answer1', 'answer4']
   ]);
 
-  assertIncorrect(t, engine, question, ['answer2', 'answer1'], [true, false]);
-  assertIncorrect(t, engine, question, ['answer1', 'answer2'], [true, false]);
-  assertIncorrect(t, engine, question, ['answer3', 'answer4'], [false, true]);
-});
-
-test('should return false when the given answer has more elements that the accepted answers', t => {
-  const question = createQuestion([
-    ['answer1', 'answer3'],
-    ['answer2', 'answer4'],
-    ['answer1', 'answer4']
-  ]);
-
-  assertIncorrect(t, engine, question, ['answer1', 'answer3', 'answer2'], [true, true, false]);
-  assertIncorrect(t, engine, question, ['answer1', 'answer5', 'answer3'], [true, false, false]);
-});
-
-test('should return false when the given answer has less elements that the accepted answers', t => {
-  const question = createQuestion([
-    ['answer1', 'answer3'],
-    ['answer2', 'answer4'],
-    ['answer1', 'answer4']
-  ]);
-
-  assertIncorrect(t, engine, question, ['answer1'], [true]);
-  assertIncorrect(t, engine, question, ['answer2'], [true]);
-  assertIncorrect(t, engine, question, ['answer5'], [false]);
-});
-
-test("should return false when the given answer isn't but resembles the accepted answers", t => {
-  const question = createQuestion([['answer2']]);
-
-  assertIncorrect(t, engine, question, ['answe2r'], [false]);
+  assertCorrect(t, engine, question, ['answer3', 'answer1']);
+  assertCorrect(t, engine, question, ['answer4', 'answer2']);
+  assertCorrect(t, engine, question, ['answer4', 'answer1']);
 });

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer.js
@@ -51,10 +51,11 @@ test("should return the value of `isCorrect` in checkAnswerCorrectness's result 
   checkBothMethods(t, false, question, ['answer1', 'answer2']);
 });
 
-test("should return the value of `isCorrect` in checkAnswerCorrectness's result (qcmDrag)", t => {
+test("should return the value of `isCorrect` in checkAnswerCorrectness's result (qcmDrag, matchOrder=true)", t => {
   const question = {
     type: 'qcmDrag',
     content: {
+      matchOrder: true,
       answers: [['answer1', 'answer3'], ['answer2', 'answer4'], ['answer1', 'answer4']]
     }
   };
@@ -63,6 +64,22 @@ test("should return the value of `isCorrect` in checkAnswerCorrectness's result 
   checkBothMethods(t, true, question, ['answer2', 'answer4']);
   checkBothMethods(t, true, question, ['answer1', 'answer4']);
   checkBothMethods(t, false, question, ['answer4', 'answer1']);
+  checkBothMethods(t, false, question, ['answer1', 'answer2']);
+});
+
+test("should return the value of `isCorrect` in checkAnswerCorrectness's result (qcmDrag, matchOrder=false)", t => {
+  const question = {
+    type: 'qcmDrag',
+    content: {
+      matchOrder: false,
+      answers: [['answer1', 'answer3'], ['answer2', 'answer4'], ['answer1', 'answer4']]
+    }
+  };
+
+  checkBothMethods(t, true, question, ['answer1', 'answer3']);
+  checkBothMethods(t, true, question, ['answer2', 'answer4']);
+  checkBothMethods(t, true, question, ['answer1', 'answer4']);
+  checkBothMethods(t, true, question, ['answer4', 'answer1']);
   checkBothMethods(t, false, question, ['answer1', 'answer2']);
 });
 

--- a/packages/@coorpacademy-progression-engine/src/types.js
+++ b/packages/@coorpacademy-progression-engine/src/types.js
@@ -88,8 +88,16 @@ export type Answer = Array<string>;
 export type AcceptedAnswers = Array<Answer>;
 
 export type QCMQuestion = {
-  type: 'qcm' | 'qcmDrag' | 'qcmGraphic',
+  type: 'qcm' | 'qcmGraphic',
   content: {
+    answers: AcceptedAnswers
+  }
+};
+
+export type QCMDragQuestion = {
+  type: 'qcmDrag',
+  content: {
+    matchOrder: boolean,
     answers: AcceptedAnswers
   }
 };
@@ -123,7 +131,12 @@ export type UnknownQuestion = {
   }
 };
 
-export type Question = QCMQuestion | BasicQuestion | TemplateQuestion | UnknownQuestion;
+export type Question =
+  | QCMQuestion
+  | QCMDragQuestion
+  | BasicQuestion
+  | TemplateQuestion
+  | UnknownQuestion;
 
 export type Slide = {
   _id: string,


### PR DESCRIPTION
- Correction du check answer : le qcmDrag était codé pour toujours respecter l'ordre. Maintenant on respecte l'ordre seulement si le flag `matchOrder` dans la slide est à true.
- Support des questions qcmDrag dans l'app-player (state-to-props, actions/ui/answers, tests, ...)
- Renvoi d'une erreur claire lorsque dans editAnswer on a un type de question inconnu. Ça pétait déjà actuellement, mais au niveau de redux (car on avait une action sans type). Je clarifie juste l'erreur plus tôt pour mieux la découvrir.