### PR TITLE
Popin-correction: Show `Next` when ending progression successfully

### DIFF
--- a/packages/@coorpacademy-app-player/src/store/view/state-to-props/popin-correction.js
+++ b/packages/@coorpacademy-app-player/src/store/view/state-to-props/popin-correction.js
@@ -3,6 +3,7 @@ import get from 'lodash/fp/get';
 import isNil from 'lodash/fp/isNil';
 import join from 'lodash/fp/join';
 import indexOf from 'lodash/fp/indexOf';
+import includes from 'lodash/fp/includes';
 import {
   getCurrentCorrection,
   getCurrentProgression,
@@ -17,8 +18,11 @@ import {selectProgression} from '../../actions/ui/progressions';
 import getResourcesProps from './resources';
 
 const isNewChapter = (state, progression) => {
-  if (progression.content.type !== 'level') {
-    return null;
+  if (
+    progression.content.type !== 'level' ||
+    includes(progression.state.nextContent.type, ['success', 'failure'])
+  ) {
+    return false;
   }
   const currentSlide = getCurrentSlide(state);
   const currentChapterId = get('chapter_id', currentSlide);

--- a/packages/@coorpacademy-app-player/src/store/view/state-to-props/test/popin-correction.create-header-cta.js
+++ b/packages/@coorpacademy-app-player/src/store/view/state-to-props/test/popin-correction.create-header-cta.js
@@ -43,6 +43,7 @@ import popinExtraLife from '../../test/fixtures/popin-correction/popin-extra-lif
 import popinFailure from '../../test/fixtures/popin-correction/popin-failure';
 import popinRevival from '../../test/fixtures/popin-correction/popin-revival';
 import popinSuccess from '../../test/fixtures/popin-correction/popin-success';
+import popinSuccessNode from '../../test/fixtures/popin-correction/popin-success-node';
 import popinNextLevel from '../../test/fixtures/popin-correction/popin-next-level';
 import {getCurrentProgressionId} from '../../../utils/state-extract';
 
@@ -136,7 +137,43 @@ test('should create a "Next" CTA when entering a success popin', async t => {
   t.deepEqual(metaOf(PROGRESSION_FETCH_REQUEST, dispatched), {id: progressionId});
 });
 
-test('should create a "Game over" CTA when entering a success popin', async t => {
+test('should create a "Next" CTA when entering a success exit popin', async t => {
+  const state = popinSuccessNode;
+  const progressionId = getCurrentProgressionId(state);
+  const dispatch = createDispatch(state);
+  const cta = createHeaderCTA({translate: mockTranslate}, {dispatch})(state);
+
+  t.deepEqual(omit('onClick', cta), {
+    type: 'correction',
+    title: '__Next',
+    nextStepTitle: null
+  });
+  const dispatched = await cta.onClick();
+  t.deepEqual(actionTypes(dispatched), [
+    UI_SELECT_PROGRESSION,
+    PROGRESSION_FETCH_REQUEST,
+    RANK_FETCH_START_REQUEST,
+    RANK_FETCH_START_SUCCESS,
+    CONTENT_FETCH_REQUEST,
+    CONTENT_FETCH_SUCCESS,
+    PROGRESSION_FETCH_BESTOF_REQUEST,
+    PROGRESSION_FETCH_BESTOF_SUCCESS,
+    ENGINE_CONFIG_FETCH_REQUEST,
+    ENGINE_CONFIG_FETCH_SUCCESS,
+    CONTENT_INFO_FETCH_REQUEST,
+    CONTENT_INFO_FETCH_SUCCESS,
+    RANK_FETCH_END_REQUEST,
+    RANK_FETCH_END_SUCCESS,
+    RECO_FETCH_REQUEST,
+    RECO_FETCH_SUCCESS,
+    EXIT_NODE_FETCH_REQUEST,
+    EXIT_NODE_FETCH_SUCCESS
+  ]);
+
+  t.deepEqual(metaOf(PROGRESSION_FETCH_REQUEST, dispatched), {id: progressionId});
+});
+
+test('should create a "Game over" CTA when entering a failure exit popin', async t => {
   const state = popinFailure;
   const progressionId = getCurrentProgressionId(state);
   const dispatch = createDispatch(state);

--- a/packages/@coorpacademy-app-player/src/store/view/test/fixtures/popin-correction/popin-success-node.json
+++ b/packages/@coorpacademy-app-player/src/store/view/test/fixtures/popin-correction/popin-success-node.json
@@ -1,0 +1,138 @@
+{
+  "data": {
+    "contents": {
+      "slide": {
+        "entities": {
+          "1.B2.4": {
+            "_id": "1.B2.4",
+            "klf": "Some KLF",
+            "tips": "XXX",
+            "chapter_id": "cha_Ny1BTxRp~",
+            "authors": [],
+            "context": {
+              "media": {
+                "subtitles": [],
+                "posters": [],
+                "src": []
+              }
+            },
+            "info": {
+              "nbSlides": 4
+            },
+            "lessons": [
+              {
+                "type": "video",
+                "poster": "//static.coorpacademy.com/content/digital/miniatures_cours/base/1B2.png",
+                "description": "Anatomie d'une page de résultats",
+                "mimeType": "application/vimeo",
+                "videoId": "88393119\n",
+                "_id": "590b862e2e967f64333ad456",
+                "subtitles": [],
+                "posters": [],
+                "src": []
+              },
+              {
+                "description": "Historique des moteurs de recherche",
+                "mimeType": "application/vimeo",
+                "poster": "//static.coorpacademy.com/content/digital/miniatures_cours/base/1B1.png",
+                "posters": [],
+                "src": [],
+                "subtitles": [],
+                "type": "video",
+                "videoId": "88546728\n",
+                "_id": "590b862e2e967f64333ad4fc"
+              }
+            ],
+            "question": {
+              "type": "basic",
+              "header": "Écrivez le mot Text dans l'input.\n",
+              "explanation": "Saisissez votre réponse.",
+              "content": {
+                "label": "Saisissez votre réponse.",
+                "placeholder": " ",
+                "maxTypos": null,
+                "choices": [],
+                "answers": [["Text"]],
+                "media": {
+                  "subtitles": [],
+                  "posters": [],
+                  "src": []
+                }
+              },
+              "medias": []
+            }
+          }
+        }
+      }
+    },
+    "answers": {
+      "entities": {
+        "0": {
+          "1.B2.4": {
+            "correctAnswer": ["Text"],
+            "corrections": [
+              {
+                "answer": "Text",
+                "isCorrect": true
+              }
+            ]
+          }
+        }
+      }
+    },
+    "progressions": {
+      "entities": {
+        "0": {
+          "_id": "0",
+          "engine": {
+            "ref": "learner",
+            "version": "1"
+          },
+          "content": {
+            "ref": "1.B",
+            "type": "level"
+          },
+          "state": {
+            "slides": ["1.B2.5", "1.B2.6", "1.B2.7", "1.B2.14", "1.B2.15", "1.B2.16", "1.B2.17", "1.B2.4"],
+            "nextContent": {
+              "ref": "successExitNode",
+              "type": "success"
+            },
+            "livesDisabled": false,
+            "lives": 1,
+            "step": {
+              "current": 8
+            },
+            "isCorrect": true,
+            "stars": 20,
+            "requestedClues": [],
+            "viewedResources": [],
+            "content": {
+              "ref": "1.B2.4",
+              "type": "slide"
+            }
+          }
+        }
+      }
+    },
+    "exitNodes": {
+      "entities": {}
+    }
+  },
+  "ui": {
+    "answers": {
+      "0": {
+        "value": ["Toto"]
+      }
+    },
+    "current": {
+      "progressionId": "0"
+    },
+    "corrections": {
+      "accordion": [true, false, false]
+    },
+    "route": {
+      "0": "correction"
+    }
+  }
+}


### PR DESCRIPTION
Fix remonté dans https://trello.com/c/5OjUVBvx/345-learner-gestion-du-changement-de-chapitre#comment-5a02de531333181858a0c441

On affiche maintenant `Next` au lieu de `Next chapter` dans la popin de correction lorsqu'on termine une progression avec succès.