### PR TITLE
Mark resource as viewed ref

### DIFF
--- a/packages/@coorpacademy-app-player/src/store/actions/api/progressions.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/progressions.js
@@ -194,7 +194,7 @@ export const markResourceAsViewed = (progressionId, resource) => (
 ) => {
   const {Progressions} = services;
   const state = getState();
-  const {_id: ref, type} = resource;
+  const {_id, ref = _id, type} = resource;
   const slide = getCurrentSlide(state) || getPreviousSlide(state);
   const progressionContent = getProgressionContent(state);
   const progression = getProgression(progressionId)(state);
@@ -202,6 +202,7 @@ export const markResourceAsViewed = (progressionId, resource) => (
 
   const payload = {
     resource: {
+      _id,
       ref,
       type,
       version: '1'

--- a/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.resource-viewed.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/test/progressions.resource-viewed.js
@@ -10,7 +10,8 @@ import {
   PROGRESSION_RESOURCE_VIEWED_FAILURE
 } from '../progressions';
 
-const resource = {_id: 'resourceId', type: 'video'};
+const resource = {_id: 'resourceId', ref: 'resourceRef', type: 'video'};
+const resourceWithoutRef = {_id: 'resourceId', type: 'pdf'};
 const content = {ref: 'contentRef', type: 'chapter'};
 
 const initState = pipe(
@@ -34,8 +35,9 @@ test(
         t.is(id, 'foo');
         t.deepEqual(payload, {
           resource: {
-            ref: resource._id,
-            type: resource.type,
+            _id: 'resourceId',
+            ref: 'resourceRef',
+            type: 'video',
             version: '1'
           },
           content,
@@ -44,7 +46,7 @@ test(
 
         return set(
           'state.viewedResources',
-          [{ref: content.ref, type: 'chapter', resources: [resource._id]}],
+          [{ref: 'contentRef', type: 'chapter', resources: ['resourceRef']}],
           {}
         );
       }
@@ -61,7 +63,53 @@ test(
       meta: {progressionId: 'foo', resource},
       payload: set(
         'state.viewedResources',
-        [{ref: content.ref, type: 'chapter', resources: [resource._id]}],
+        [{ref: 'contentRef', type: 'chapter', resources: ['resourceRef']}],
+        {}
+      )
+    }
+  ],
+  2
+);
+
+test(
+  'should use resource._id as the ref if the resource has no ref',
+  macro,
+  initState(set('ui.route.foo', 'media', {})),
+  t => ({
+    Progressions: {
+      markResourceAsViewed: (id, payload) => {
+        t.is(id, 'foo');
+        t.deepEqual(payload, {
+          resource: {
+            _id: 'resourceId',
+            ref: 'resourceId',
+            type: 'pdf',
+            version: '1'
+          },
+          content,
+          slide: 'slide2'
+        });
+
+        return set(
+          'state.viewedResources',
+          [{ref: 'contentRef', type: 'chapter', resources: ['resourceId']}],
+          {}
+        );
+      }
+    }
+  }),
+  markResourceAsViewed('foo', resourceWithoutRef),
+  [
+    {
+      type: PROGRESSION_RESOURCE_VIEWED_REQUEST,
+      meta: {progressionId: 'foo', resource: resourceWithoutRef}
+    },
+    {
+      type: PROGRESSION_RESOURCE_VIEWED_SUCCESS,
+      meta: {progressionId: 'foo', resource: resourceWithoutRef},
+      payload: set(
+        'state.viewedResources',
+        [{ref: 'contentRef', type: 'chapter', resources: ['resourceId']}],
         {}
       )
     }
@@ -83,8 +131,9 @@ test(
         t.is(id, 'foo');
         t.deepEqual(payload, {
           resource: {
-            ref: resource._id,
-            type: resource.type,
+            _id: 'resourceId',
+            ref: 'resourceRef',
+            type: 'video',
             version: '1'
           },
           content,
@@ -93,7 +142,7 @@ test(
 
         return set(
           'state.viewedResources',
-          [{ref: content.ref, type: 'chapter', resources: [resource._id]}],
+          [{ref: 'contentRef', type: 'chapter', resources: ['resourceRef']}],
           {}
         );
       }
@@ -110,7 +159,7 @@ test(
       meta: {progressionId: 'foo', resource},
       payload: set(
         'state.viewedResources',
-        [{ref: content.ref, type: 'chapter', resources: [resource._id]}],
+        [{ref: 'contentRef', type: 'chapter', resources: ['resourceRef']}],
         {}
       )
     }
@@ -124,7 +173,7 @@ test(
   pipe(
     initState,
     set('data.progressions.entities.foo.state.viewedResources', [
-      {ref: content.ref, type: 'chapter', resources: [resource._id]}
+      {ref: 'contentRef', type: 'chapter', resources: ['resourceRef']}
     ]),
     set('ui.route.foo', 'media')
   )({}),
@@ -160,8 +209,9 @@ test(
         t.is(id, 'foo');
         t.deepEqual(payload, {
           resource: {
-            ref: resource._id,
-            type: resource.type,
+            _id: 'resourceId',
+            ref: 'resourceRef',
+            type: 'video',
             version: '1'
           },
           content,

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/video.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/video.js
@@ -20,7 +20,7 @@ import {
   PROGRESSION_RESOURCE_VIEWED_SUCCESS
 } from '../../api/progressions';
 
-const resource = {_id: 'resourceId', type: 'video'};
+const resource = {_id: 'resourceId', ref: 'resourceRef', type: 'video'};
 const content = {ref: 'chapterRef', type: 'chapter'};
 
 test(
@@ -90,8 +90,9 @@ test(
         t.is(progressionId, 'foo');
         t.deepEqual(payload, {
           resource: {
-            ref: resource._id,
-            type: resource.type,
+            _id: 'resourceId',
+            ref: 'resourceRef',
+            type: 'video',
             version: '1'
           },
           content,

--- a/packages/@coorpacademy-app-player/src/store/services/progressions.js
+++ b/packages/@coorpacademy-app-player/src/store/services/progressions.js
@@ -109,7 +109,9 @@ export const postExtraLife = async (progressionId, payload) => {
   const feedNextContent = _action => {
     let nextState = updateState(progression.engine, progression.state, [_action]);
     nextState = set('nextContent', progression.state.content, nextState);
-    return set('payload.nextContent', computeNextStep(progression.engine, slidePools, nextState))(
+    return set(
+      'payload.nextContent',
+      computeNextStep(progression.engine, slidePools, nextState),
       _action
     );
   };

--- a/packages/@coorpacademy-app-player/src/store/utils/state-extract.js
+++ b/packages/@coorpacademy-app-player/src/store/utils/state-extract.js
@@ -137,7 +137,7 @@ export const getQuestionMedia = state => {
   return get('question.medias.0.src.0.url', slide);
 };
 
-export const getResourcesToPlay = state => get('ui.corrections.playResource', state);
+export const getResourceToPlay = state => get('ui.corrections.playResource', state);
 
 export const getLives = state => {
   const progression = getCurrentProgression(state);

--- a/packages/@coorpacademy-app-player/src/store/utils/test/state-extract.js
+++ b/packages/@coorpacademy-app-player/src/store/utils/test/state-extract.js
@@ -22,7 +22,7 @@ import {
   getStepContent,
   getEndRank,
   getBestScore,
-  getResourcesToPlay,
+  getResourceToPlay,
   getNextContentFromRecommendations
 } from '../state-extract';
 
@@ -232,10 +232,10 @@ test('getCurrentClue should get current clue from state', t => {
   t.is(getCurrentClue(state), clue);
 });
 
-test('getResourcesToPlay should get resources to play from state', t => {
+test('getResourceToPlay should get resources to play from state', t => {
   const state = set('ui.corrections.playResource', true, {});
 
-  t.true(getResourcesToPlay(state));
+  t.true(getResourceToPlay(state));
 });
 
 test('getEngine should extract engine from state', t => {

--- a/packages/@coorpacademy-app-player/src/store/view/state-to-props/player.js
+++ b/packages/@coorpacademy-app-player/src/store/view/state-to-props/player.js
@@ -29,6 +29,12 @@ const STARS_DIFF = {
   clue: 'starsPerAskingClue'
 };
 
+const shouldDisplayNewMedia = (slide, progression) => {
+  const currentLessons = map('ref', get('lessons', slide));
+  const viewedResources = flatMap('resources', getOr([], 'state.viewedResources', progression));
+  return isEmpty(intersection(currentLessons, viewedResources));
+};
+
 const playerProps = (options, store) => state => {
   const {translate} = options;
   const {dispatch} = store;
@@ -41,10 +47,9 @@ const playerProps = (options, store) => state => {
   const clue = getCurrentClue(state) || null;
   const route = getRoute(state);
   const resources = getResourcesProps(options, store)(state, slide);
-  const currentLessons = map('_id', get('lessons', slide));
-  const viewedResources = flatMap('resources', getOr([], 'state.viewedResources', progression));
-  const notifyNewMedia = isEmpty(intersection(currentLessons, viewedResources));
-  const starsDiff = (STARS_DIFF[route] && get(STARS_DIFF[route], engineConfig)) || 0;
+  const help = createGetHelp(options, store)(slide);
+  const notifyNewMedia = shouldDisplayNewMedia(slide, progression);
+  const starsDiff = get(STARS_DIFF[route], engineConfig) || 0;
   const isAnswer = !includes(route, ROUTES);
   const clickClueHandler = () => dispatch(selectClue);
   const clickSeeClueHandler = () => dispatch(getClue);
@@ -56,9 +61,6 @@ const playerProps = (options, store) => state => {
         slideId: slide._id
       })
     );
-
-  const getHelp = createGetHelp(options, store);
-  const help = getHelp(slide);
 
   const slideContext = get('context', slide);
   const contextButton = get('title', slideContext)

--- a/packages/@coorpacademy-app-player/src/store/view/state-to-props/resources.js
+++ b/packages/@coorpacademy-app-player/src/store/view/state-to-props/resources.js
@@ -3,39 +3,34 @@ import isEmpty from 'lodash/fp/isEmpty';
 import map from 'lodash/fp/map';
 import pipe from 'lodash/fp/pipe';
 import set from 'lodash/fp/set';
-import update from 'lodash/fp/update';
-import {getResourcesToPlay} from '../../utils/state-extract';
+import some from 'lodash/fp/some';
+import {getResourceToPlay} from '../../utils/state-extract';
 import {selectResource} from '../../actions/ui/corrections';
 import {play, pause, resume, ended} from '../../actions/ui/video';
 
 const getResourcesProps = (options, store) => (state, slide) => {
   const {dispatch} = store;
-  const resourcesToPlay = getResourcesToPlay(state);
+  const resourceToPlay = getResourceToPlay(state);
 
   const lessons = pipe(
     getOr([], 'lessons'),
-    map(lesson => {
-      return pipe(
-        set('onClick', () => dispatch(selectResource(lesson._id))),
-        set('onPlay', () => dispatch(play(lesson))),
-        set('onResume', () => dispatch(resume(lesson))),
-        set('onPause', () => dispatch(pause(lesson))),
-        set('onEnded', () => dispatch(ended(lesson))),
-        set('selected', lesson._id === resourcesToPlay),
-        _lesson => {
-          if (_lesson.type === 'pdf') {
-            return set('mediaUrl', _lesson.mediaUrl, _lesson);
-          }
-          return _lesson;
-        }
-      )(lesson);
-    })
+    map(lesson => ({
+      ...lesson,
+      onClick: () => dispatch(selectResource(lesson._id)),
+      onPlay: () => dispatch(play(lesson)),
+      onResume: () => dispatch(resume(lesson)),
+      onPause: () => dispatch(pause(lesson)),
+      onEnded: () => dispatch(ended(lesson)),
+      selected: lesson._id === resourceToPlay
+    }))
   )(slide);
 
-  const forceSelected = !resourcesToPlay && !isEmpty(lessons);
-  return !isEmpty(lessons)
-    ? update('0.selected', selected => forceSelected || selected)(lessons)
-    : lessons;
+  if (isEmpty(lessons) || some({selected: true}, lessons)) {
+    return lessons;
+  }
+
+  // If there are lessons but none are selected, force select the first one
+  return set([0, 'selected'], true, lessons);
 };
 
 export default getResourcesProps;

--- a/packages/@coorpacademy-app-player/src/store/view/state-to-props/test/player.js
+++ b/packages/@coorpacademy-app-player/src/store/view/state-to-props/test/player.js
@@ -224,7 +224,7 @@ test('should not display new media notification when user has seen at least one 
   const progression = createProgression(basicSlide);
   progression.state.viewedResources = [
     {
-      resources: [basicSlide.lessons[0]._id]
+      resources: [basicSlide.lessons[0].ref]
     }
   ];
   const state = {


### PR DESCRIPTION
- Dans markResourceAsViewed, envoi de la ref de la ressource dans le payload, et envoi de l'_id (au lieu d'un champ ref qui a la valeur du champ l'_id)

(+ 1 commit de refacto de trucs que j'ai vu passer en même temps)