### PR TITLE
css changes to contain and adapt mobile

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
@@ -33,13 +33,14 @@
   align-items: center;
   height: 110px;
   margin-bottom: 16px;
-  background-size: cover;
+  background-size: contain;
+  background: no-repeat;
   background-position: center center;
 }
 
 .titleWrapper {
   font-family: 'Open Sans';
-  font-size: 15px;
+  font-size: 19px;
   line-height: 20px;
   font-weight: 600;
   padding: 0 8px;
@@ -84,7 +85,7 @@
 
   .imageWrapper {
     height: 66px;
-    width: 86px;
+    width: 113px;
     margin-bottom: 0;
     margin-right: 16px;
     flex-shrink: 0;

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
@@ -34,7 +34,7 @@
   height: 110px;
   margin-bottom: 16px;
   background-size: contain;
-  background: no-repeat;
+  background-repeat: no-repeat;
   background-position: center center;
 }
 


### PR DESCRIPTION
 - Demande censée du contenu : harmoniser les formats des qcm image entre desktop et mobile (j'ai donc "horizontalisé" le format mobile pour qu'il soit comme en desktop)
 - J'ai mis la font-size à 19px pour être synchro avec les designs
 - Les filles du contenu préfèreraient que l'on soit en contain plutôt qu'en cover sur les qcm image, ça permet de voir toute l'image systématiquement (**J'attends confirmation de ceci demain mercredi 25/10**, elles vont tester sur différentes images ce que cela donne)