### PR TITLE
Change schema for the resource view action

### DIFF
--- a/packages/@coorpacademy-app-player/src/view/state-to-props/answer.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/answer.js
@@ -166,9 +166,7 @@ const sliderProps = (options, store) => (state, slide) => {
   );
 
   const stateValue = pipe(getAnswerValues, head)(slide, state);
-  const currentValue = isNil(stateValue)
-    ? slide.question.content.defaultValue
-    : parseInt(stateValue);
+  const currentValue = parseInt(stateValue);
 
   const indexValue = indexOf(currentValue, values);
   const handleChange = editAnswerAction(options, store)(state, slide);

--- a/packages/@coorpacademy-progression-engine/src/test/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/test/update-state.js
@@ -19,14 +19,19 @@ const engine = {
   version: '1'
 };
 
-function chapterResourceViewedAction(chapter_ref: string): ChapterResourceViewedAction {
+function chapterResourceViewedAction(chapterRef: string): ChapterResourceViewedAction {
   return Object.freeze({
     type: 'resource',
     payload: {
-      content: {
+      resource: {
         ref: uniqueId(),
-        type: 'resource',
-        chapter_ref
+        type: 'video',
+        version: '1'
+      },
+      chapter: {
+        ref: chapterRef,
+        type: 'chapter',
+        version: '1'
       }
     }
   });

--- a/packages/@coorpacademy-progression-engine/src/types.js
+++ b/packages/@coorpacademy-progression-engine/src/types.js
@@ -13,8 +13,7 @@ export type GenericContent = {
 
 export type ResourceContent = {
   ref: string,
-  type: 'resource',
-  chapter_ref: string,
+  type: 'video' | 'pdf',
   version?: string
 };
 
@@ -42,7 +41,8 @@ export type AskClueAction = {
 export type ChapterResourceViewedAction = {
   type: 'resource',
   payload: {
-    content: ResourceContent
+    resource: ResourceContent,
+    chapter: Content
   }
 };
 

--- a/packages/@coorpacademy-progression-engine/src/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/update-state.js
@@ -52,7 +52,7 @@ function viewedResources(config: MicroLearningConfig): (Array<string>, Action) =
     switch (action.type) {
       case 'resource': {
         const resourceViewAction = (action: ChapterResourceViewedAction);
-        const chapterRef = resourceViewAction.payload.content.chapter_ref;
+        const chapterRef = resourceViewAction.payload.chapter.ref;
         return includes(chapterRef, array) ? array : concat(array, [chapterRef]);
       }
       default:
@@ -141,7 +141,7 @@ function stars(config: MicroLearningConfig): (number, Action, State) => number {
       }
       case 'resource': {
         const chapterResourceViewedAction = (action: ChapterResourceViewedAction);
-        const chapterRef = chapterResourceViewedAction.payload.content.chapter_ref;
+        const chapterRef = chapterResourceViewedAction.payload.chapter.ref;
         return includes(chapterRef, state.viewedResources)
           ? currentStars
           : currentStars + config.starsPerResourceViewed;


### PR DESCRIPTION
Changement du format du payload de l'action `resource`.

Le nouveau format est le suivant: https://github.com/CoorpAcademy/components/compare/update-state-resource?expand=1#diff-449f5f3d13ca3c7ca13d4dd0fb31f569R26

(On peut rajouter ce qu'on veut comme information additionnelle dans le payload, car celui-ci sera stocké tel quel dans les actions de la progression)