### PR TITLE
mobile fixes

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/answer/style.css
+++ b/packages/@coorpacademy-components/src/molecule/answer/style.css
@@ -25,3 +25,9 @@
   justify-content: center;
   margin: 25px auto;
 }
+
+@media mobile {
+  .media {
+    margin: 0 auto 25px;
+  }
+}

--- a/packages/@coorpacademy-components/src/molecule/app-player/popin/popin-header/style.css
+++ b/packages/@coorpacademy-components/src/molecule/app-player/popin/popin-header/style.css
@@ -138,7 +138,7 @@
   color: white;
   font-weight: 600;
   font-size: 22px;
-  padding: 0 30px 0 10px;
+  padding: 0 20px 0 10px;
 }
 
 /*
@@ -190,8 +190,8 @@
     flex-flow: column;
     align-items: left;
     justify-content: space-around;
-    width: 70px;
-    right: 35px;
+    width: auto;
+    right: 3px;
   }
 
   .section {

--- a/packages/@coorpacademy-components/src/molecule/questions/picker/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/picker/style.css
@@ -74,4 +74,8 @@
   .selectedAnswers {
     min-height: auto;
   }
+
+  .answer:hover {
+    background-color: white;
+  }
 }

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-image/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-image/style.css
@@ -70,6 +70,10 @@
     margin: 0 0 8px;
   }
 
+  .answer:hover {
+    background-color: white;
+  }
+
   .answer:last-child {
     margin-bottom: 0;
   }

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm/style.css
@@ -9,12 +9,6 @@
   text-align: center;
 }
 
-@media mobile {
-  .wrapper {
-    min-width: 100%;
-  }
-}
-
 .answer {
   width: 100%;
   font-family: 'Open Sans';
@@ -43,4 +37,14 @@
 .selected {
   composes: answer;
   color: white;
+}
+
+@media mobile {
+  .wrapper {
+    min-width: 100%;
+  }
+
+  .answer:hover {
+    background-color: white;
+  }
 }

--- a/packages/@coorpacademy-components/src/molecule/slides/slides-footer/style.css
+++ b/packages/@coorpacademy-components/src/molecule/slides/slides-footer/style.css
@@ -85,3 +85,17 @@
   font-size: 13px;
   color: black;
 }
+
+@media mobile {
+  .button:hover {
+    background-color: xtraLightGrey;
+  }
+
+  .selected:hover {
+    background-color: light;
+  }
+
+  .disabled:hover {
+    background-color: xtraLightGrey;
+  }
+}

--- a/packages/@coorpacademy-components/src/organism/accordion/part/style.css
+++ b/packages/@coorpacademy-components/src/organism/accordion/part/style.css
@@ -104,7 +104,11 @@
 }
 
 @media mobile {
-  .header:hover {
+  .openHeader:hover {
+    background-color: xtraLightGrey;
+  }
+
+  .closedHeader:hover {
     background-color: light;
   }
 }

--- a/packages/@coorpacademy-components/src/template/app-player/popin-correction/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-correction/style.css
@@ -199,6 +199,7 @@
   .answer {
     padding-left: 22px;
     padding-top: 5px;
+    width: 100%;
   }
 
   .browser,


### PR DESCRIPTION
- [x] Effets hover : lorsqu'on ouvre un accordéon, il devrait devenir blanc en mobile (état actif). Ce n'est plus le cas
- [x] Effets hover: les modales media et indice restent grises une fois qu'on les désélectionne (IMPORTANT)
- [x] Effets hover : sur les QCM, lorsque je clique sur un carré, et que je le désélectionne, il reste gris (état hover du desktop) (PAS IMPORTANT pour MVP)
- [x] Espace du texte de la bonne réponse n'est pas bon lorsque la réponse est trop courte (voir Espace bonne réponse.png )
- [x] @media (max-width: 960px) components.434006e5c7f.css:1.popin-header_iconsWrapper { right: 16px } voir (Capture d’écran 2017-07-27 à 11.50.36.png )