### PR TITLE
Extralife within action progressionUpdated

### DIFF
--- a/packages/@coorpacademy-app-player/src/store/actions/api/analytics.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/analytics.js
@@ -1,5 +1,5 @@
 import buildTask from '../../utils/redux-task';
-import {getRoute, getCurrentEngine, getStepContent} from '../../utils/state-extract';
+import {getRoute, getCurrentProgression, getEngineConfig} from '../../utils/state-extract';
 
 export const MEDIA_VIEWED_ANALYTICS_REQUEST = '@@analytics/MEDIA_VIEWED_REQUEST';
 export const MEDIA_VIEWED_ANALYTICS_SUCCESS = '@@analytics/MEDIA_VIEWED_SUCCESS';
@@ -30,8 +30,8 @@ export const SEND_PROGRESSION_ANALYTICS_FAILURE = '@@analytics/SEND_PROGRESSION_
 export const sendProgressionAnalytics = progressionId => (dispatch, getState, {services}) => {
   const {Analytics} = services;
   const state = getState();
-  const engine = getCurrentEngine(state);
-  const nextContent = getStepContent(state);
+  const currentProgression = getCurrentProgression(state);
+  const engineConfig = getEngineConfig(state);
 
   const action = buildTask({
     types: [
@@ -39,8 +39,8 @@ export const sendProgressionAnalytics = progressionId => (dispatch, getState, {s
       SEND_PROGRESSION_ANALYTICS_SUCCESS,
       SEND_PROGRESSION_ANALYTICS_FAILURE
     ],
-    task: () => Analytics.sendProgressionAnalytics(engine.ref, nextContent),
-    meta: {id: progressionId}
+    task: () => Analytics.sendProgressionAnalytics(currentProgression, engineConfig),
+    meta: {currentProgression, engineConfig}
   });
 
   return dispatch(action);

--- a/packages/@coorpacademy-app-player/src/store/actions/api/analytics.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/api/analytics.js
@@ -40,7 +40,7 @@ export const sendProgressionAnalytics = progressionId => (dispatch, getState, {s
       SEND_PROGRESSION_ANALYTICS_FAILURE
     ],
     task: () => Analytics.sendProgressionAnalytics(currentProgression, engineConfig),
-    meta: {currentProgression, engineConfig}
+    meta: {id: progressionId}
   });
 
   return dispatch(action);

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-accordion.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-accordion.js
@@ -70,9 +70,9 @@ const services = result => t => ({
     }
   },
   Analytics: {
-    sendProgressionAnalytics: (engineRef, nextContent) => {
-      t.is(engineRef, 'learner');
-      t.deepEqual(nextContent, result.state.nextContent);
+    sendProgressionAnalytics: (currentProgression, engineConfig) => {
+      t.is(currentProgression.engine.ref, 'learner');
+      t.deepEqual(currentProgression.state.nextContent, result.state.nextContent);
       return 'sent';
     }
   }

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-exit-node.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-exit-node.js
@@ -32,9 +32,9 @@ const services = t => ({
     }
   },
   Analytics: {
-    sendProgressionAnalytics: (engineRef, nextContent) => {
-      t.is(engineRef, 'learner');
-      t.deepEqual(nextContent, {type: 'success', ref: 'successExitNode'});
+    sendProgressionAnalytics: (currentProgression, engineConfig) => {
+      t.is(currentProgression.engine.ref, 'learner');
+      t.deepEqual(currentProgression.state.nextContent, {type: 'success', ref: 'successExitNode'});
       return 'sent';
     }
   }

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-failure.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-failure.js
@@ -102,9 +102,12 @@ test(
       }
     },
     Analytics: {
-      sendProgressionAnalytics: (engineRef, nextContent) => {
-        t.is(engineRef, 'learner');
-        t.deepEqual(nextContent, {type: 'success', ref: 'successExitNode'});
+      sendProgressionAnalytics: (currentProgression, engineConfig) => {
+        t.is(currentProgression.engine.ref, 'learner');
+        t.deepEqual(currentProgression.state.nextContent, {
+          type: 'success',
+          ref: 'successExitNode'
+        });
         return 'sent';
       }
     }

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-success.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/answers-validation/check-success.js
@@ -129,9 +129,9 @@ test(
       }
     },
     Analytics: {
-      sendProgressionAnalytics: (engineRef, nextContent) => {
-        t.is(engineRef, 'learner');
-        t.deepEqual(nextContent, postAnswersPayload.state.nextContent);
+      sendProgressionAnalytics: (currentProgression, engineConfig) => {
+        t.is(currentProgression.engine.ref, 'learner');
+        t.deepEqual(currentProgression.state.nextContent, postAnswersPayload.state.nextContent);
         return 'sent';
       }
     }

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/clues.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/clues.js
@@ -54,9 +54,9 @@ test(
   )({}),
   t => ({
     Analytics: {
-      sendProgressionAnalytics: (engineRef, nextContent) => {
-        t.is(engineRef, 'microlearning');
-        t.deepEqual(nextContent, {type: 'slide', ref: 'bar'});
+      sendProgressionAnalytics: (currentProgression, engineConfig) => {
+        t.is(currentProgression.engine.ref, 'microlearning');
+        t.deepEqual(currentProgression.state.nextContent, {type: 'slide', ref: 'bar'});
         return 'sent';
       }
     },

--- a/packages/@coorpacademy-app-player/src/store/actions/ui/test/extra-life.js
+++ b/packages/@coorpacademy-app-player/src/store/actions/ui/test/extra-life.js
@@ -59,9 +59,9 @@ test(
   )({}),
   t => ({
     Analytics: {
-      sendProgressionAnalytics: (engineRef, nextContent) => {
-        t.is(engineRef, 'microlearning');
-        t.deepEqual(nextContent, {type: 'slide', ref: 'slideRef'});
+      sendProgressionAnalytics: (currentProgression, engineConfig) => {
+        t.is(currentProgression.engine.ref, 'microlearning');
+        t.deepEqual(currentProgression.state.nextContent, {type: 'slide', ref: 'slideRef'});
         return 'sent';
       }
     },
@@ -221,9 +221,9 @@ test(
   )({}),
   t => ({
     Analytics: {
-      sendProgressionAnalytics: (engineRef, nextContent) => {
-        t.is(engineRef, 'microlearning');
-        t.deepEqual(nextContent, {type: 'slide', ref: 'slideRef'});
+      sendProgressionAnalytics: (currentProgression, engineConfig) => {
+        t.is(currentProgression.engine.ref, 'microlearning');
+        t.deepEqual(currentProgression.state.nextContent, {type: 'slide', ref: 'slideRef'});
         return 'sent';
       }
     },

--- a/packages/@coorpacademy-app-player/src/store/services/analytics.js
+++ b/packages/@coorpacademy-app-player/src/store/services/analytics.js
@@ -9,14 +9,21 @@ export const sendViewedMediaAnalytics = (resource, location) => {
   return window.dataLayer;
 };
 
-export const sendProgressionAnalytics = (engineRef, nextContent) => {
+export const sendProgressionAnalytics = (currentProgression, engineConfig) => {
+  const state = currentProgression.state;
   window.dataLayer = window.dataLayer || [];
-  if (nextContent.type === 'success' || nextContent.type === 'failure') {
+
+  if (state.nextContent.type === 'success' || state.nextContent.type === 'failure') {
+    const nbExtraLifeUsed =
+      state.remainingLifeRequests < 0
+        ? 0
+        : engineConfig.remainingLifeRequests - state.remainingLifeRequests;
     window.dataLayer.push({
       event: 'finishProgression',
       progression: {
-        type: engineRef,
-        state: nextContent.type
+        type: currentProgression.engine.ref,
+        state: state.nextContent.type,
+        nbExtraLifeUsed
       }
     });
   }

--- a/packages/@coorpacademy-app-player/src/store/services/progressions.js
+++ b/packages/@coorpacademy-app-player/src/store/services/progressions.js
@@ -5,6 +5,7 @@ import {
   checkAnswer,
   updateState
 } from '@coorpacademy/progression-engine';
+import defaultsDeep from 'lodash/fp/defaultsDeep';
 import map from 'lodash/fp/map';
 import toPairs from 'lodash/fp/toPairs';
 import groupBy from 'lodash/fp/groupBy';
@@ -29,7 +30,18 @@ const slideStore = reduce(
 
 const generateId = () => uniqueId('progression');
 const progressionStore = reduce(
-  (progressionMap, progression) => progressionMap.set(progression._id, progression),
+  (progressionMap, progression) =>
+    progressionMap.set(
+      progression._id,
+      defaultsDeep(
+        {
+          state: {
+            remainingLifeRequests: getConfig(progression.engine).remainingLifeRequests
+          }
+        },
+        progression
+      )
+    ),
   new Map(),
   progressionsData
 );
@@ -142,7 +154,6 @@ export const create = async progression => {
   };
 
   const newProgression = createProgression(progression.engine, chapter, initialContent);
-
   return save({
     _id,
     ...newProgression

--- a/packages/@coorpacademy-app-player/src/store/services/test/analytics.js
+++ b/packages/@coorpacademy-app-player/src/store/services/test/analytics.js
@@ -1,4 +1,6 @@
 import test from 'ava';
+import set from 'lodash/fp/set';
+import pipe from 'lodash/fp/pipe';
 import {sendViewedMediaAnalytics, sendProgressionAnalytics} from '../analytics';
 
 test('populate dataLayer when empty', t => {
@@ -28,11 +30,19 @@ test('verify sendProgressionAnalytics tag', t => {
       push: evt => {
         t.deepEqual(evt, {
           event: 'finishProgression',
-          progression: {type: 'microlearning', state: 'success'}
+          progression: {type: 'microlearning', state: 'success', nbExtraLifeUsed: 2}
         });
       }
     }
   };
 
-  sendProgressionAnalytics('microlearning', {type: 'success'});
+  const currentProgression = pipe(
+    set('engine.ref', 'microlearning'),
+    set('state.nextContent.type', 'success'),
+    set('state.remainingLifeRequests', 1)
+  )({});
+
+  const engineConfig = {remainingLifeRequests: 3};
+
+  sendProgressionAnalytics(currentProgression, engineConfig);
 });

--- a/packages/@coorpacademy-app-player/src/store/view/state-to-props/popin-correction.js
+++ b/packages/@coorpacademy-app-player/src/store/view/state-to-props/popin-correction.js
@@ -8,6 +8,7 @@ import {
   getCurrentCorrection,
   getCurrentProgression,
   getCurrentProgressionId,
+  getEngineConfig,
   getLives,
   getPreviousSlide,
   getCurrentSlide
@@ -101,7 +102,10 @@ export const popinCorrectionStateToProps = (options, store) => state => {
   const {dispatch} = store;
   const toggleAccordionSection = sectionId => dispatch(toggleAccordion(sectionId));
   const slide = getPreviousSlide(state);
+  const engineConfig = getEngineConfig(state);
   const progression = getCurrentProgression(state);
+  const isExtraLifeAvailable = get('remainingLifeRequests', engineConfig) > 0;
+  const remainingLifeRequests = get('state.remainingLifeRequests', progression);
   const accordion = get('ui.corrections.accordion', state);
   const answerResult = getCurrentCorrection(state);
   const correctAnswer = get('correctAnswer', answerResult) || [];
@@ -110,8 +114,7 @@ export const popinCorrectionStateToProps = (options, store) => state => {
   const isLoading = isNil(isCorrect);
   const isExtraLifeActive = get('state.nextContent.ref', progression) === 'extraLife';
   const isRevival = get('ui.extraLife.acceptRevivalPending', state);
-  const isDead = progression.state.lives === 0;
-  const exhausted = isDead && !isRevival && !isCorrect && !isExtraLifeActive;
+  const exhausted = isExtraLifeAvailable && remainingLifeRequests === 0;
   const header = isNil(answerResult)
     ? {}
     : {

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step.js
@@ -13,6 +13,7 @@ import getConfig from './config';
 
 const isAlive = (state: State): boolean => state.lives > 0;
 const hasRemainingLifeRequests = (state: State): boolean => state.remainingLifeRequests > 0;
+const stepIsAlreadyExtraLife = (state: State): boolean => get('content.ref', state) === 'extraLife';
 
 const getSlidePool = (
   config: Config,
@@ -44,7 +45,7 @@ export default function computeNextStep(
   const config = (getConfig(engine): Config);
   // if no more lives, return failure endpoint
   if (!isAlive(state)) {
-    return hasRemainingLifeRequests(state)
+    return !stepIsAlreadyExtraLife(state) && hasRemainingLifeRequests(state)
       ? {ref: 'extraLife', type: 'node'}
       : {ref: 'failExitNode', type: 'failure'};
   }

--- a/packages/@coorpacademy-progression-engine/src/config/microlearning.js
+++ b/packages/@coorpacademy-progression-engine/src/config/microlearning.js
@@ -12,7 +12,7 @@ const realConfigurations: Array<Config> = [
     starsPerAskingClue: -1,
     starsPerCorrectAnswer: 4,
     starsPerResourceViewed: 4,
-    remainingLifeRequests: 1
+    remainingLifeRequests: 3
   }
 ];
 

--- a/packages/@coorpacademy-progression-engine/src/config/microlearning.js
+++ b/packages/@coorpacademy-progression-engine/src/config/microlearning.js
@@ -12,7 +12,7 @@ const realConfigurations: Array<Config> = [
     starsPerAskingClue: -1,
     starsPerCorrectAnswer: 4,
     starsPerResourceViewed: 4,
-    remainingLifeRequests: 3
+    remainingLifeRequests: 1
   }
 ];
 

--- a/packages/@coorpacademy-progression-engine/src/test/compute-next-step.microlearning.js
+++ b/packages/@coorpacademy-progression-engine/src/test/compute-next-step.microlearning.js
@@ -7,7 +7,8 @@ import {
   stateBeforeGettingNextContent,
   failProgressionState,
   successProgressionState,
-  extraLifeProgressionState
+  extraLifeProgressionState,
+  extraLifeAlreadyRefusedProgressionState
 } from './fixtures/states';
 
 const engine = {
@@ -56,5 +57,15 @@ test('should return the extraLife endpoint when progressions has no more lives &
   t.deepEqual(nextStep, {
     ref: 'extraLife',
     type: 'node'
+  });
+});
+
+test('should return the failure endpoint when progression has at least one remaining extra life and extraLife has already just been refused', t => {
+  const state = Object.freeze(extraLifeAlreadyRefusedProgressionState);
+
+  const nextStep = computeNextStep(engine, slides, state);
+  t.deepEqual(nextStep, {
+    ref: 'failExitNode',
+    type: 'failure'
   });
 });

--- a/packages/@coorpacademy-progression-engine/src/test/fixtures/states.js
+++ b/packages/@coorpacademy-progression-engine/src/test/fixtures/states.js
@@ -109,6 +109,29 @@ export const extraLifeProgressionState: State = {
   remainingLifeRequests: 1
 };
 
+export const extraLifeAlreadyRefusedProgressionState: State = {
+  content: {
+    ref: 'extraLife',
+    type: 'node'
+  },
+  nextContent: {
+    ref: 'none',
+    type: 'node'
+  },
+  lives: 0,
+  livesDisabled: false,
+  isCorrect: false,
+  slides: ['1.A1.1', '1.A1.2'],
+  step: {
+    current: 3,
+    total: 4
+  },
+  requestedClues: [],
+  viewedResources: [],
+  stars: 4,
+  remainingLifeRequests: 4
+};
+
 export const successProgressionState: State = {
   content: {
     ref: '1.A1.4',

--- a/packages/@coorpacademy-progression-engine/src/test/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/test/update-state.js
@@ -473,7 +473,7 @@ test('should go to failure when refusing extra life', t => {
   const newState = updateState(engine, state, [action]);
 
   t.is(newState.lives, 0);
-  t.is(newState.remainingLifeRequests, 0);
+  t.is(newState.remainingLifeRequests, 1);
   t.is(newState.nextContent.type, 'failure');
   t.is(get('content.ref', newState), 'extraLife');
 });

--- a/packages/@coorpacademy-progression-engine/src/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/update-state.js
@@ -117,7 +117,6 @@ function remainingLifeRequests(config: Config): (number, Action, State) => numbe
       case 'extraLifeAccepted': {
         return count > 0 ? count - 1 : count;
       }
-      case 'extraLifeRefused':
       default:
         return count;
     }

--- a/packages/@coorpacademy-progression-engine/src/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/update-state.js
@@ -117,9 +117,7 @@ function remainingLifeRequests(config: Config): (number, Action, State) => numbe
       case 'extraLifeAccepted': {
         return count > 0 ? count - 1 : count;
       }
-      case 'extraLifeRefused': {
-        return 0;
-      }
+      case 'extraLifeRefused':
       default:
         return count;
     }


### PR DESCRIPTION
on ne reset plus `remainingLifeRequests` à 0 lors d'un extralife refused
- on garde le decrement en l'etat = on peut faire la diff avec la config pour compter combien d'extralife ont été utilisés
- pour ne pas boucler sur le step extralife, on check si le node precedent etait DEJA un extralife, auquel cas on devient `node = fail`