### PR TITLE
Template fixes

### DIFF
--- a/packages/@coorpacademy-app-player/src/services/slides.data.json
+++ b/packages/@coorpacademy-app-player/src/services/slides.data.json
@@ -837,12 +837,12 @@
             "items": [
               {
                 "text": "Select",
-                "value": "Select",
+                "value": "sli_12345.choice_01",
                 "_id": "596338e04af4cb8a08a94494"
               },
               {
                 "text": "Text",
-                "value": "Text",
+                "value": "sli_12345.choice_02",
                 "_id": "596338e04af4cb8a08a94493"
               }
             ]

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/answer.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/answer.js
@@ -11,7 +11,6 @@ import size from 'lodash/fp/size';
 import set from 'lodash/fp/set';
 import isNil from 'lodash/fp/isNil';
 import rangeStep from 'lodash/fp/rangeStep';
-import toArray from 'lodash/fp/toArray';
 import toString from 'lodash/fp/toString'; // eslint-disable-line no-shadow
 import indexOf from 'lodash/fp/indexOf';
 import {
@@ -81,7 +80,7 @@ const qcmGraphicProps = (options, store) => (state, slide) => {
   };
 };
 
-const updateTemplateAnswer = (answers, index) => value => toArray(set(index, value, answers));
+const updateTemplateAnswer = (answers = [], index) => value => set(index, value, answers);
 
 const templateTextProps = (options, store) => (state, slide, choice, index) => {
   const {translate} = options;

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/answer.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/answer.js
@@ -110,9 +110,9 @@ const templateSelectProps = (options, store) => (state, slide, choice, index) =>
   const selectOptions = choice.items.map(item => {
     return {
       name: item.text,
-      value: item.value,
+      value: item.text,
       validOption: true,
-      selected: item.value === answer
+      selected: item.text === answer
     };
   });
 

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/test/answer.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/test/answer.js
@@ -299,6 +299,27 @@ test('should create action: edit-answer-slider', t => {
   });
 });
 
