### PR TITLE
add-data-type-to-dashboard-slider

### DIFF
--- a/packages/@coorpacademy-components/src/atom/cta/index.js
+++ b/packages/@coorpacademy-components/src/atom/cta/index.js
@@ -87,6 +87,7 @@ class CTA extends React.Component {
           this.props.className
         )}
         data-name={ctaName || 'cta'}
+        data-type={target}
         style={this.getStyle()}
       >
         {submitValue}


### PR DESCRIPTION
@esa-coorp, @godu je suis loin d’être sur de moi sur ce coup.

Afin de mettre en place un TAG GTM, j’aimerais pouvoir différencier les CTA des différents types de slide sur le dashboard par un data attribute.

Seulement je ne sais pas trop ce que je peux récupérer comme variable dans les composants d’un slide… J’ai pris celle qui me paraissaît la plus pertinente {{target}}

Mon besoin :
Récupérer la cible => consultation catalogue / Continuer un cours / Commencer une battle