### PR TITLE
Test that propTypes are not undefined

### DIFF
--- a/packages/@coorpacademy-components/scripts/fixture-tests.js
+++ b/packages/@coorpacademy-components/scripts/fixture-tests.js
@@ -14,6 +14,7 @@ const readFixtureTests$ = (cwd, macro) =>
       Observable.concat(
         Observable.of(
           `import test from 'ava';`,
+          `import _ from 'lodash';`,
           `import renderComponentMacro from '${join(
             relative(testPath, dirname(macro)),
             basename(macro, '.js')
@@ -24,7 +25,18 @@ const readFixtureTests$ = (cwd, macro) =>
           ({fixture, fixturePath}) =>
             `import fixture${fixture} from './${relative(testPath, fixturePath)}';`
         ),
-        Observable.of(''),
+        Observable.of(
+          ``,
+          `test('${type} › ${title} > should have valid propTypes', t => {`,
+          `  t.pass();`,
+          `  _.forEach(${title}.propTypes, (value, key) => {`,
+          `    t.not(value, undefined, \`PropType for "${type}.${
+            title
+          }.propTypes.$\{key}" may not be undefined. Did you mistype the propTypes definition?\`);`,
+          `  });`,
+          `});`,
+          ``
+        ),
         readComponentFixtures$({title, path, type}).map(
           ({fixture}) =>
             `test('${type} › ${title} › ${pascalCase(

--- a/packages/@coorpacademy-components/src/atom/loader/index.js
+++ b/packages/@coorpacademy-components/src/atom/loader/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import style from './style.css';
 
@@ -13,6 +14,10 @@ const Loader = ({className}) => {
       </div>
     </div>
   );
+};
+
+Loader.propTypes = {
+  className: PropTypes.string
 };
 
 export default Loader;

--- a/packages/@coorpacademy-components/src/template/app-player/loading/index.js
+++ b/packages/@coorpacademy-components/src/template/app-player/loading/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Loader from '../../../atom/loader';
 import style from './style.css';
 
-const PlayerLoading = props => {
+const PlayerLoading = () => {
   return (
     <div className={style.wrapper}>
       <Loader />

--- a/packages/@coorpacademy-components/src/template/back-office/dashboard-preview/index.js
+++ b/packages/@coorpacademy-components/src/template/back-office/dashboard-preview/index.js
@@ -71,6 +71,15 @@ const Dashboard = (props, context) => {
     </div>
   );
 };
+
+Dashboard.propTypes = {
+  url: PropTypes.string,
+  error: PropTypes.string,
+  selected: PropTypes.shape({
+    name: PropTypes.string
+  })
+};
+
 Dashboard.contextTypes = {
   skin: Provider.childContextTypes.skin,
   translate: Provider.childContextTypes.translate
@@ -87,6 +96,12 @@ const ErrorPopin = ({onErrorRedirect, ctaLabel, error}, {translate}) => {
       <p>{error}</p>
     </DashboardPopin>
   ) : null;
+};
+
+ErrorPopin.propTypes = {
+  onErrorRedirect: PropTypes.func.isRequired,
+  ctaLabel: PropTypes.string.isRequired,
+  error: PropTypes.string
 };
 
 ErrorPopin.contextTypes = {
@@ -119,7 +134,7 @@ const DashboardPreview = (props, context) => {
     return <Loader />;
   }
 
-  const dahsboardList = dashboards.map(d => ({
+  const dashboardList = dashboards.map(d => ({
     title: d.name,
     name: `${kebabCase(d.name)}-link`,
     type: 'link',
@@ -128,7 +143,7 @@ const DashboardPreview = (props, context) => {
     selected: d.name === get('name', currentDashboard)
   }));
 
-  const sidebarItems = [dahsboardList];
+  const sidebarItems = [dashboardList];
   if (currentDashboard) {
     sidebarItems.push(
       currentDashboardSidebarSection({
@@ -156,6 +171,7 @@ const DashboardPreview = (props, context) => {
     </div>
   );
 };
+
 DashboardPreview.contextTypes = {
   skin: Provider.childContextTypes.skin,
   translate: Provider.childContextTypes.translate
@@ -177,6 +193,7 @@ DashboardPreview.propTypes = {
     schema: PropTypes.arrayOf(PropTypes.string)
   }),
   url: PropTypes.string,
+  error: PropTypes.string,
   onSelectDashboard: PropTypes.func,
   onUpdateVersion: PropTypes.func,
   onUpdateField: PropTypes.func,


### PR DESCRIPTION
Il peut nous arriver trop facilement de faire une typo dans une declaration de propTypes, du coup je rajoute un test sur chaque composant qui valide que :
- Ils ont des propTypes
- Aucun des champs n'évalue à `undefined`.

Ça ne check pas des trucs nesté par contre, du coup faudra peut-être faire une règle ESLint pour ça :/