### PR TITLE
Bug fixes

### DIFF
--- a/packages/@coorpacademy-app-player/src/services/progressions.data.json
+++ b/packages/@coorpacademy-app-player/src/services/progressions.data.json
@@ -102,5 +102,28 @@
       },
       "lives": 0
     }
+  },
+  {
+    "_id": "template",
+    "engine": {
+      "ref": "microlearning",
+      "version": "1"
+    },
+    "content": {
+      "ref": "5.C7",
+      "type": "chapter"
+    },
+    "state": {
+      "slides": [],
+      "nextContent": {
+        "ref": "sli_Nk2vje~E~",
+        "type": "slide"
+      },
+      "lives": 1,
+      "step": {
+        "current": 1,
+        "total": 4
+      }
+    }
   }
 ]

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/answer.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/answer.js
@@ -80,7 +80,8 @@ const qcmGraphicProps = (options, store) => (state, slide) => {
   };
 };
 
-const updateTemplateAnswer = (answers = [], index) => value => set(index, value, answers);
+const updateTemplateAnswer = (answers = [], index) => value =>
+  map(a => (isNil(a) ? '' : a), set(index, value, answers));
 
 const templateTextProps = (options, store) => (state, slide, choice, index) => {
   const {translate} = options;

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/test/answer.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/test/answer.js
@@ -279,6 +279,27 @@ test('should create action: edit-answer-template', t => {
   t.is(selectAction.meta.progressionId, '1234');
 });
 
+test('should create action: edit-answer-template (entering second field with no current answer existing)', t => {
+  const state = {
+    ui: {
+      answers: {},
+      current: {progressionId: '1234'}
+    }
+  };
+
+  const props = getAnswerProps(state, template);
+  const textAction = props.answers[0].onChange('bar');
+  const selectAction = props.answers[1].onChange('bar');
+
+  t.is(textAction.type, ANSWER_EDIT.template);
+  t.deepEqual(textAction.payload, ['bar']);
+  t.is(textAction.meta.progressionId, '1234');
+
+  t.is(selectAction.type, ANSWER_EDIT.template);
+  t.deepEqual(selectAction.payload, ['', 'bar']);
+  t.is(selectAction.meta.progressionId, '1234');
+});
+
 test('should create action: edit-answer-slider', t => {
   const state = {
     ui: {
@@ -297,27 +318,6 @@ test('should create action: edit-answer-slider', t => {
       progressionId: '1234'
     }
   });
-});
-
-test('should create action: edit-answer-template (entering second field with no current answer existing)', t => {
-  const state = {
-    ui: {
-      answers: {},
-      current: {progressionId: '1234'}
-    }
-  };
-
-  const props = getAnswerProps(state, template);
-  const textAction = props.answers[0].onChange('bar');
-  const selectAction = props.answers[1].onChange('bar');
-
-  t.is(textAction.type, ANSWER_EDIT.template);
-  t.deepEqual(textAction.payload, ['bar']);
-  t.is(textAction.meta.progressionId, '1234');
-
-  t.is(selectAction.type, ANSWER_EDIT.template);
-  t.deepEqual(selectAction.payload, [undefined, 'bar']);
-  t.is(selectAction.meta.progressionId, '1234');
 });
 
 test('should create initial basic props', t => {

--- a/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
+++ b/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
@@ -1,4 +1,5 @@
 // @flow
+import get from 'lodash/fp/get';
 import map from 'lodash/fp/map';
 import zip from 'lodash/fp/zip';
 import some from 'lodash/fp/some';
@@ -92,19 +93,23 @@ function matchAnswerForTemplate(
   question: TemplateQuestion,
   givenAnswer: Answer
 ): Array<Array<PartialCorrection>> {
-  return [
-    givenAnswer.map((answer, index) => ({
-      answer,
-      isCorrect: question.content.answers.some(allowedAnswer =>
-        isTextCorrect(
-          config,
-          [allowedAnswer[index]],
-          toLower(answer),
-          question.content.choices[index].type === 'text' ? question.content.maxTypos : 0
-        )
+  const result = givenAnswer.map((answer, index) => ({
+    answer,
+    isCorrect: question.content.answers.some(allowedAnswer =>
+      isTextCorrect(
+        config,
+        [allowedAnswer[index]],
+        toLower(answer),
+        get(['content', 'choices', index, 'type'], question) === 'text'
+          ? question.content.maxTypos
+          : 0
       )
-    }))
-  ];
+    )
+  }));
+  const missingAnswers = question.content.answers[0]
+    .slice(result.length)
+    .map(() => ({answer: undefined, isCorrect: false}));
+  return [result.concat(missingAnswers)];
 }
 
 function matchAnswerForUnorderedItems(

--- a/packages/@coorpacademy-progression-engine/src/config/microlearning.js
+++ b/packages/@coorpacademy-progression-engine/src/config/microlearning.js
@@ -23,7 +23,7 @@ const testConfigurations: Array<MicroLearningConfig> = [
     answerBoundaryLimit: 5,
     starsPerAskingClue: -1,
     starsPerCorrectAnswer: 4,
-    starsPerResourceViewed: 4
+    starsPerResourceViewed: 5
   }
 ];
 

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-drag.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-drag.js
@@ -79,6 +79,7 @@ function createQuestion(matchOrder: boolean, answers: AcceptedAnswers): QCMDragQ
     assertIncorrect(t, engine, question, ['answer1'], [true]);
     assertIncorrect(t, engine, question, ['answer2'], [true]);
     assertIncorrect(t, engine, question, ['answer5'], [false]);
+    assertIncorrect(t, engine, question, [], []);
   });
 
   test(`should return false when the given answer is different but looks like the accepted answers (matchOrder=${bool.toString()})`, t => {

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-graphic.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-graphic.js
@@ -81,6 +81,7 @@ test('should return false when the given answer has less elements that the accep
   assertIncorrect(t, engine, question, ['answer1'], [true]);
   assertIncorrect(t, engine, question, ['answer2'], [true]);
   assertIncorrect(t, engine, question, ['answer5'], [false]);
+  assertIncorrect(t, engine, question, [], []);
 });
 
 test("should return false when the given answer isn't the same but resembles the accepted answers", t => {

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm.js
@@ -81,6 +81,7 @@ test('should return false when the given answer has less elements that the accep
   assertIncorrect(t, engine, question, ['answer1'], [true]);
   assertIncorrect(t, engine, question, ['answer2'], [true]);
   assertIncorrect(t, engine, question, ['answer5'], [false]);
+  assertIncorrect(t, engine, question, [], []);
 });
 
 test("should return false when the given answer isn't the same but resembles the accepted answers", t => {

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.template.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.template.js
@@ -130,3 +130,33 @@ test('should not allow typos or additional characters for select inputs', t => {
   assertIncorrect(t, engine, question, ['parachuteZ'], [false]);
   assertIncorrect(t, engine, question, ['Zparachute'], [false]);
 });
+
+test('should return false when the given answer has more elements that the accepted answers', t => {
+  const question = createQuestion(
+    [['2', 'un'], ['deux', 'un'], ['saut', 'parachute']],
+    ['text', 'text']
+  );
+
+  assertIncorrect(t, engine, question, ['2', 'un', 'trois'], [true, true, false]);
+  assertIncorrect(t, engine, question, ['deux', 'un', 'trois'], [true, true, false]);
+  assertIncorrect(t, engine, question, ['saut', 'parachute', 'avion'], [true, true, false]);
+  assertIncorrect(
+    t,
+    engine,
+    question,
+    ['saut', 'parachute', 'avion', 'pilote'],
+    [true, true, false, false]
+  );
+});
+
+test('should return false when the given answer has less elements that the accepted answerss', t => {
+  const question = createQuestion(
+    [['2', 'un'], ['deux', 'un'], ['saut', 'parachute']],
+    ['text', 'text']
+  );
+
+  assertIncorrect(t, engine, question, ['2'], [true]);
+  assertIncorrect(t, engine, question, ['deux'], [true]);
+  assertIncorrect(t, engine, question, ['saut'], [true]);
+  assertIncorrect(t, engine, question, [], []);
+});

--- a/packages/@coorpacademy-progression-engine/src/test/helpers/assert-check-answer-correctness.js
+++ b/packages/@coorpacademy-progression-engine/src/test/helpers/assert-check-answer-correctness.js
@@ -24,7 +24,7 @@ function assertIncorrect(
   t.is(
     givenAnswer.length,
     expectedCorrections.length,
-    'expected corrections should have the same length as givenAnswer'
+    'Expected corrections should have the same length as givenAnswer'
   );
   const result = checkAnswerCorrectness(engine, question, givenAnswer);
   t.false(result.isCorrect, 'Answer should have been considered as incorrect');

--- a/packages/@coorpacademy-progression-engine/src/test/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/test/update-state.js
@@ -290,6 +290,37 @@ test('should update stars after viewing a resource', t => {
   );
 });
 
+test('should update stars after viewing a resource (with different number of stars)', t => {
+  const state: State = Object.freeze(stateForSecondSlide);
+
+  const action: ChapterResourceViewedAction = Object.freeze({
+    type: 'resource',
+    payload: {
+      content: {
+        ref: '5936600c50571fa407e7c4c4',
+        type: 'resource',
+        chapter_ref: '1.A1'
+      }
+    }
+  });
+
+  const engineWithDifferentStars = {
+    ref: 'microlearning',
+    version: 'allow_typos_3'
+  };
+
+  const omitChangedFields = omit(['viewedResources', 'stars']);
+  const newState = updateState(engineWithDifferentStars, state, [action, action]);
+
+  t.is(newState.stars, 9);
+  t.deepEqual(newState.viewedResources, ['1.A1']);
+  t.deepEqual(
+    omitChangedFields(newState),
+    omitChangedFields(state),
+    'Some fields that should not have been touched have been modified'
+  );
+});
+
 test("should throw if the state's nextContent is not the same as the action's content", t => {
   const state: State = Object.freeze(stateForSecondSlide);
 

--- a/packages/@coorpacademy-progression-engine/src/types.js
+++ b/packages/@coorpacademy-progression-engine/src/types.js
@@ -75,7 +75,7 @@ export type Progression = {
 };
 
 export type PartialCorrection = {
-  answer: string,
+  answer: string | void,
   isCorrect: boolean
 };
 

--- a/packages/@coorpacademy-progression-engine/src/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/update-state.js
@@ -51,8 +51,8 @@ function viewedResources(config: MicroLearningConfig): (Array<string>, Action) =
   return (array: Array<string> = [], action: Action): Array<string> => {
     switch (action.type) {
       case 'resource': {
-        const requestedClueAction = (action: ChapterResourceViewedAction);
-        const chapterRef = requestedClueAction.payload.content.chapter_ref;
+        const resourceViewAction = (action: ChapterResourceViewedAction);
+        const chapterRef = resourceViewAction.payload.content.chapter_ref;
         return includes(chapterRef, array) ? array : concat(array, [chapterRef]);
       }
       default:
@@ -144,7 +144,7 @@ function stars(config: MicroLearningConfig): (number, Action, State) => number {
         const chapterRef = chapterResourceViewedAction.payload.content.chapter_ref;
         return includes(chapterRef, state.viewedResources)
           ? currentStars
-          : currentStars + config.starsPerCorrectAnswer;
+          : currentStars + config.starsPerResourceViewed;
       }
       default:
         return currentStars;


### PR DESCRIPTION
Pas mal de corrections :
- Lorsqu'on visionnait une laçon, on gagnait le nombre d'étoiles qu'on gagne lorsqu'on répond à une question, et pas le nombre d'étoiles qu'on gagne lorsqu'on visionne une leçon.
- Dans une question de type template, lorsqu'on rentrait une valeur pour le deuxième champ et qu'on valide sans modifier le premier champ, on avait un blocage (car on envoyait `null` ou `undefined`)
- Les réponses aux questions templates ne sont plus considérés comme correctes lorsqu'on envoie moins de réponses qu'attendus

Misc:
- Ajout d'une fixture de progression dans l'app-player sous `/template` permettant d'accéder directement à une question de type template.