+test('should create action: edit-answer-template (entering second field with no current answer existing)', t => {
+  const state = {
+    ui: {
+      answers: {},
+      current: {progressionId: '1234'}
+    }
+  };
+
+  const props = getAnswerProps(state, template);
+  const textAction = props.answers[0].onChange('bar');
+  const selectAction = props.answers[1].onChange('bar');
+
+  t.is(textAction.type, ANSWER_EDIT.template);
+  t.deepEqual(textAction.payload, ['bar']);
+  t.is(textAction.meta.progressionId, '1234');
+
+  t.is(selectAction.type, ANSWER_EDIT.template);
+  t.deepEqual(selectAction.payload, [undefined, 'bar']);
+  t.is(selectAction.meta.progressionId, '1234');
+});
+
 test('should create initial basic props', t => {
   const state = {};
   const props = getAnswerProps(state, basic);

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/test/answer.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/test/answer.js
@@ -47,7 +47,7 @@ test('should create edited qcm props', t => {
 test('should create edited template props', t => {
   const state = {
     ui: {
-      answers: {'1234': {value: ['foo', 'sli_Nk2vje~E~.choice_Ek~jJyPNUZ']}},
+      answers: {'1234': {value: ['foo', 'exclusive']}},
       current: {progressionId: '1234'}
     }
   };
@@ -69,11 +69,11 @@ test('should create edited template props', t => {
   t.true(Array.isArray(selectOptions));
   t.is(selectOptions.length, 2);
   t.is(selectOptions[0].name, 'temporary');
-  t.is(selectOptions[0].value, 'sli_Nk2vje~E~.choice_VyloJkDEUb');
+  t.is(selectOptions[0].value, 'temporary');
   t.false(selectOptions[0].selected);
   t.true(selectOptions[0].validOption);
   t.is(selectOptions[1].name, 'exclusive');
-  t.is(selectOptions[1].value, 'sli_Nk2vje~E~.choice_Ek~jJyPNUZ');
+  t.is(selectOptions[1].value, 'exclusive');
   t.true(selectOptions[1].selected);
   t.true(selectOptions[1].validOption);
 });
@@ -93,11 +93,11 @@ test('should add an invalid `select an answer` choice for a select field in a te
   t.true(selectOptions[0].selected);
   t.false(selectOptions[0].validOption);
   t.is(selectOptions[1].name, 'temporary');
-  t.is(selectOptions[1].value, 'sli_Nk2vje~E~.choice_VyloJkDEUb');
+  t.is(selectOptions[1].value, 'temporary');
   t.false(selectOptions[1].selected);
   t.true(selectOptions[1].validOption);
   t.is(selectOptions[2].name, 'exclusive');
-  t.is(selectOptions[2].value, 'sli_Nk2vje~E~.choice_Ek~jJyPNUZ');
+  t.is(selectOptions[2].value, 'exclusive');
   t.false(selectOptions[2].selected);
   t.true(selectOptions[2].validOption);
 });
@@ -261,7 +261,7 @@ test('should create action: edit-answer-qcmDrag (answer removal)', t => {
 test('should create action: edit-answer-template', t => {
   const state = {
     ui: {
-      answers: {'1234': {value: ['ABCDEFGH', 'sli_Nk2vje~E~.choice_Ek~jJyPNUZ']}},
+      answers: {'1234': {value: ['ABCDEFGH', 'exclusive']}},
       current: {progressionId: '1234'}
     }
   };
@@ -271,7 +271,7 @@ test('should create action: edit-answer-template', t => {
   const selectAction = props.answers[1].onChange('bar');
 
   t.is(textAction.type, ANSWER_EDIT.template);
-  t.deepEqual(textAction.payload, ['bar', 'sli_Nk2vje~E~.choice_Ek~jJyPNUZ']);
+  t.deepEqual(textAction.payload, ['bar', 'exclusive']);
   t.is(textAction.meta.progressionId, '1234');
 
   t.is(selectAction.type, ANSWER_EDIT.template);

--- a/packages/@coorpacademy-components/src/atom/select/index.js
+++ b/packages/@coorpacademy-components/src/atom/select/index.js
@@ -17,7 +17,8 @@ const themeStyle = {
   mooc: style.mooc,
   question: style.question,
   sort: style.sort,
-  thematiques: style.thematiques
+  thematiques: style.thematiques,
+  template: style.template
 };
 
 const Select = (props, context) => {
@@ -65,11 +66,14 @@ const Select = (props, context) => {
   const black = get('common.black', skin);
   const color = get('common.primary', skin);
   const skinColor = {
-    color: theme === 'question' ? color : null
+    color: theme === 'question' || 'template' ? color : null
   };
 
   const arrowView = !multiple
-    ? <ArrowDown color={theme === 'question' ? color : black} className={style.arrow} />
+    ? <ArrowDown
+        color={theme === 'question' || 'template' ? color : black}
+        className={style.arrow}
+      />
     : null;
   const className = getClassState(style.default, style.modified, style.error, modified);
 

--- a/packages/@coorpacademy-components/src/atom/select/style.css
+++ b/packages/@coorpacademy-components/src/atom/select/style.css
@@ -394,3 +394,32 @@
     padding: 0 30px 0 15px;
   }
 }
+
+/*
+  Template
+*/
+.template {
+  composes: question;
+}
+
+.template select {
+  width: auto;
+  height: 54px;
+  padding-right: 35px;
+  box-sizing: border-box;
+}
+
+.template .label {
+  font-size: 15px;
+  font-weight: 700;
+  border: 2px solid;
+  height: 54px;
+  line-height: 52px;
+}
+
+.template label {
+  display: block;
+  width: auto;
+  margin-right: 0;
+  height: 54px;
+}

--- a/packages/@coorpacademy-components/src/atom/select/test/fixtures/template.js
+++ b/packages/@coorpacademy-components/src/atom/select/test/fixtures/template.js
@@ -1,0 +1,10 @@
+import defaultsDeep from 'lodash/fp/defaultsDeep';
+import Default from './default';
+
+const {props} = Default;
+
+export default {
+  props: defaultsDeep(props, {
+    theme: 'template'
+  })
+};

--- a/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/template.js
+++ b/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/template.js
@@ -1,4 +1,4 @@
-import Template from '../../../questions/template/test/fixtures/default';
+import Template from '../../../questions/template/test/fixtures/multiple';
 
 export default {
   props: {

--- a/packages/@coorpacademy-components/src/molecule/questions/drop-down/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/drop-down/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import filter from 'lodash/fp/filter';
+import getOr from 'lodash/fp/getOr';
 import head from 'lodash/fp/head';
 import pipe from 'lodash/fp/pipe';
 import Select, {SelectOptionPropTypes} from '../../../atom/select';
@@ -10,7 +11,9 @@ const DropDown = (props, context) => {
   const {options, onChange} = props;
 
   const currentSelection = pipe(filter('selected'), head)(options);
-  const theme = currentSelection.validOption === false ? 'invalid' : 'question';
+  const defaultTheme = currentSelection.validOption === false ? 'invalid' : 'question';
+
+  const theme = getOr(defaultTheme, 'theme', props);
 
   return (
     <div className={style.wrapper}>

--- a/packages/@coorpacademy-components/src/molecule/questions/drop-down/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/drop-down/style.css
@@ -5,4 +5,8 @@
   .wrapper {
     width: 100%;
   }
+
+  select {
+    display: inherit;
+  }
 }

--- a/packages/@coorpacademy-components/src/molecule/questions/template/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/index.js
@@ -19,8 +19,12 @@ const Template = props => {
     if (type === 'answerField') {
       const field = find({name: part.value}, props.answers);
       return field.type === 'text'
-        ? <FreeText {...field} key={part.value} className={style.field} />
-        : <DropDown {...field} key={part.value} className={style.field} />;
+        ? <div className={style.answerType}>
+            <FreeText {...field} key={part.value} className={style.text} />
+          </div>
+        : <div className={style.answerType}>
+            <DropDown {...field} key={part.value} className={style.select} theme="template" />
+          </div>;
     }
   }, totalTemplate);
 

--- a/packages/@coorpacademy-components/src/molecule/questions/template/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/index.js
@@ -19,10 +19,12 @@ const Template = props => {
       const fieldView = field.type === 'text'
         ? <FreeText {...field} className={style.text} />
         : <DropDown {...field} className={style.select} theme="template" />;
-      
-      return <div className={style.answerType} key={part.value}>
-        {fieldView}
-      </div>;
+
+      return (
+        <div className={style.answerType} key={part.value}>
+          {fieldView}
+        </div>
+      );
     }
   }, totalTemplate);
 

--- a/packages/@coorpacademy-components/src/molecule/questions/template/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/index.js
@@ -14,7 +14,7 @@ const Template = props => {
     const type = part.type;
 
     if (type === 'string') {
-      return <div className={style.string} key={key}>{part.value}</div>;
+      return part.value;
     }
     if (type === 'answerField') {
       const field = find({name: part.value}, props.answers);

--- a/packages/@coorpacademy-components/src/molecule/questions/template/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/index.js
@@ -12,17 +12,17 @@ const Template = props => {
   const templateCompose = map.convert({cap: false})((part, key) => {
     const type = part.type;
     if (type === 'string') {
-      return part.value;
+      return <span key={key}>{part.value}</span>;
     }
     if (type === 'answerField') {
       const field = find({name: part.value}, props.answers);
-      return field.type === 'text'
-        ? <div className={style.answerType}>
-            <FreeText {...field} key={part.value} className={style.text} />
-          </div>
-        : <div className={style.answerType}>
-            <DropDown {...field} key={part.value} className={style.select} theme="template" />
-          </div>;
+      const fieldView = field.type === 'text'
+        ? <FreeText {...field} className={style.text} />
+        : <DropDown {...field} className={style.select} theme="template" />;
+      
+      return <div className={style.answerType} key={part.value}>
+        {fieldView}
+      </div>;
     }
   }, totalTemplate);
 

--- a/packages/@coorpacademy-components/src/molecule/questions/template/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/index.js
@@ -9,10 +9,8 @@ import style from './style.css';
 
 const Template = props => {
   const totalTemplate = parseTemplateString(props.template);
-
   const templateCompose = map.convert({cap: false})((part, key) => {
     const type = part.type;
-
     if (type === 'string') {
       return part.value;
     }

--- a/packages/@coorpacademy-components/src/molecule/questions/template/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/style.css
@@ -27,12 +27,17 @@
 .wrapper div {
   display: inline-block;
   width: auto;
+  margin: 8px 0;
 }
 
 .wrapper div div label {
   display: block;
   width: auto;
   margin-right: 0;
+}
+
+.wrapper div div select {
+  height: 53px;
 }
 
 @media mobile {
@@ -48,6 +53,7 @@
   .wrapper div div select {
     height: 100%;
     width: auto;
+    height: 53px;
     padding-right: 35px;
     box-sizing: border-box;
   }
@@ -77,6 +83,7 @@
   .wrapper div div select {
     height: 100%;
     width: auto;
+    height: 53px;
     padding-right: 35px;
     box-sizing: border-box;
   }

--- a/packages/@coorpacademy-components/src/molecule/questions/template/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/style.css
@@ -6,40 +6,13 @@
   display: block;
   width: auto;
   align-items: center;
-  margin: 0 auto;
   padding: 8px;
   box-sizing: border-box;
   justify-content: center;
   font-family: "Open Sans";
   font-weight: 700;
   font-size: 14px;
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
   margin: 0 4px;
-  box-sizing: border-box;
->>>>>>> 9d7aba1... review fixes
-}
-
-.answerType {
-  display: inline-block;
-  margin: 8px 0;
-}
-
-.answerType .text {
-  border: solid 3px red;
-}
-
-<<<<<<< HEAD
-.answerType .select {
-  margin-top: 2px;
-=======
-@media mobile {
-  .wrapper {
-    display: block;
-    width: 100%;
-  }
-=======
 }
 
 .answerType {
@@ -53,6 +26,4 @@
 
 .answerType .select {
   margin-top: 2px;
->>>>>>> 6e8f6f3... fix review
->>>>>>> 9d7aba1... review fixes
 }

--- a/packages/@coorpacademy-components/src/molecule/questions/template/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/style.css
@@ -5,7 +5,6 @@
 .wrapper {
   display: block;
   width: auto;
-  line-height: 58px;
   align-items: center;
   margin: 0 auto;
   padding: 0;
@@ -43,7 +42,7 @@
   }
 
   .wrapper div {
-    margin-bottom: 8px;
+    margin: 8px 0;
   }
 
   .wrapper div div select {
@@ -72,7 +71,7 @@
   }
 
   .wrapper div {
-    margin-bottom: 8px;
+    margin: 8px 0;
   }
 
   .wrapper div div select {

--- a/packages/@coorpacademy-components/src/molecule/questions/template/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/style.css
@@ -1,22 +1,23 @@
 @value breakpoints: "../../../variables/breakpoints.css";
 @value mobile from breakpoints;
+@value tablet from breakpoints;
 
 .wrapper {
-  display: flex;
+  display: block;
   width: auto;
+  line-height: 58px;
   align-items: center;
   margin: 0 auto;
   padding: 0;
   box-sizing: border-box;
   justify-content: center;
-}
-
-.string {
   font-family: "Open Sans";
   font-weight: 700;
   font-size: 14px;
-  margin: 0 4px;
-  box-sizing: border-box;
+}
+
+.field {
+  display: inline-block;
 }
 
 .field label {
@@ -24,9 +25,71 @@
   box-sizing: border-box;
 }
 
+.wrapper div {
+  display: inline-block;
+  width: auto;
+}
+
+.wrapper div div label {
+  display: block;
+  width: auto;
+  margin-right: 0;
+}
+
 @media mobile {
   .wrapper {
+    padding: 8px 16px;
+    box-sizing: border-box;
+  }
+
+  .wrapper div {
+    margin-bottom: 8px;
+  }
+
+  .wrapper div div select {
+    height: 100%;
+    width: auto;
+    padding-right: 35px;
+    box-sizing: border-box;
+  }
+
+  .wrapper div div label {
     display: block;
-    width: 100%;
+    width: auto;
+    margin-right: 0;
+  }
+
+  .wrapper div {
+    display: inline-block;
+    width: auto;
+  }
+}
+
+@media tablet {
+  .wrapper {
+    padding: 8px 16px;
+    box-sizing: border-box;
+  }
+
+  .wrapper div {
+    margin-bottom: 8px;
+  }
+
+  .wrapper div div select {
+    height: 100%;
+    width: auto;
+    padding-right: 35px;
+    box-sizing: border-box;
+  }
+
+  .wrapper div div label {
+    display: block;
+    width: auto;
+    margin-right: 0;
+  }
+
+  .wrapper div {
+    display: inline-block;
+    width: auto;
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/questions/template/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/style.css
@@ -13,6 +13,33 @@
   font-family: "Open Sans";
   font-weight: 700;
   font-size: 14px;
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+  margin: 0 4px;
+  box-sizing: border-box;
+>>>>>>> 9d7aba1... review fixes
+}
+
+.answerType {
+  display: inline-block;
+  margin: 8px 0;
+}
+
+.answerType .text {
+  border: solid 3px red;
+}
+
+<<<<<<< HEAD
+.answerType .select {
+  margin-top: 2px;
+=======
+@media mobile {
+  .wrapper {
+    display: block;
+    width: 100%;
+  }
+=======
 }
 
 .answerType {
@@ -26,4 +53,6 @@
 
 .answerType .select {
   margin-top: 2px;
+>>>>>>> 6e8f6f3... fix review
+>>>>>>> 9d7aba1... review fixes
 }

--- a/packages/@coorpacademy-components/src/molecule/questions/template/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/style.css
@@ -7,7 +7,7 @@
   width: auto;
   align-items: center;
   margin: 0 auto;
-  padding: 0;
+  padding: 8px;
   box-sizing: border-box;
   justify-content: center;
   font-family: "Open Sans";
@@ -15,87 +15,15 @@
   font-size: 14px;
 }
 
-.field {
+.answerType {
   display: inline-block;
-}
-
-.field label {
-  margin: 0;
-  box-sizing: border-box;
-}
-
-.wrapper div {
-  display: inline-block;
-  width: auto;
   margin: 8px 0;
 }
 
-.wrapper div div label {
-  display: block;
-  width: auto;
-  margin-right: 0;
+.answerType .text {
+  border: solid 3px red;
 }
 
-.wrapper div div select {
-  height: 53px;
-}
-
-@media mobile {
-  .wrapper {
-    padding: 8px 16px;
-    box-sizing: border-box;
-  }
-
-  .wrapper div {
-    margin: 8px 0;
-  }
-
-  .wrapper div div select {
-    height: 100%;
-    width: auto;
-    height: 53px;
-    padding-right: 35px;
-    box-sizing: border-box;
-  }
-
-  .wrapper div div label {
-    display: block;
-    width: auto;
-    margin-right: 0;
-  }
-
-  .wrapper div {
-    display: inline-block;
-    width: auto;
-  }
-}
-
-@media tablet {
-  .wrapper {
-    padding: 8px 16px;
-    box-sizing: border-box;
-  }
-
-  .wrapper div {
-    margin: 8px 0;
-  }
-
-  .wrapper div div select {
-    height: 100%;
-    width: auto;
-    height: 53px;
-    padding-right: 35px;
-    box-sizing: border-box;
-  }
-
-  .wrapper div div label {
-    display: block;
-    width: auto;
-    margin-right: 0;
-  }
-
-  .wrapper div {
-    display: inline-block;
-    width: auto;
-  }
+.answerType .select {
+  margin-top: 2px;
 }

--- a/packages/@coorpacademy-components/src/molecule/questions/template/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/test/fixtures/default.js
@@ -12,6 +12,7 @@ export default {
       },
       {
         type: 'select',
+        theme: 'template',
         name: 'sel31191',
         label: ' ',
         onChange: value => console.log(value),

--- a/packages/@coorpacademy-components/src/molecule/questions/template/test/fixtures/multiple.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/test/fixtures/multiple.js
@@ -1,25 +1,15 @@
 export default {
   props: {
     template:
-      'la réponse est {{sel31191}} {{sel31192}} lorem ipsum {{sel31193}} Sed maximum est in amicitia parem esse inferiori. Saepe enim excellentiae quaedam sunt {{sel31194}}.',
+      'la réponse est {{inp81438}} {{sel31192}} lorem ipsum {{sel31193}} Sed maximum est in amicitia parem esse inferiori. Saepe enim excellentiae quaedam sunt {{sel31194}}.',
     answers: [
       {
-        type: 'select',
-        name: 'sel31191',
+        type: 'text',
+        name: 'inp81438',
         label: ' ',
-        onChange: value => console.log(value),
-        options: [
-          {
-            name: 'temporary',
-            value: 'sli_Nk2vje~E~.choice_VyloJkDEUb',
-            selected: true
-          },
-          {
-            name: 'exclusive',
-            value: 'sli_Nk2vje~E~.choice_Ek~jJyPNUZ',
-            selected: false
-          }
-        ]
+        placeholder: ' ',
+        value: 'an answer',
+        onChange: value => console.log(value)
       },
       {
         type: 'select',

--- a/packages/@coorpacademy-components/src/molecule/questions/template/test/fixtures/multiple.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/test/fixtures/multiple.js
@@ -1,0 +1,80 @@
+export default {
+  props: {
+    template:
+      'la réponse est {{sel31191}} {{sel31192}} lorem ipsum {{sel31193}} Sed maximum est in amicitia parem esse inferiori. Saepe enim excellentiae quaedam sunt {{sel31194}}.',
+    answers: [
+      {
+        type: 'select',
+        name: 'sel31191',
+        label: ' ',
+        onChange: value => console.log(value),
+        options: [
+          {
+            name: 'temporary',
+            value: 'sli_Nk2vje~E~.choice_VyloJkDEUb',
+            selected: true
+          },
+          {
+            name: 'exclusive',
+            value: 'sli_Nk2vje~E~.choice_Ek~jJyPNUZ',
+            selected: false
+          }
+        ]
+      },
+      {
+        type: 'select',
+        name: 'sel31192',
+        label: ' ',
+        onChange: value => console.log(value),
+        options: [
+          {
+            name: 'temporary',
+            value: 'sli_Nk2vje~E~.choice_VyloJkDEUb',
+            selected: true
+          },
+          {
+            name: 'exclusive',
+            value: 'sli_Nk2vje~E~.choice_Ek~jJyPNUZ',
+            selected: false
+          }
+        ]
+      },
+      {
+        type: 'select',
+        name: 'sel31193',
+        label: ' ',
+        onChange: value => console.log(value),
+        options: [
+          {
+            name: 'temporary',
+            value: 'sli_Nk2vje~E~.choice_VyloJkDEUb',
+            selected: true
+          },
+          {
+            name: 'exclusive',
+            value: 'sli_Nk2vje~E~.choice_Ek~jJyPNUZ',
+            selected: false
+          }
+        ]
+      },
+      {
+        type: 'select',
+        name: 'sel31194',
+        label: ' ',
+        onChange: value => console.log(value),
+        options: [
+          {
+            name: 'temporary',
+            value: 'sli_Nk2vje~E~.choice_VyloJkDEUb',
+            selected: true
+          },
+          {
+            name: 'exclusive',
+            value: 'sli_Nk2vje~E~.choice_Ek~jJyPNUZ',
+            selected: false
+          }
+        ]
+      }
+    ]
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/slides/slides-player/test/fixtures/qcm-template.js
+++ b/packages/@coorpacademy-components/src/molecule/slides/slides-player/test/fixtures/qcm-template.js
@@ -1,0 +1,12 @@
+import Answer from '../../../../answer/test/fixtures/template';
+import Default from './default';
+
+const answerType = Answer.props;
+
+export default {
+  props: {
+    typeClue: 'answer',
+    ...Default.props,
+    answerType
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/slides/slides-player/test/fixtures/template.js
+++ b/packages/@coorpacademy-components/src/molecule/slides/slides-player/test/fixtures/template.js
@@ -1,0 +1,12 @@
+import Answer from '../../../../answer/test/fixtures/template';
+import Default from './default';
+
+const answerType = Answer.props;
+
+export default {
+  props: {
+    typeClue: 'template',
+    ...Default.props,
+    answerType
+  }
+};

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -220,6 +220,7 @@ import SelectFixtureMultiple from '../src/atom/select/test/fixtures/multiple';
 import SelectFixtureQuestion from '../src/atom/select/test/fixtures/question';
 import SelectFixtureRequired from '../src/atom/select/test/fixtures/required';
 import SelectFixtureSort from '../src/atom/select/test/fixtures/sort';
+import SelectFixtureTemplate from '../src/atom/select/test/fixtures/template';
 import SelectFixtureThematiquesLong from '../src/atom/select/test/fixtures/thematiques-long';
 import SelectFixtureThematiques from '../src/atom/select/test/fixtures/thematiques';
 import SlideFixtureDefault from '../src/atom/slide/test/fixtures/default';
@@ -842,6 +843,7 @@ export const fixtures = {
       Question: SelectFixtureQuestion,
       Required: SelectFixtureRequired,
       Sort: SelectFixtureSort,
+      Template: SelectFixtureTemplate,
       ThematiquesLong: SelectFixtureThematiquesLong,
       Thematiques: SelectFixtureThematiques
     },

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -413,6 +413,7 @@ import SlidesPlayerFixtureOnlyClue from '../src/molecule/slides/slides-player/te
 import SlidesPlayerFixtureQcmDrag from '../src/molecule/slides/slides-player/test/fixtures/qcm-drag';
 import SlidesPlayerFixtureQcmGraphic from '../src/molecule/slides/slides-player/test/fixtures/qcm-graphic';
 import SlidesPlayerFixtureQcmShort from '../src/molecule/slides/slides-player/test/fixtures/qcm-short';
+import SlidesPlayerFixtureQcmTemplate from '../src/molecule/slides/slides-player/test/fixtures/qcm-template';
 import SlidesPlayerFixtureQcm from '../src/molecule/slides/slides-player/test/fixtures/qcm';
 import SlidesPlayerFixtureRange from '../src/molecule/slides/slides-player/test/fixtures/range';
 import SlidesPlayerFixtureWithMinHeight from '../src/molecule/slides/slides-player/test/fixtures/with-min-height';
@@ -1172,6 +1173,7 @@ export const fixtures = {
       QcmDrag: SlidesPlayerFixtureQcmDrag,
       QcmGraphic: SlidesPlayerFixtureQcmGraphic,
       QcmShort: SlidesPlayerFixtureQcmShort,
+      QcmTemplate: SlidesPlayerFixtureQcmTemplate,
       Qcm: SlidesPlayerFixtureQcm,
       Range: SlidesPlayerFixtureRange,
       WithMinHeight: SlidesPlayerFixtureWithMinHeight

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -391,6 +391,7 @@ import QcmFixtureNoSelected from '../src/molecule/questions/qcm/test/fixtures/no
 import QcmFixtureShortAnswers from '../src/molecule/questions/qcm/test/fixtures/short-answers';
 import QuestionRangeFixtureDefault from '../src/molecule/questions/question-range/test/fixtures/default';
 import TemplateFixtureDefault from '../src/molecule/questions/template/test/fixtures/default';
+import TemplateFixtureMultiple from '../src/molecule/questions/template/test/fixtures/multiple';
 import SlidesFooterFixtureClueSelected from '../src/molecule/slides/slides-footer/test/fixtures/clue-selected';
 import SlidesFooterFixtureDefault from '../src/molecule/slides/slides-footer/test/fixtures/default';
 import SlidesFooterFixtureDisabled from '../src/molecule/slides/slides-footer/test/fixtures/disabled';
@@ -416,6 +417,7 @@ import SlidesPlayerFixtureQcmShort from '../src/molecule/slides/slides-player/te
 import SlidesPlayerFixtureQcmTemplate from '../src/molecule/slides/slides-player/test/fixtures/qcm-template';
 import SlidesPlayerFixtureQcm from '../src/molecule/slides/slides-player/test/fixtures/qcm';
 import SlidesPlayerFixtureRange from '../src/molecule/slides/slides-player/test/fixtures/range';
+import SlidesPlayerFixtureTemplate from '../src/molecule/slides/slides-player/test/fixtures/template';
 import SlidesPlayerFixtureWithMinHeight from '../src/molecule/slides/slides-player/test/fixtures/with-min-height';
 import ContainerFixtureDefault from '../src/organism/accordion/container/test/fixtures/default';
 import PartFixtureDefault from '../src/organism/accordion/part/test/fixtures/default';
@@ -1142,7 +1144,8 @@ export const fixtures = {
       Default: QuestionRangeFixtureDefault
     },
     Template: {
-      Default: TemplateFixtureDefault
+      Default: TemplateFixtureDefault,
+      Multiple: TemplateFixtureMultiple
     }
   },
   MoleculeSlides: {
@@ -1176,6 +1179,7 @@ export const fixtures = {
       QcmTemplate: SlidesPlayerFixtureQcmTemplate,
       Qcm: SlidesPlayerFixtureQcm,
       Range: SlidesPlayerFixtureRange,
+      Template: SlidesPlayerFixtureTemplate,
       WithMinHeight: SlidesPlayerFixtureWithMinHeight
     }
   },


### PR DESCRIPTION
- Fix: Lorsqu'on avait pas encore rentré de réponse, et qu'on rentre une réponse pour le deuxième champ, cette valeur était considérée et affichée comme la réponse du premier champ.
- Fix: Pour un champ de type select, on enregistre comme réponse le texte de la réponse (e.g. "Google"), plutôt que sa value (eg. "sli_12345.choice_01"). Ça corrige le fait que la réponse était toujours considérée comme incorrecte et qu'on affichait "sli_12345.choice_01" comme réponse entrée par l'utilisateur dans la popin de réponse.
- Ajout d'une fixture pour les template dans SlidesPlayer, il n'y en avait pas.

Cette PR ne prend (pour le moment) en compte que les retours métiers du ticket linké plus bas. Selon la vitesse de validation, les retours graphiques seront poussés sur cette branche ou poussés dans une autre PR. Les deux types de retours sont totalement décorelés, donc ça ne posera pas de problème si mergé séparément.