### PR TITLE
force crop on discipline header wrapper

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/discipline-header/style.css
+++ b/packages/@coorpacademy-components/src/molecule/discipline-header/style.css
@@ -75,8 +75,9 @@
 
   .imgWrapper {
     flex: none;
-    height: auto;
     text-align: center;
+    height: auto;
+    max-height: 30vh;
   }
 
   .courseWrapper {

--- a/packages/@coorpacademy-components/src/molecule/discipline-header/test/fixtures/portait-ratio.js
+++ b/packages/@coorpacademy-components/src/molecule/discipline-header/test/fixtures/portait-ratio.js
@@ -1,0 +1,12 @@
+/* eslint-disable max-len */
+
+export default {
+  props: {
+    title: 'Les nouveaux business',
+    description:
+      'La révolution numérique a tout accéléré : les communications, la récupération des données, la propagation de l’information et des innovations… On peut presque tout savoir instantanément : les bonnes pratiques d’une entreprise comme les mauvaises ; les goûts et les comportements de ses clients… Pour ne pas rater le coche, il faut être au fait des tendances et des changements qui se profilent. C’est ce que propose cette discipline nourrie d’exemples concrets.',
+    image: {
+      '1x': 'https://placehold.it/380x800/1d1d1d'
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/discipline-header/test/fixtures/portait-ratio.js
+++ b/packages/@coorpacademy-components/src/molecule/discipline-header/test/fixtures/portait-ratio.js
@@ -6,7 +6,8 @@ export default {
     description:
       'La révolution numérique a tout accéléré : les communications, la récupération des données, la propagation de l’information et des innovations… On peut presque tout savoir instantanément : les bonnes pratiques d’une entreprise comme les mauvaises ; les goûts et les comportements de ses clients… Pour ne pas rater le coche, il faut être au fait des tendances et des changements qui se profilent. C’est ce que propose cette discipline nourrie d’exemples concrets.',
     image: {
-      '1x': 'https://placehold.it/380x800/1d1d1d'
+      '1x':
+        'https://api.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/CoorpAcademy/content-architas/cockpit-architas/default/focus_image_risk-performance-1505894743913.jpg&h=500&w=500&q=90'
     }
   }
 };

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -324,6 +324,7 @@ import DisciplineCtaFixtureNoStart from '../src/molecule/discipline-cta/test/fix
 import DisciplineHeaderFixtureDefault from '../src/molecule/discipline-header/test/fixtures/default';
 import DisciplineHeaderFixtureNoVideoNoImage from '../src/molecule/discipline-header/test/fixtures/no-video-no-image';
 import DisciplineHeaderFixtureNoVideo from '../src/molecule/discipline-header/test/fixtures/no-video';
+import DisciplineHeaderFixturePortaitRatio from '../src/molecule/discipline-header/test/fixtures/portait-ratio';
 import DisciplinePartnersFixtureDefault from '../src/molecule/discipline-partners/test/fixtures/default';
 import DisciplinePartnersFixtureDoubleAuthors from '../src/molecule/discipline-partners/test/fixtures/double-authors';
 import DisciplinePartnersFixtureMoreInfo from '../src/molecule/discipline-partners/test/fixtures/more-info';
@@ -1045,7 +1046,8 @@ export const fixtures = {
     DisciplineHeader: {
       Default: DisciplineHeaderFixtureDefault,
       NoVideoNoImage: DisciplineHeaderFixtureNoVideoNoImage,
-      NoVideo: DisciplineHeaderFixtureNoVideo
+      NoVideo: DisciplineHeaderFixtureNoVideo,
+      PortaitRatio: DisciplineHeaderFixturePortaitRatio
     },
     DisciplinePartners: {
       Default: DisciplinePartnersFixtureDefault,


### PR DESCRIPTION
Dans le cas ou l'image de cours a un ratio type "portrait", elle prend tout l'espace sur mobile.
J'ai ajouté un max-height pour que l'image ne couvre qu'un tiers de l'écran au maximum.

Sachant que dans l'ideal, les images ne devraient pas avoir ce ratio. Donc ce n'est pas idéal, mais ça permet de ne pas bloquer l'xp utilisateur.