### PR TITLE
fix rules for media queries

### DIFF
--- a/packages/@coorpacademy-components/src/variables/breakpoints.css
+++ b/packages/@coorpacademy-components/src/variables/breakpoints.css
@@ -1,4 +1,4 @@
 @value mobile:  (max-width: 640px);
-@value tablet:  (max-width: 1024px);
+@value tablet:  (max-width: 960px);
 @value desktop: (max-width: 1280px);
 @value wide:    (max-width: 1680px);


### PR DESCRIPTION
le précédent passage du breakpoint tablet de 960 vers 1080 cassait des tests e2e.

* Restoration des anciennes règles
* Création de la règle laptop = 1024
* Suppression de la règle wide inutilisé