### PR TITLE
Improve app-player code coverage

### DIFF
--- a/packages/@coorpacademy-app-player/src/services/test/progressions.js
+++ b/packages/@coorpacademy-app-player/src/services/test/progressions.js
@@ -1,7 +1,15 @@
 import test from 'ava';
 import isObject from 'lodash/fp/isObject';
 import isString from 'lodash/fp/isString';
-import {create, findById, createAnswer, findBestOf, markResourceAsViewed} from '../progressions';
+import {
+  create,
+  findById,
+  createAnswer,
+  findBestOf,
+  markResourceAsViewed,
+  getEngineConfig
+} from '../progressions';
+import engineConfigData from '../progression-config.data';
 
 const engine = {
   ref: 'microlearning',
@@ -58,4 +66,9 @@ test('should mark a resource as viewed', async t => {
   });
 
   t.deepEqual(result.state.viewedResources, [progression.content.ref]);
+});
+
+test('getEngineConfig should return the value in "./progression-config.data"', async t => {
+  const config = await getEngineConfig();
+  t.deepEqual(config, engineConfigData);
 });

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/test/answer.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/test/answer.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import omit from 'lodash/fp/omit';
 import isFunction from 'lodash/fp/isFunction';
 import identity from 'lodash/fp/identity';
 import {createGetAnswerProps, createGetHelp} from '../answer';
@@ -202,8 +203,21 @@ test('should create edited qcmDrag props', t => {
 });
 
 test('should create initial slider props', t => {
+  t.plan(8);
   const state = {};
-  const props = getAnswerProps(state, slider);
+
+  const dispatch = action => {
+    t.deepEqual(action, {
+      type: ANSWER_EDIT.slider,
+      meta: {
+        progressionId: undefined
+      },
+      payload: ['900']
+    });
+  };
+
+  const props = createGetAnswerProps(options, {dispatch})(state, slider);
+
   t.is(props.type, 'slider');
   t.is(props.placeholder, 'Déplacez le curseur.');
   t.is(props.minLabel, '0 an(s)');
@@ -211,6 +225,32 @@ test('should create initial slider props', t => {
   t.is(props.title, '500 an(s)');
   t.is(props.value, 0.5);
   t.true(isFunction(props.onChange));
+
+  props.onChange(0.87);
+});
+
+test('should default slider step to 1', t => {
+  t.plan(2);
+  const state = {};
+
+  const dispatch = action => {
+    t.deepEqual(action, {
+      type: ANSWER_EDIT.slider,
+      meta: {
+        progressionId: undefined
+      },
+      payload: ['870']
+    });
+  };
+
+  const props = createGetAnswerProps(options, {dispatch})(
+    state,
+    omit('question.content.step', slider)
+  );
+
+  t.true(isFunction(props.onChange));
+
+  props.onChange(0.87);
 });
 
 test('should create edited slider props', t => {

--- a/packages/@coorpacademy-app-player/src/view/state-to-props/test/player.js
+++ b/packages/@coorpacademy-app-player/src/view/state-to-props/test/player.js
@@ -5,6 +5,7 @@ import fromPairs from 'lodash/fp/fromPairs';
 import isFunction from 'lodash/fp/isFunction';
 import identity from 'lodash/fp/identity';
 import createPlayer from '../player';
+import {UI_SELECT_ROUTE} from '../../../actions/ui/route';
 import basicSlide from './fixtures/slides/basic';
 import contextSlide from './fixtures/slides/with-context';
 
@@ -72,6 +73,7 @@ test('should create player props for basic question', t => {
 });
 
 test('should display context tab button if slide context is available', t => {
+  t.plan(10);
   const state = {
     data,
     ui: {
@@ -79,7 +81,17 @@ test('should display context tab button if slide context is available', t => {
     }
   };
 
-  const props = playerProps(state);
+  const dispatch = action => {
+    t.deepEqual(action, {
+      type: UI_SELECT_ROUTE,
+      payload: 'context',
+      meta: {
+        progressionId: 'context'
+      }
+    });
+  };
+
+  const props = createPlayer(options, {dispatch: action => action(dispatch, () => state)})(state);
 
   t.is(typeof props.slideContext, 'object');
   t.is(props.slideContext.title, 'Some context title');
@@ -90,4 +102,6 @@ test('should display context tab button if slide context is available', t => {
   t.is(props.buttons[0].type, 'context');
   t.false(props.buttons[0].selected);
   t.is(typeof props.buttons[0].onClick, 'function');
+
+  props.buttons[0].onClick();
 });

--- a/packages/@coorpacademy-history/package.json
+++ b/packages/@coorpacademy-history/package.json
@@ -28,7 +28,7 @@
     "Julien Seren-Rosso <julien.seren-rosso@coorpacademy.com>"
   ],
   "dependencies": {
-    "history": "^4.6.1",
+    "history": "^4.7.2",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/packages/@coorpacademy-history/src/history.js
+++ b/packages/@coorpacademy-history/src/history.js
@@ -1,7 +1,9 @@
 import {parse} from 'url';
-import _createBrowserHistory from 'history/createBrowserHistory';
-import _createMemoryHistory from 'history/createMemoryHistory';
-import _createHashHistory from 'history/createHashHistory';
+import {
+  createBrowserHistory as _createBrowserHistory,
+  createMemoryHistory as _createMemoryHistory,
+  createHashHistory as _createHashHistory
+} from 'history';
 
 export const useBasename = createHistory => options => {
   const {basename = ''} = options || {};


### PR DESCRIPTION
- Le code coverage n'était plus à 100% et faisait péter la condition de code coverage sur toutes les PR.
- Un bump de history (dans le range défini par le package.json avec `^x.y.z`) faisait crasher les tests.