### PR TITLE
Fix long comment not being clickable.

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/forum/forum-post/style.css
+++ b/packages/@coorpacademy-components/src/molecule/forum/forum-post/style.css
@@ -115,10 +115,7 @@
 }
 
 .hiddenMessage {
-  padding: 0;
-  height: 0;
-  opacity: 0;
-  margin: 0;
+  display: none;
 }
 
 .visible {


### PR DESCRIPTION
Corrige un bug qui rendait les commentaires non-clickables.

Lorsqu'on éditait un commentaire, on "cachait" le message sous sa forme non-editable, en mettant ses padding/margin/hauteur (mais pas largeur) à 0 et on affichait le textarea pour éditer.

Lorsque le message était suffisamment gros, quand on cliquait sur le textarea aux endroits normalement couvert par le message non-editable, on ne réussissait pas à cliquer sur le textarea.

En mettant `width` à 0, ça résoud le problème, mais autant simplifier le fait de cacher la section en mettant `display: none`.