### PR TITLE
Change wording for the cta in the context tab

### DIFF
--- a/packages/@coorpacademy-app-player/locales/en/player.json
+++ b/packages/@coorpacademy-app-player/locales/en/player.json
@@ -26,5 +26,6 @@
   "Validate": "Validate",
   "Wrong answer": "Wrong answer",
   "You are out of lives!": "You are out of lives!",
-  "Back to question": "Back to question"
+  "Back to question": "Back to question",
+  "Go to question": "Go to question"
 }

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/player.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/player.js
@@ -83,7 +83,7 @@ const playerProps = (options, store) => state => {
           secondary: false
         }
       : {
-          submitValue: translate('Back to question'),
+          submitValue: translate(route === 'context' ? 'Go to question' : 'Back to question'),
           onClick: clickBackToAnswerHandler,
           light: false,
           small: false,

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/test/player.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/test/player.js
@@ -69,6 +69,7 @@ test('should create player props for basic question', t => {
   t.is(props.answerType.model.type, 'freeText');
   t.true(isFunction(props.answerType.model.onChange));
   t.is(props.slideContext, undefined);
+  t.is(props.cta.submitValue, 'Validate');
 });
 
 test('should display context tab button if slide context is available', t => {
@@ -90,4 +91,36 @@ test('should display context tab button if slide context is available', t => {
   t.is(props.buttons[0].type, 'context');
   t.false(props.buttons[0].selected);
   t.is(typeof props.buttons[0].onClick, 'function');
+});
+
+test('should display "Back to question" for the cta in the tabs', t => {
+  const state = {
+    data,
+    ui: {
+      current: {progressionId: 'foo'},
+      route: {
+        foo: 'media'
+      }
+    }
+  };
+
+  t.is(playerProps(state).cta.submitValue, 'Back to question');
+
+  state.ui.route.foo = 'clue';
+  t.is(playerProps(state).cta.submitValue, 'Back to question');
+});
+
+test('should display "Go to question" for the context tab cta', t => {
+  const state = {
+    data,
+    ui: {
+      current: {progressionId: 'foo'},
+      route: {
+        foo: 'context'
+      }
+    }
+  };
+
+  const props = playerProps(state);
+  t.is(props.cta.submitValue, 'Go to question');
 });


### PR DESCRIPTION
Changement du wording du CTA de `Back to question` en `Go to question` juste pour l'onglet de contexte.

cc @MelkMerle 