### PR TITLE
Use reducers in action test macro

### DIFF
--- a/packages/@coorpacademy-app-player/src/store/actions/api/contents.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/contents.js
@@ -41,8 +41,5 @@ export const fetchSlideChapter = slideRef => async (dispatch, getState, {service
     return slideFetchResult;
   }
   const slide = getSlide(slideRef)(getState());
-  if (!slide) {
-    return slideFetchResult;
-  }
   return dispatch(fetchContent('chapter', slide.chapter_id));
 };

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/clues.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/clues.js
@@ -27,7 +27,8 @@ test(
       meta: {progressionId: 'foo', slideId: 'bar'},
       payload: 'baz'
     }
-  ]
+  ],
+  2
 );
 
 test(
@@ -47,7 +48,8 @@ test(
       type: CLUE_FETCH_REQUEST,
       meta: {progressionId: 'foo', slideId: 'bar'}
     }
-  ]
+  ],
+  0
 );
 
 test(
@@ -55,11 +57,16 @@ test(
   macro,
   {},
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Clues: {
       findById: (progressionId, slideId) => {
         t.is(progressionId, 'foo');
         t.is(slideId, 'bar');
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -73,7 +80,8 @@ test(
       type: CLUE_FETCH_FAILURE,
       meta: {progressionId: 'foo', slideId: 'bar'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  3
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/contents.fetch-content.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/contents.fetch-content.js
@@ -32,19 +32,18 @@ test(
       meta: {ref: 'foo', type: 'contentType'},
       payload: 'foo'
     }
-  ]
+  ],
+  2
 );
 
 test(
-  'should prevent request if content already fetched',
+  'should prevent request if content is already fetched',
   macro,
   set('data.contents.contentType.entities.foo', 'fooContent', {}),
   t => ({
     Content: {
-      find: (type, ref) => {
-        t.is(type, 'contentType');
-        t.is(ref, 'foo');
-        return ref;
+      find() {
+        t.fail();
       }
     }
   }),
@@ -54,7 +53,8 @@ test(
       type: CONTENT_FETCH_REQUEST,
       meta: {ref: 'foo', type: 'contentType'}
     }
-  ]
+  ],
+  0
 );
 
 test(
@@ -62,11 +62,16 @@ test(
   macro,
   {},
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Content: {
       find: (type, ref) => {
         t.is(type, 'contentType');
         t.is(ref, 'foo');
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -80,7 +85,8 @@ test(
       type: CONTENT_FETCH_FAILURE,
       meta: {ref: 'foo', type: 'contentType'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  3
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/contents.fetch-slide-chapter.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/contents.fetch-slide-chapter.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import Promise from 'bluebird';
 import macro from '../../test/helpers/macro';
-import dataContentReducer from '../../../reducers/data/contents';
+import mockContentService from '../../test/helpers/mock-content-service';
 import {
   fetchSlideChapter,
   CONTENT_FETCH_REQUEST,
@@ -9,29 +9,12 @@ import {
   CONTENT_FETCH_FAILURE
 } from '../contents';
 
-const chapterFetchSuccessAction = {
-  type: CONTENT_FETCH_SUCCESS,
-  meta: {ref: 'slideRef', type: 'slide'},
-  payload: {chapter_id: 'chapId', _id: 'slideRef', foo: 'bar'}
-};
-
 test(
   'should fetch a slide then the chapter it is contained in',
   macro,
   {},
   t => ({
-    Content: {
-      find: (type, ref) => {
-        if (type === 'slide') {
-          t.is(ref, 'slideRef');
-          return Promise.resolve({chapter_id: 'chapId', _id: ref, foo: 'bar'});
-        } else if (type === 'chapter') {
-          t.is(ref, 'chapId');
-          return Promise.resolve({_id: ref, foo: 'baz'});
-        }
-        t.fail();
-      }
-    }
+    Content: mockContentService(t)
   }),
   fetchSlideChapter('slideRef'),
   [
@@ -39,10 +22,11 @@ test(
       type: CONTENT_FETCH_REQUEST,
       meta: {ref: 'slideRef', type: 'slide'}
     },
-    [
-      chapterFetchSuccessAction,
-      {data: {contents: dataContentReducer({}, chapterFetchSuccessAction)}}
-    ],
+    {
+      type: CONTENT_FETCH_SUCCESS,
+      meta: {ref: 'slideRef', type: 'slide'},
+      payload: {chapter_id: 'chapId', _id: 'slideRef', foo: 'bar'}
+    },
     {
       type: CONTENT_FETCH_REQUEST,
       meta: {type: 'chapter', ref: 'chapId'}
@@ -52,18 +36,24 @@ test(
       meta: {type: 'chapter', ref: 'chapId'},
       payload: {_id: 'chapId', foo: 'baz'}
     }
-  ]
+  ],
+  2
 );
 
-const notFoundError = new Error('Could not find item');
 test(
   'should not fetch the chapter if the slide could not be fetched',
   macro,
   {},
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'Could not find item');
+      }
+    },
     Content: {
-      find: (type, ref) => {
-        return Promise.reject(notFoundError);
+      find: () => {
+        t.pass();
+        return Promise.reject(new Error('Could not find item'));
       }
     }
   }),
@@ -77,34 +67,8 @@ test(
       type: CONTENT_FETCH_FAILURE,
       error: true,
       meta: {ref: 'slideRef', type: 'slide'},
-      payload: notFoundError
+      payload: new Error('Could not find item')
     }
-  ]
-);
-
-test(
-  'should not fetch the chapter if the slide could not be found in the state',
-  macro,
-  {},
-  t => ({
-    Content: {
-      find: (type, ref) => {
-        t.is(type, 'slide');
-        t.is(ref, 'slideRef');
-        return Promise.resolve({});
-      }
-    }
-  }),
-  fetchSlideChapter('slideRef'),
-  [
-    {
-      type: CONTENT_FETCH_REQUEST,
-      meta: {ref: 'slideRef', type: 'slide'}
-    },
-    {
-      type: CONTENT_FETCH_SUCCESS,
-      meta: {ref: 'slideRef', type: 'slide'},
-      payload: {}
-    }
-  ]
+  ],
+  2
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/exit-nodes.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/exit-nodes.js
@@ -31,7 +31,8 @@ test(
       meta: {id: 'foo'},
       payload: 'foo'
     }
-  ]
+  ],
+  1
 );
 
 test(
@@ -51,7 +52,8 @@ test(
       type: EXIT_NODE_FETCH_REQUEST,
       meta: {id: 'foo'}
     }
-  ]
+  ],
+  0
 );
 
 test(
@@ -59,10 +61,15 @@ test(
   macro,
   {},
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     ExitNodes: {
       findById: id => {
         t.is(id, 'foo');
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -76,7 +83,8 @@ test(
       type: EXIT_NODE_FETCH_FAILURE,
       meta: {id: 'foo'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  2
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.create-answer.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.create-answer.js
@@ -38,7 +38,8 @@ test(
       meta: {progressionId: 'foo'},
       payload: 'qux'
     }
-  ]
+  ],
+  2
 );
 
 test(
@@ -46,10 +47,15 @@ test(
   macro,
   getState({}),
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Progressions: {
       postAnswers: id => {
         t.is(id, 'foo');
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -63,7 +69,8 @@ test(
       type: PROGRESSION_CREATE_ANSWER_FAILURE,
       meta: {progressionId: 'foo'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  2
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.extra-life.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.extra-life.js
@@ -50,7 +50,8 @@ test(
       meta: {progressionId: 'foo'},
       payload: 'foo'
     }
-  ]
+  ],
+  3
 );
 
 test(
@@ -58,6 +59,11 @@ test(
   macro,
   initState({}),
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Progressions: {
       postExtraLife: (id, payload) => {
         const isAccepted = get('isAccepted', payload);
@@ -67,7 +73,7 @@ test(
         t.is(contentRef, 'extraLife');
         t.is(id, 'foo');
 
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -81,9 +87,10 @@ test(
       type: PROGRESSION_EXTRALIFEACCEPTED_FAILURE,
       meta: {progressionId: 'foo'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  4
 );
 
 test(
@@ -114,7 +121,8 @@ test(
       meta: {progressionId: 'foo'},
       payload: 'foo'
     }
-  ]
+  ],
+  3
 );
 
 test(
@@ -122,6 +130,11 @@ test(
   macro,
   initState({}),
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Progressions: {
       postExtraLife: (id, payload) => {
         const isAccepted = get('isAccepted', payload);
@@ -131,7 +144,7 @@ test(
         t.is(contentRef, 'extraLife');
         t.is(id, 'foo');
 
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -145,7 +158,8 @@ test(
       type: PROGRESSION_EXTRALIFEREFUSED_FAILURE,
       meta: {progressionId: 'foo'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  4
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.fetch-bestof.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.fetch-bestof.js
@@ -38,15 +38,13 @@ test(
       type: PROGRESSION_FETCH_BESTOF_REQUEST,
       meta: progressionContent
     },
-    [
-      {
-        type: PROGRESSION_FETCH_BESTOF_SUCCESS,
-        meta: progressionContent,
-        payload: 'baz'
-      },
-      set('data.contents.chapter.entities.bar.bestScore', 'baz', {})
-    ]
-  ]
+    {
+      type: PROGRESSION_FETCH_BESTOF_SUCCESS,
+      meta: progressionContent,
+      payload: 'baz'
+    }
+  ],
+  3
 );
 
 test(
@@ -70,7 +68,8 @@ test(
       type: PROGRESSION_FETCH_BESTOF_REQUEST,
       meta: progressionContent
     }
-  ]
+  ],
+  0
 );
 
 test(
@@ -78,10 +77,15 @@ test(
   macro,
   state,
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Progressions: {
       findBestOf: (engineRef, contentRef, id) => {
         t.is(contentRef, 'bar');
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -95,7 +99,8 @@ test(
       type: PROGRESSION_FETCH_BESTOF_FAILURE,
       meta: progressionContent,
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  2
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.fetch-progression.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.fetch-progression.js
@@ -31,7 +31,8 @@ test(
       meta: {id: 'foo'},
       payload: 'foo'
     }
-  ]
+  ],
+  1
 );
 
 test(
@@ -51,7 +52,8 @@ test(
       type: PROGRESSION_FETCH_REQUEST,
       meta: {id: 'foo'}
     }
-  ]
+  ],
+  0
 );
 
 test(
@@ -59,10 +61,15 @@ test(
   macro,
   {},
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Progressions: {
       findById: id => {
         t.is(id, 'foo');
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -76,7 +83,8 @@ test(
       type: PROGRESSION_FETCH_FAILURE,
       meta: {id: 'foo'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  2
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.request-clue.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.request-clue.js
@@ -38,7 +38,8 @@ test(
       meta: {progressionId: 'foo'},
       payload: 'baz'
     }
-  ]
+  ],
+  2
 );
 
 test(
@@ -58,7 +59,8 @@ test(
       type: PROGRESSION_REQUEST_CLUE_REQUEST,
       meta: {progressionId: 'foo'}
     }
-  ]
+  ],
+  0
 );
 
 test(
@@ -66,11 +68,16 @@ test(
   macro,
   initState({}),
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Progressions: {
       requestClue: (id, payload) => {
         t.is(id, 'foo');
         t.deepEqual(payload, {content: {ref: 'bar', type: 'slide'}});
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -84,7 +91,8 @@ test(
       type: PROGRESSION_REQUEST_CLUE_FAILURE,
       meta: {progressionId: 'foo'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  3
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.resource-viewed.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.resource-viewed.js
@@ -65,7 +65,8 @@ test(
         {}
       )
     }
-  ]
+  ],
+  2
 );
 
 test(
@@ -113,7 +114,8 @@ test(
         {}
       )
     }
-  ]
+  ],
+  2
 );
 
 test(
@@ -139,7 +141,8 @@ test(
       type: PROGRESSION_RESOURCE_VIEWED_REQUEST,
       meta: {progressionId: 'foo', resource}
     }
-  ]
+  ],
+  0
 );
 
 test(
@@ -147,6 +150,11 @@ test(
   macro,
   initState(set('ui.route.foo', 'media', {})),
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Progressions: {
       markResourceAsViewed: (id, payload) => {
         t.is(id, 'foo');
@@ -159,7 +167,7 @@ test(
           content,
           slide: 'slide2'
         });
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -173,7 +181,8 @@ test(
       type: PROGRESSION_RESOURCE_VIEWED_FAILURE,
       meta: {progressionId: 'foo', resource},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  3
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/rank.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/rank.js
@@ -19,6 +19,7 @@ test(
   t => ({
     LeaderBoard: {
       getRank: () => {
+        t.pass();
         return 1;
       }
     }
@@ -32,7 +33,8 @@ test(
       type: RANK_FETCH_START_SUCCESS,
       payload: 1
     }
-  ]
+  ],
+  1
 );
 
 test(
@@ -42,6 +44,7 @@ test(
   t => ({
     LeaderBoard: {
       getRank: () => {
+        t.pass();
         return 1;
       }
     }
@@ -55,7 +58,8 @@ test(
       type: RANK_FETCH_END_SUCCESS,
       payload: 1
     }
-  ]
+  ],
+  1
 );
 
 test(
@@ -74,7 +78,8 @@ test(
     {
       type: RANK_FETCH_START_REQUEST
     }
-  ]
+  ],
+  0
 );
 
 test(
@@ -82,9 +87,15 @@ test(
   macro,
   {},
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     LeaderBoard: {
       getRank: () => {
-        throw new Error();
+        t.pass();
+        throw new Error('some error');
       }
     }
   }),
@@ -96,9 +107,10 @@ test(
     {
       type: RANK_FETCH_START_FAILURE,
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  2
 );
 
 test(
@@ -106,9 +118,15 @@ test(
   macro,
   {},
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     LeaderBoard: {
       getRank: () => {
-        throw new Error();
+        t.pass();
+        throw new Error('some error');
       }
     }
   }),
@@ -120,7 +138,8 @@ test(
     {
       type: RANK_FETCH_END_FAILURE,
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  2
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/recommendations.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/recommendations.js
@@ -39,7 +39,8 @@ test(
       meta: {id: 'foo'},
       payload: 'bar'
     }
-  ]
+  ],
+  2
 );
 
 test(
@@ -59,7 +60,8 @@ test(
       type: RECO_FETCH_REQUEST,
       meta: {id: 'foo'}
     }
-  ]
+  ],
+  0
 );
 
 test(
@@ -67,11 +69,16 @@ test(
   macro,
   initState({}),
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Recommendations: {
       find: (type, ref) => {
         t.is(ref, 'chapterRef');
         t.is(type, 'chapter');
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -85,7 +92,8 @@ test(
       type: RECO_FETCH_FAILURE,
       meta: {id: 'foo'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  3
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/test/helpers/macro.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/test/helpers/macro.js
@@ -1,36 +1,62 @@
 import {createStore} from 'redux';
 import last from 'lodash/fp/last';
-import head from 'lodash/fp/head';
 import size from 'lodash/fp/size';
-import isArray from 'lodash/fp/isArray';
-import map from 'lodash/fp/map';
+import isEqual from 'lodash/fp/isEqual';
+import isNumber from 'lodash/fp/isNumber';
 import defaultsDeep from 'lodash/fp/defaultsDeep';
 import createMiddleware from '../../../middlewares/index';
+import createReducer from '../../../../store/reducers';
 
-const mapExpected = map(expected => (isArray(expected) ? expected : [expected]));
+const reducer = createReducer({});
 
-const actionMacro = async (t, state, createServices, action, expected, plan) => {
-  if (plan) {
-    t.plan(plan);
+const actionMacro = async (
+  t,
+  initialState,
+  createServices,
+  actionCreator,
+  _expectedActions,
+  expectedNbAssertions
+) => {
+  if (isNumber(expectedNbAssertions)) {
+    t.plan(expectedNbAssertions + _expectedActions.length + 4);
   }
-  const options = {
-    services: {Logger: {error: () => {}}, ...createServices(t)}
+
+  const defaultServices = {
+    Logger: {
+      error: err => {
+        t.log(`Unexpected error was logged: ${err.message}`);
+        t.fail();
+      }
+    }
   };
-  const expectedActions = mapExpected([{type: '@@redux/INIT'}, ...expected]);
+
+  const options = {
+    services: defaultsDeep(defaultServices, createServices(t))
+  };
+  const expectedActions = [{type: '@@redux/INIT'}, ..._expectedActions];
+  let actionIndex = -1;
   const {dispatch} = createStore(
-    (_state, _action) => {
-      const [expectedAction, newState = _state] = expectedActions.shift() || [];
-      t.deepEqual(_action, expectedAction);
-      return defaultsDeep(_state, newState);
+    (state, action) => {
+      const expectedAction = expectedActions.shift();
+      if (action.error && !isEqual(action, expectedAction)) {
+        t.log(`Got unexpected error in action: ${action.payload.message}`);
+      }
+      t.deepEqual(
+        action,
+        expectedAction,
+        `Did not get expected action (action at position ${actionIndex++})`
+      );
+      return reducer(state, action);
     },
-    state,
+    initialState,
     createMiddleware(options)
   );
 
-  const result = await dispatch(action);
+  const result = await dispatch(actionCreator);
 
-  t.is(size(expectedActions), 0);
-  t.deepEqual(result, head(last(mapExpected(expected))));
+  t.true(size(expectedActions) <= 0, 'Action creator generated more actions than expected');
+  t.true(size(expectedActions) >= 0, 'Expected more actions to be created');
+  t.deepEqual(result, last(_expectedActions));
 };
 
 export default actionMacro;

--- a/packages/@coorpacademy-app-player/src/store/actions/test/helpers/mock-content-service.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/test/helpers/mock-content-service.js
@@ -1,0 +1,23 @@
+import Promise from 'bluebird';
+
+const Content = t => ({
+  find(type, ref) {
+    if (type === 'slide') {
+      t.is(ref, 'slideRef');
+      return Promise.resolve({chapter_id: 'chapId', _id: ref, foo: 'bar'});
+    } else if (type === 'chapter') {
+      t.is(ref, 'chapId');
+      return Promise.resolve({_id: ref, foo: 'baz'});
+    }
+    t.fail();
+  },
+
+  getInfo(contentRef, engineRef, engineVersion) {
+    t.is(contentRef, 'chapId');
+    t.is(engineRef, 'microlearning');
+    t.is(engineVersion, '1');
+    return {nbSlides: 20};
+  }
+});
+
+export default Content;

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/progressions.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/progressions.js
@@ -30,10 +30,9 @@ export const selectProgression = id => async (dispatch, getState) => {
   const response = await dispatch(fetchProgression(progressionId));
   if (response.error) return response;
 
+  await dispatch(fetchStartRank());
   const progressionContent = getProgressionContent(getState());
   const engine = getEngine(getState());
-
-  await dispatch(fetchStartRank());
   await dispatch(fetchContent(progressionContent.type, progressionContent.ref));
   await dispatch(fetchBestProgression(progressionContent, progressionId));
   await dispatch(fetchEngineConfig(engine));

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-exit-node.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-exit-node.js
@@ -8,53 +8,16 @@ import {
   PROGRESSION_CREATE_ANSWER_REQUEST,
   PROGRESSION_CREATE_ANSWER_SUCCESS
 } from '../../../api/progressions';
-import {CONTENT_FETCH_REQUEST, CONTENT_FETCH_SUCCESS} from '../../../api/contents';
-import {accordionIsOpenAt, fetchCorrection} from './helpers/shared';
-
-const answerAndGetSuccessExitNode = [
-  [
-    {
-      type: PROGRESSION_CREATE_ANSWER_REQUEST,
-      meta: {progressionId: 'foo'}
-    },
-    set('ui.current.progressionId', 'foo', {})
-  ],
-  [
-    {
-      type: PROGRESSION_CREATE_ANSWER_SUCCESS,
-      meta: {progressionId: 'foo'},
-      payload: pipe(
-        set('state.content.ref', 'baz'),
-        set('state.nextContent', {type: 'slide', ref: 'baz'})
-      )({})
-    },
-    pipe(
-      set('data.progressions.entities.foo', null),
-      set('data.progressions.entities.foo.state.nextContent', {
-        type: 'success',
-        ref: 'successExitNode'
-      })
-    )({})
-  ]
-];
+import {ANSWER_FETCH_REQUEST, ANSWER_FETCH_SUCCESS} from '../../../api/answers';
+import {accordionIsOpenAt} from './helpers/shared';
 
 const services = t => ({
-  Content: {
-    find: (type, ref) => {
-      if (type === 'slide') {
-        return {_id: ref, chapter_id: 'chapId'};
-      }
-      if (type === 'chapter') {
-        return {_id: ref};
-      }
-    }
-  },
   Progressions: {
     postAnswers: (id, payload) => {
       t.is(id, 'foo');
       return pipe(
-        set('state.content.ref', 'baz'),
-        set('state.nextContent', {type: 'slide', ref: 'baz'})
+        set('state.content.ref', 'slideRef'),
+        set('state.nextContent', {type: 'success', ref: 'successExitNode'})
       )({});
     },
     findById: id => {
@@ -75,35 +38,41 @@ const services = t => ({
   }
 });
 
-const contentFetchActions = [
-  {
-    type: CONTENT_FETCH_REQUEST,
-    meta: {
-      type: 'slide',
-      ref: 'baz'
-    }
-  },
-  {
-    type: CONTENT_FETCH_SUCCESS,
-    meta: {
-      type: 'slide',
-      ref: 'baz'
-    },
-    payload: {_id: 'baz', chapter_id: 'chapId'}
-  }
-];
-
 test(
   'should submit last answer',
   macro,
-  set('data.progressions.entities.foo.state.nextContent', {type: 'slide', ref: 'baz'})({}),
+  set('data.progressions.entities.foo.state.nextContent', {type: 'slide', ref: 'slideRef'})({}),
   services,
   validateAnswer('foo', {answers: ['bar']}),
   flatten([
-    answerAndGetSuccessExitNode,
-    contentFetchActions,
+    {
+      type: PROGRESSION_CREATE_ANSWER_REQUEST,
+      meta: {progressionId: 'foo'}
+    },
+    {
+      type: PROGRESSION_CREATE_ANSWER_SUCCESS,
+      meta: {progressionId: 'foo'},
+      payload: pipe(
+        set('state.content.ref', 'slideRef'),
+        set('state.nextContent', {type: 'success', ref: 'successExitNode'})
+      )({})
+    },
     accordionIsOpenAt(0),
-    fetchCorrection
+    {
+      type: ANSWER_FETCH_REQUEST,
+      meta: {
+        progressionId: 'foo',
+        slideId: 'slideRef'
+      }
+    },
+    {
+      type: ANSWER_FETCH_SUCCESS,
+      meta: {
+        progressionId: 'foo',
+        slideId: 'slideRef'
+      },
+      payload: ['Bonne réponse']
+    }
   ]),
-  13
+  3
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-failure.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-failure.js
@@ -19,14 +19,9 @@ test(
     ref: 'baz'
   })({}),
   t => ({
-    Content: {
-      find: (type, ref) => {
-        if (type === 'slide') {
-          return {_id: ref, chapter_id: '5.C7'};
-        }
-        if (type === 'chapter') {
-          return {_id: ref};
-        }
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
       }
     },
     Progressions: {
@@ -36,26 +31,24 @@ test(
           content: {type: 'slide', ref: 'baz'},
           answers: ['bar']
         });
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
   validateAnswer('foo', {answers: ['bar']}),
   [
-    [
-      {
-        type: PROGRESSION_CREATE_ANSWER_REQUEST,
-        meta: {progressionId: 'foo'}
-      },
-      set('ui.current.progressionId', 'foo', {})
-    ],
+    {
+      type: PROGRESSION_CREATE_ANSWER_REQUEST,
+      meta: {progressionId: 'foo'}
+    },
     {
       type: PROGRESSION_CREATE_ANSWER_FAILURE,
       meta: {progressionId: 'foo'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  3
 );
 
 test(
@@ -66,14 +59,9 @@ test(
     ref: 'baz'
   })({}),
   t => ({
-    Content: {
-      find: (type, ref) => {
-        if (type === 'slide') {
-          return {_id: ref, chapter_id: '5.C7'};
-        }
-        if (type === 'chapter') {
-          return {_id: ref};
-        }
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
       }
     },
     Progressions: {
@@ -89,16 +77,12 @@ test(
           set('state.isCorrect', false),
           set('state.viewedResources', [])
         )({});
-      },
-      findById: id => {
-        t.is(id, 'foo');
-        return 'foo';
       }
     },
     Answers: {
       findById: id => {
         t.is(id, 'foo');
-        throw new Error();
+        throw new Error('some error');
       }
     },
     Analytics: {
@@ -109,47 +93,33 @@ test(
   }),
   validateAnswer('foo', {answers: ['bar']}),
   [
-    [
-      {
-        type: PROGRESSION_CREATE_ANSWER_REQUEST,
-        meta: {progressionId: 'foo'}
-      },
-      set('ui.current.progressionId', 'foo', {})
-    ],
-    [
-      {
-        type: PROGRESSION_CREATE_ANSWER_SUCCESS,
-        meta: {progressionId: 'foo'},
-        payload: pipe(
-          set('state.content.ref', 'baz'),
-          set('state.nextContent', {type: 'success', ref: 'successExitNode'}),
-          set('state.isCorrect', false),
-          set('state.viewedResources', [])
-        )({})
-      },
-      set('data.progressions.entities.foo.state.nextContent', {
-        type: 'success',
-        ref: 'successExitNode'
-      })
-    ],
-    [
-      {
-        type: UI_TOGGLE_ACCORDION,
-        payload: {
-          id: 0
-        }
+    {
+      type: PROGRESSION_CREATE_ANSWER_REQUEST,
+      meta: {progressionId: 'foo'}
+    },
+    {
+      type: PROGRESSION_CREATE_ANSWER_SUCCESS,
+      meta: {progressionId: 'foo'},
+      payload: pipe(
+        set('state.content.ref', 'baz'),
+        set('state.nextContent', {type: 'success', ref: 'successExitNode'}),
+        set('state.isCorrect', false),
+        set('state.viewedResources', [])
+      )({})
+    },
+    {
+      type: UI_TOGGLE_ACCORDION,
+      payload: {
+        id: 0
       }
-    ],
-    [
-      {
-        type: ANSWER_FETCH_REQUEST,
-        meta: {
-          progressionId: 'foo',
-          slideId: 'baz'
-        }
-      },
-      set('ui.answers.0.correction', null, {})
-    ],
+    },
+    {
+      type: ANSWER_FETCH_REQUEST,
+      meta: {
+        progressionId: 'foo',
+        slideId: 'baz'
+      }
+    },
     {
       type: ANSWER_FETCH_FAILURE,
       meta: {
@@ -157,8 +127,8 @@ test(
         slideId: 'baz'
       },
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
   ],
-  12
+  5
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/helpers/shared.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/helpers/shared.js
@@ -1,38 +1,29 @@
-import set from 'lodash/fp/set';
 import {UI_TOGGLE_ACCORDION} from '../../../../ui/corrections';
 import {ANSWER_FETCH_REQUEST, ANSWER_FETCH_SUCCESS} from '../../../../api/answers';
 
 export const accordionIsOpenAt = i => [
-  [
-    {
-      type: UI_TOGGLE_ACCORDION,
-      payload: {
-        id: i
-      }
+  {
+    type: UI_TOGGLE_ACCORDION,
+    payload: {
+      id: i
     }
-  ]
+  }
 ];
 
 export const fetchCorrection = [
-  [
-    {
-      type: ANSWER_FETCH_REQUEST,
-      meta: {
-        progressionId: 'foo',
-        slideId: 'baz'
-      }
+  {
+    type: ANSWER_FETCH_REQUEST,
+    meta: {
+      progressionId: 'foo',
+      slideId: 'baz'
+    }
+  },
+  {
+    type: ANSWER_FETCH_SUCCESS,
+    meta: {
+      progressionId: 'foo',
+      slideId: 'baz'
     },
-    set('ui.answers.0.correction', null, {})
-  ],
-  [
-    {
-      type: ANSWER_FETCH_SUCCESS,
-      meta: {
-        progressionId: 'foo',
-        slideId: 'baz'
-      },
-      payload: ['Bonne réponse']
-    },
-    set('ui.answers.0.correction', 'Bonne réponse', {})
-  ]
+    payload: ['Bonne réponse']
+  }
 ];

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/clues.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/clues.js
@@ -17,15 +17,13 @@ test(
   t => ({}),
   selectClue,
   [
-    [
-      {
-        type: UI_SELECT_ROUTE,
-        meta: {progressionId: 'foo'},
-        payload: 'clue'
-      },
-      set('ui.route.foo', 'clue', {})
-    ]
-  ]
+    {
+      type: UI_SELECT_ROUTE,
+      meta: {progressionId: 'foo'},
+      payload: 'clue'
+    }
+  ],
+  0
 );
 
 test(
@@ -54,50 +52,38 @@ test(
       findById: (progressionId, slideId) => {
         t.is(progressionId, 'foo');
         t.is(slideId, 'bar');
-
         return ['Clue'];
       }
     }
   }),
   getClue,
   [
-    [
-      {
-        type: PROGRESSION_REQUEST_CLUE_REQUEST,
-        meta: {progressionId: 'foo'}
+    {
+      type: PROGRESSION_REQUEST_CLUE_REQUEST,
+      meta: {progressionId: 'foo'}
+    },
+    {
+      type: PROGRESSION_REQUEST_CLUE_SUCCESS,
+      meta: {progressionId: 'foo'},
+      payload: set('state.requestdClues', ['bar'], {})
+    },
+    {
+      type: CLUE_FETCH_REQUEST,
+      meta: {
+        progressionId: 'foo',
+        slideId: 'bar'
+      }
+    },
+    {
+      type: CLUE_FETCH_SUCCESS,
+      meta: {
+        progressionId: 'foo',
+        slideId: 'bar'
       },
-      set('ui.current.progressionId', 'foo', {})
-    ],
-    [
-      {
-        type: PROGRESSION_REQUEST_CLUE_SUCCESS,
-        meta: {progressionId: 'foo'},
-        payload: set('state.requestdClues', ['bar'], {})
-      },
-      set('data.progressions.entities.foo.state.requestedClues', ['bar'], {})
-    ],
-    [
-      {
-        type: CLUE_FETCH_REQUEST,
-        meta: {
-          progressionId: 'foo',
-          slideId: 'bar'
-        }
-      },
-      set('api.clues.foo.bar', null, {})
-    ],
-    [
-      {
-        type: CLUE_FETCH_SUCCESS,
-        meta: {
-          progressionId: 'foo',
-          slideId: 'bar'
-        },
-        payload: ['Clue']
-      },
-      set('api.clues.foo.bar', ['Clue'], {})
-    ]
-  ]
+      payload: ['Clue']
+    }
+  ],
+  4
 );
 
 test(
@@ -118,7 +104,6 @@ test(
             type: 'slide'
           }
         });
-
         return set('state.requestdClues', ['bar'], {});
       }
     },
@@ -126,48 +111,36 @@ test(
       findById: (progressionId, slideId) => {
         t.is(progressionId, 'foo');
         t.is(slideId, 'bar');
-
         return ['Clue'];
       }
     }
   }),
   getClue,
   [
-    [
-      {
-        type: PROGRESSION_REQUEST_CLUE_REQUEST,
-        meta: {progressionId: 'foo'}
+    {
+      type: PROGRESSION_REQUEST_CLUE_REQUEST,
+      meta: {progressionId: 'foo'}
+    },
+    {
+      type: PROGRESSION_REQUEST_CLUE_SUCCESS,
+      meta: {progressionId: 'foo'},
+      payload: set('state.requestdClues', ['bar'], {})
+    },
+    {
+      type: CLUE_FETCH_REQUEST,
+      meta: {
+        progressionId: 'foo',
+        slideId: 'bar'
+      }
+    },
+    {
+      type: CLUE_FETCH_SUCCESS,
+      meta: {
+        progressionId: 'foo',
+        slideId: 'bar'
       },
-      set('ui.current.progressionId', 'foo', {})
-    ],
-    [
-      {
-        type: PROGRESSION_REQUEST_CLUE_SUCCESS,
-        meta: {progressionId: 'foo'},
-        payload: set('state.requestdClues', ['bar'], {})
-      },
-      set('data.progressions.entities.foo.state.requestedClues', ['bar'], {})
-    ],
-    [
-      {
-        type: CLUE_FETCH_REQUEST,
-        meta: {
-          progressionId: 'foo',
-          slideId: 'bar'
-        }
-      },
-      set('api.clues.foo.bar', null, {})
-    ],
-    [
-      {
-        type: CLUE_FETCH_SUCCESS,
-        meta: {
-          progressionId: 'foo',
-          slideId: 'bar'
-        },
-        payload: ['Clue']
-      },
-      set('api.clues.foo.bar', ['Clue'], {})
-    ]
-  ]
+      payload: ['Clue']
+    }
+  ],
+  4
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/corrections.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/corrections.js
@@ -1,14 +1,18 @@
 import test from 'ava';
-import set from 'lodash/fp/set';
 import macro from '../../test/helpers/macro';
 import {selectResource, UI_SELECT_RESOURCE_IN_POPIN} from '../corrections';
 
-test('should set state with selected resource', macro, {}, t => ({}), selectResource('videoId'), [
+test(
+  'should set state with selected resource',
+  macro,
+  {},
+  t => ({}),
+  selectResource('videoId'),
   [
     {
       type: UI_SELECT_RESOURCE_IN_POPIN,
       payload: {id: 'videoId'}
-    },
-    set('ui.current.playResource', 'videoId', {})
-  ]
-]);
+    }
+  ],
+  0
+);

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/extra-life.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/extra-life.js
@@ -1,8 +1,8 @@
 import test from 'ava';
 import pipe from 'lodash/fp/pipe';
 import set from 'lodash/fp/set';
-import get from 'lodash/fp/get';
 import macro from '../../test/helpers/macro';
+import mockContentService from '../../test/helpers/mock-content-service';
 import {
   UI_REVIVAL_PENDING,
   pending,
@@ -12,18 +12,36 @@ import {
 import {UI_SELECT_PROGRESSION} from '../progressions';
 import {
   PROGRESSION_FETCH_REQUEST,
-  PROGRESSION_FETCH_FAILURE,
   PROGRESSION_EXTRALIFEACCEPTED_REQUEST,
   PROGRESSION_EXTRALIFEACCEPTED_SUCCESS,
   PROGRESSION_EXTRALIFEREFUSED_REQUEST,
-  PROGRESSION_EXTRALIFEREFUSED_SUCCESS
+  PROGRESSION_EXTRALIFEREFUSED_SUCCESS,
+  PROGRESSION_FETCH_BESTOF_REQUEST,
+  PROGRESSION_FETCH_BESTOF_SUCCESS,
+  ENGINE_CONFIG_FETCH_REQUEST,
+  ENGINE_CONFIG_FETCH_SUCCESS
 } from '../../api/progressions';
+import {RANK_FETCH_START_REQUEST, RANK_FETCH_START_SUCCESS} from '../../api/rank';
+import {
+  CONTENT_FETCH_REQUEST,
+  CONTENT_FETCH_SUCCESS,
+  CONTENT_INFO_FETCH_REQUEST,
+  CONTENT_INFO_FETCH_SUCCESS
+} from '../../api/contents';
 
-test('should dispatch revival pending', macro, {}, t => ({}), pending(), [
-  {
-    type: UI_REVIVAL_PENDING
-  }
-]);
+test(
+  'should dispatch revival pending',
+  macro,
+  {},
+  t => ({}),
+  pending(),
+  [
+    {
+      type: UI_REVIVAL_PENDING
+    }
+  ],
+  0
+);
 
 test(
   'should dispatch refuse and reset progression',
@@ -31,20 +49,44 @@ test(
   pipe(
     set('ui.current.progressionId', 'foo'),
     set('data.progressions.entities.foo._id', 'foo'),
-    set('data.progressions.entities.foo.nextContent', {type: 'node', ref: 'extraLife'})
+    set('data.progressions.entities.foo.engine', {ref: 'microlearning', version: '1'}),
+    set('data.progressions.entities.foo.state.nextContent', {type: 'node', ref: 'extraLife'}),
+    set('data.progressions.entities.foo.state.content', {type: 'slide', ref: '1.A2.1'})
   )({}),
   t => ({
+    Content: mockContentService(t),
     Progressions: {
       findById: id => {
         t.is(id, 'foo');
-        throw new Error();
+        throw new Error('some error');
+      },
+      findBestOf: (type, ref, id) => {
+        t.is(ref, 'chapId');
+        return 16;
       },
       postExtraLife: (id, payload) => {
-        const isAccepted = get('isAccepted', payload);
-
-        t.false(isAccepted);
         t.is(id, 'foo');
-        return 'foo';
+        t.deepEqual(payload, {
+          content: {type: 'node', ref: 'extraLife'},
+          isAccepted: false
+        });
+        return {
+          content: {type: 'chapter', ref: 'chapId'},
+          state: {
+            content: {type: 'slide', ref: '1.A2.1'},
+            nextContent: {type: 'slide', ref: 'slideRef'}
+          }
+        };
+      },
+      getEngineConfig: engine => {
+        t.deepEqual(engine, {ref: 'microlearning', version: '1'});
+        return {foo: 'engine'};
+      }
+    },
+    LeaderBoard: {
+      getRank: () => {
+        t.pass();
+        return 1;
       }
     }
   }),
@@ -56,30 +98,85 @@ test(
     },
     {
       type: PROGRESSION_EXTRALIFEREFUSED_SUCCESS,
-      payload: 'foo',
-      meta: {progressionId: 'foo'}
+      meta: {progressionId: 'foo'},
+      payload: {
+        content: {type: 'chapter', ref: 'chapId'},
+        state: {
+          content: {type: 'slide', ref: '1.A2.1'},
+          nextContent: {type: 'slide', ref: 'slideRef'}
+        }
+      }
     },
-    [
-      {
-        type: UI_SELECT_PROGRESSION,
-        payload: {id: 'foo'}
-      },
-      set('ui.current.progressionId', 'foo', {})
-    ],
-    [
-      {
-        type: PROGRESSION_FETCH_REQUEST,
-        meta: {id: 'foo'}
-      },
-      set('data.progressions.entities.foo', null, {})
-    ],
     {
-      type: PROGRESSION_FETCH_FAILURE,
-      meta: {id: 'foo'},
-      error: true,
-      payload: new Error()
+      type: UI_SELECT_PROGRESSION,
+      payload: {id: 'foo'}
+    },
+    {
+      type: PROGRESSION_FETCH_REQUEST,
+      meta: {id: 'foo'}
+    },
+    {
+      type: RANK_FETCH_START_REQUEST
+    },
+    {
+      type: RANK_FETCH_START_SUCCESS,
+      payload: 1
+    },
+    {
+      type: CONTENT_FETCH_REQUEST,
+      meta: {type: 'chapter', ref: 'chapId'}
+    },
+    {
+      type: CONTENT_FETCH_SUCCESS,
+      meta: {type: 'chapter', ref: 'chapId'},
+      payload: {_id: 'chapId', foo: 'baz'}
+    },
+    {
+      type: PROGRESSION_FETCH_BESTOF_REQUEST,
+      meta: {type: 'chapter', ref: 'chapId'}
+    },
+    {
+      type: PROGRESSION_FETCH_BESTOF_SUCCESS,
+      meta: {type: 'chapter', ref: 'chapId'},
+      payload: 16
+    },
+    {
+      type: ENGINE_CONFIG_FETCH_REQUEST,
+      meta: {engine: {ref: 'microlearning', version: '1'}}
+    },
+    {
+      type: ENGINE_CONFIG_FETCH_SUCCESS,
+      meta: {engine: {ref: 'microlearning', version: '1'}},
+      payload: {foo: 'engine'}
+    },
+    {
+      type: CONTENT_INFO_FETCH_REQUEST,
+      meta: {type: 'chapter', ref: 'chapId'}
+    },
+    {
+      type: CONTENT_INFO_FETCH_SUCCESS,
+      meta: {type: 'chapter', ref: 'chapId'},
+      payload: {nbSlides: 20}
+    },
+    {
+      type: CONTENT_FETCH_REQUEST,
+      meta: {type: 'slide', ref: 'slideRef'}
+    },
+    {
+      type: CONTENT_FETCH_SUCCESS,
+      meta: {type: 'slide', ref: 'slideRef'},
+      payload: {
+        _id: 'slideRef',
+        chapter_id: 'chapId',
+        foo: 'bar'
+      }
+    },
+    {
+      type: CONTENT_FETCH_REQUEST,
+      meta: {type: 'chapter', ref: 'chapId'}
     }
-  ]
+  ],
+  10
 );
 
 test(
@@ -88,19 +185,40 @@ test(
   pipe(
     set('ui.current.progressionId', 'foo'),
     set('data.progressions.entities.foo._id', 'foo'),
-    set('data.progressions.entities.foo.nextContent', {type: 'node', ref: 'extraLife'})
+    set('data.progressions.entities.foo.engine', {ref: 'microlearning', version: '1'}),
+    set('data.progressions.entities.foo.state.nextContent', {type: 'node', ref: 'extraLife'}),
+    set('data.progressions.entities.foo.state.content', {type: 'slide', ref: '1.A2.1'})
   )({}),
   t => ({
+    Content: mockContentService(t),
     Progressions: {
-      findById: id => {
-        t.is(id, 'foo');
-        throw new Error();
+      findBestOf: (type, ref, id) => {
+        t.is(ref, 'chapId');
+        return 16;
       },
       postExtraLife: (id, payload) => {
-        const isAccepted = get('isAccepted', payload);
-
-        t.true(isAccepted);
-        return 'foo';
+        t.is(id, 'foo');
+        t.deepEqual(payload, {
+          content: {type: 'node', ref: 'extraLife'},
+          isAccepted: true
+        });
+        return {
+          content: {type: 'chapter', ref: 'chapId'},
+          state: {
+            content: {type: 'slide', ref: '1.A2.1'},
+            nextContent: {type: 'slide', ref: 'slideRef'}
+          }
+        };
+      },
+      getEngineConfig: engine => {
+        t.deepEqual(engine, {ref: 'microlearning', version: '1'});
+        return {foo: 'engine'};
+      }
+    },
+    LeaderBoard: {
+      getRank: (...args) => {
+        t.pass();
+        return 1;
       }
     }
   }),
@@ -112,28 +230,83 @@ test(
     },
     {
       type: PROGRESSION_EXTRALIFEACCEPTED_SUCCESS,
-      payload: 'foo',
-      meta: {progressionId: 'foo'}
+      meta: {progressionId: 'foo'},
+      payload: {
+        content: {type: 'chapter', ref: 'chapId'},
+        state: {
+          content: {type: 'slide', ref: '1.A2.1'},
+          nextContent: {type: 'slide', ref: 'slideRef'}
+        }
+      }
     },
-    [
-      {
-        type: UI_SELECT_PROGRESSION,
-        payload: {id: 'foo'}
-      },
-      set('ui.current.progressionId', 'foo', {})
-    ],
-    [
-      {
-        type: PROGRESSION_FETCH_REQUEST,
-        meta: {id: 'foo'}
-      },
-      set('data.progressions.entities.foo', null, {})
-    ],
     {
-      type: PROGRESSION_FETCH_FAILURE,
-      meta: {id: 'foo'},
-      error: true,
-      payload: new Error()
+      type: UI_SELECT_PROGRESSION,
+      payload: {id: 'foo'}
+    },
+    {
+      type: PROGRESSION_FETCH_REQUEST,
+      meta: {id: 'foo'}
+    },
+    {
+      type: RANK_FETCH_START_REQUEST
+    },
+    {
+      type: RANK_FETCH_START_SUCCESS,
+      payload: 1
+    },
+    {
+      type: CONTENT_FETCH_REQUEST,
+      meta: {type: 'chapter', ref: 'chapId'}
+    },
+    {
+      type: CONTENT_FETCH_SUCCESS,
+      meta: {type: 'chapter', ref: 'chapId'},
+      payload: {_id: 'chapId', foo: 'baz'}
+    },
+    {
+      type: PROGRESSION_FETCH_BESTOF_REQUEST,
+      meta: {type: 'chapter', ref: 'chapId'}
+    },
+    {
+      type: PROGRESSION_FETCH_BESTOF_SUCCESS,
+      meta: {type: 'chapter', ref: 'chapId'},
+      payload: 16
+    },
+    {
+      type: ENGINE_CONFIG_FETCH_REQUEST,
+      meta: {engine: {ref: 'microlearning', version: '1'}}
+    },
+    {
+      type: ENGINE_CONFIG_FETCH_SUCCESS,
+      meta: {engine: {ref: 'microlearning', version: '1'}},
+      payload: {foo: 'engine'}
+    },
+    {
+      type: CONTENT_INFO_FETCH_REQUEST,
+      meta: {type: 'chapter', ref: 'chapId'}
+    },
+    {
+      type: CONTENT_INFO_FETCH_SUCCESS,
+      meta: {type: 'chapter', ref: 'chapId'},
+      payload: {nbSlides: 20}
+    },
+    {
+      type: CONTENT_FETCH_REQUEST,
+      meta: {type: 'slide', ref: 'slideRef'}
+    },
+    {
+      type: CONTENT_FETCH_SUCCESS,
+      meta: {type: 'slide', ref: 'slideRef'},
+      payload: {
+        _id: 'slideRef',
+        chapter_id: 'chapId',
+        foo: 'bar'
+      }
+    },
+    {
+      type: CONTENT_FETCH_REQUEST,
+      meta: {type: 'chapter', ref: 'chapId'}
     }
-  ]
+  ],
+  10
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/location.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/location.js
@@ -47,7 +47,8 @@ test(
       meta: {contentRef: 'foo'},
       payload: 'foo'
     }
-  ]
+  ],
+  1
 );
 
 test(
@@ -58,10 +59,15 @@ test(
     set('data.progressions.entities.0.content.ref', 'foo')
   )({}),
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Location: {
       retry: contentRef => {
         t.is(contentRef, 'foo');
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -75,9 +81,10 @@ test(
       type: LOCATION_RETRY_FAILURE,
       meta: {contentRef: 'foo'},
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  2
 );
 
 test(
@@ -87,6 +94,7 @@ test(
   t => ({
     Location: {
       exit: () => {
+        t.pass();
         return 'foo';
       }
     }
@@ -100,7 +108,8 @@ test(
       type: LOCATION_EXIT_SUCCESS,
       payload: 'foo'
     }
-  ]
+  ],
+  1
 );
 
 test(
@@ -108,9 +117,15 @@ test(
   macro,
   {},
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Location: {
       exit: () => {
-        throw new Error();
+        t.pass();
+        throw new Error('some error');
       }
     }
   }),
@@ -122,9 +137,10 @@ test(
     {
       type: LOCATION_EXIT_FAILURE,
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  2
 );
 
 test(
@@ -138,6 +154,7 @@ test(
   t => ({
     Location: {
       back: () => {
+        t.pass();
         return 'foo';
       }
     }
@@ -151,7 +168,8 @@ test(
       type: LOCATION_BACK_SUCCESS,
       payload: 'foo'
     }
-  ]
+  ],
+  1
 );
 
 test(
@@ -163,9 +181,15 @@ test(
     set('data.progressions.entities.0.content', {type: 'level', ref: 'foo'})
   )({}),
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Location: {
       back: () => {
-        throw new Error();
+        t.pass();
+        throw new Error('some error');
       }
     }
   }),
@@ -177,9 +201,10 @@ test(
     {
       type: LOCATION_BACK_FAILURE,
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
-  ]
+  ],
+  2
 );
 
 test(
@@ -209,7 +234,7 @@ test(
       payload: '1.A'
     }
   ],
-  6
+  1
 );
 
 test(
@@ -222,10 +247,15 @@ test(
     set(['data', 'contents', 'level', 'entities', '1.B'], {ref: '1.B', level: 'base'})
   )({}),
   t => ({
+    Logger: {
+      error(err) {
+        t.is(err.message, 'some error');
+      }
+    },
     Location: {
       nextLevel: contentRef => {
         t.is(contentRef, '1.A');
-        throw new Error();
+        throw new Error('some error');
       }
     }
   }),
@@ -237,10 +267,10 @@ test(
     {
       type: LOCATION_NEXT_CONTENT_FAILURE,
       error: true,
-      payload: new Error()
+      payload: new Error('some error')
     }
   ],
-  6
+  2
 );
 
 test(
@@ -261,5 +291,5 @@ test(
   }),
   nextLevel,
   [],
-  3
+  0
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/route.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/route.js
@@ -11,15 +11,13 @@ test(
   t => ({}),
   selectRoute('clue'),
   [
-    [
-      {
-        type: UI_SELECT_ROUTE,
-        meta: {progressionId: 'foo'},
-        payload: 'clue'
-      },
-      set('ui.route.foo', 'clue', {})
-    ]
-  ]
+    {
+      type: UI_SELECT_ROUTE,
+      meta: {progressionId: 'foo'},
+      payload: 'clue'
+    }
+  ],
+  0
 );
 
 test(
@@ -29,13 +27,11 @@ test(
   t => ({}),
   selectRoute('clue'),
   [
-    [
-      {
-        type: UI_SELECT_ROUTE,
-        meta: {progressionId: 'foo'},
-        payload: null
-      },
-      set('ui.route.foo', null, {})
-    ]
-  ]
+    {
+      type: UI_SELECT_ROUTE,
+      meta: {progressionId: 'foo'},
+      payload: null
+    }
+  ],
+  0
 );

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/video.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/video.js
@@ -23,26 +23,50 @@ import {
 const resource = {_id: 'resourceId', type: 'video'};
 const content = {ref: 'chapterRef', type: 'chapter'};
 
-test('should dispatch video pause action', macro, {}, t => ({}), pause(resource), [
-  {
-    type: UI_VIDEO_PAUSE,
-    resource
-  }
-]);
+test(
+  'should dispatch video pause action',
+  macro,
+  {},
+  t => ({}),
+  pause(resource),
+  [
+    {
+      type: UI_VIDEO_PAUSE,
+      resource
+    }
+  ],
+  0
+);
 
-test('should dispatch video ended action', macro, {}, t => ({}), ended(resource), [
-  {
-    type: UI_VIDEO_ENDED,
-    resource
-  }
-]);
+test(
+  'should dispatch video ended action',
+  macro,
+  {},
+  t => ({}),
+  ended(resource),
+  [
+    {
+      type: UI_VIDEO_ENDED,
+      resource
+    }
+  ],
+  0
+);
 
-test('should dispatch video resume action', macro, {}, t => ({}), resume(resource), [
-  {
-    type: UI_VIDEO_RESUME,
-    resource
-  }
-]);
+test(
+  'should dispatch video resume action',
+  macro,
+  {},
+  t => ({}),
+  resume(resource),
+  [
+    {
+      type: UI_VIDEO_RESUME,
+      resource
+    }
+  ],
+  0
+);
 
 test(
   'should dispatch video play action and forward to mark a resource as viewed',
@@ -57,7 +81,9 @@ test(
   )({}),
   t => ({
     Analytics: {
-      sendViewedMediaAnalytics: (media, location) => {}
+      sendViewedMediaAnalytics: (media, location) => {
+        t.pass();
+      }
     },
     Progressions: {
       markResourceAsViewed: (progressionId, payload) => {
@@ -91,19 +117,17 @@ test(
       type: PROGRESSION_RESOURCE_VIEWED_REQUEST,
       meta: {progressionId: 'foo', resource}
     },
-    [
-      {
-        type: PROGRESSION_RESOURCE_VIEWED_SUCCESS,
-        meta: {progressionId: 'foo', resource},
-        payload: set('state.viewedResources', [content.ref], {})
-      },
-      set('data.progressions.entities.foo.state.viewedResources', [content.ref], {})
-    ]
-  ]
+    {
+      type: PROGRESSION_RESOURCE_VIEWED_SUCCESS,
+      meta: {progressionId: 'foo', resource},
+      payload: set('state.viewedResources', [content.ref], {})
+    }
+  ],
+  3
 );
 
 test(
-  'should dispatch video play action and forward to mark a resource as viewed',
+  'should dispatch video play action and forward to mark a resource as viewed when requesting an extra life',
   macro,
   pipe(
     set('ui.current.progressionId', 'foo'),
@@ -114,11 +138,13 @@ test(
       ref: 'extraLife'
     }),
     set('data.progressions.entities.foo.content', content),
-    set('data.slides.entities.slideRef', 'slide')
+    set('data.contents.slide.entities.slideRef', 'slide')
   )({}),
   t => ({
     Analytics: {
-      sendViewedMediaAnalytics: (media, location) => {}
+      sendViewedMediaAnalytics: (media, location) => {
+        t.pass();
+      }
     },
     Progressions: {
       markResourceAsViewed: (progressionId, payload) => {
@@ -145,12 +171,11 @@ test(
       type: PROGRESSION_RESOURCE_VIEWED_REQUEST,
       meta: {progressionId: 'foo', resource}
     },
-    [
-      {
-        type: PROGRESSION_RESOURCE_VIEWED_SUCCESS,
-        meta: {progressionId: 'foo', resource},
-        payload: 'foo'
-      }
-    ]
-  ]
+    {
+      type: PROGRESSION_RESOURCE_VIEWED_SUCCESS,
+      meta: {progressionId: 'foo', resource},
+      payload: 'foo'
+    }
+  ],
+  2
 );

--- a/packages/@coorpacademy-app-player/src/store/middlewares/test/error-logger.js
+++ b/packages/@coorpacademy-app-player/src/store/middlewares/test/error-logger.js
@@ -22,7 +22,8 @@ test(
     }
   }),
   NORMAL_ACTION,
-  [NORMAL_ACTION]
+  [NORMAL_ACTION],
+  0
 );
 
 test(
@@ -32,14 +33,13 @@ test(
   t => ({
     Logger: {
       error: e => {
-        t.pass();
         t.deepEqual(e, payloadError);
       }
     }
   }),
   ERROR_ACTION,
   [ERROR_ACTION],
-  6
+  1
 );
 
 test(
@@ -49,12 +49,13 @@ test(
   t => ({
     Logger: {
       error: e => {
-        throw loggerError;
+        t.fail();
       }
     }
   }),
   NORMAL_ACTION,
-  [NORMAL_ACTION]
+  [NORMAL_ACTION],
+  0
 );
 
 test(
@@ -64,6 +65,7 @@ test(
   t => ({
     Logger: {
       error: e => {
+        t.pass();
         throw loggerError;
       }
     }
@@ -78,5 +80,6 @@ test(
       }
     },
     ERROR_ACTION
-  ]
+  ],
+  1
 );


### PR DESCRIPTION
Modification des tests sur les actions dans app-player
- Le state est maintenant calculé automatiquement dans la macro de test à partir du payload des actions. On n'a plus à (et on ne peut plus) indiquer manuellement quel devrait être l'état du state après le passage de cette action (on faisait ça en mettant l'action dans un tableau, et le premier élément correspondait à l'action et le 2e à l'état post-action). Ça devrait éviter pas mal de tests mal fait liés à des états mal formés. Par contre, ça va rendre les tests d'actions dépendant des reducers, mais bon.
- Correction des tests liés à ce changement.

- La macro est maintenant plus clair sur certaines des erreurs qui sont remontées.

- Modification de comment la planification du nombre d'assertions est faite. Le dernier argument, lorsque donné, activait la planification d'évènements via `t.plan(n)`. On devait par contre donner le nombre total d'assertions qui se passeraient, incluant celles dans la macro de test (donc si on modifiait celle-là, on devait modifier tous les tests). Maintenant, on ne doit indiquer que le nombre d'assertions faites dans les services.
- Ajout de la planification dans tous les tests d'actions existants.