### PR TITLE
Adaptive

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/index.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/index.js
@@ -15,8 +15,8 @@ import last from 'lodash/fp/last';
 import filter from 'lodash/fp/filter';
 import includes from 'lodash/fp/includes';
 import intersection from 'lodash/fp/intersection';
-import type {State, Slide, Content, Engine, Config} from './types';
-import getConfig from './config';
+import type {State, Slide, Content, Engine, Config} from '../types';
+import getConfig from '../config';
 
 const isAlive = (state: State): boolean => state.lives > 0;
 const hasRemainingLifeRequests = (state: State): boolean => state.remainingLifeRequests > 0;

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/rule-engine/condition-operators.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/rule-engine/condition-operators.js
@@ -1,0 +1,53 @@
+// @flow
+import sortBy from 'lodash/fp/sortBy';
+import negate from 'lodash/fp/negate';
+import isEqual from 'lodash/fp/isEqual';
+
+// eslint-disable-next-line flowtype/no-weak-types
+const IN = (expectedValues: Array<any>, value: any): boolean => {
+  // TODO We may need to look at whether the order of items is important.
+  // We need to extract that from the slide or add an addition operator for when the order matters.
+  // Or maybe this is not important anymore, but we need to take a look at this before shipping.
+  return expectedValues.some(isEqual(value));
+};
+
+// eslint-disable-next-line flowtype/no-weak-types
+const EQUALS = (expectedValues: Array<any>, value: any): boolean => {
+  return isEqual(expectedValues[0], value);
+};
+
+const BETWEEN = (expectedValues: Array<number>, value: number): boolean => {
+  const [min, max] = sortBy(v => v, expectedValues);
+  return min <= value && value <= max;
+};
+
+const LT = (expectedValues: Array<number>, value: number): boolean => {
+  return value < expectedValues[0];
+};
+
+const GT = (expectedValues: Array<number>, value: number): boolean => {
+  return value > expectedValues[0];
+};
+
+const operators = {
+  IN,
+  NOT_IN: negate(IN),
+  EQUALS,
+  NOT_EQUALS: negate(EQUALS),
+  BETWEEN,
+  NOT_BETWEEN: negate(BETWEEN),
+  LT,
+  GTE: negate(LT),
+  GT,
+  LTE: negate(GT)
+};
+
+const checkCondition = (
+  operator: $Keys<typeof operators>,
+  expectedValues: any, // eslint-disable-line flowtype/no-weak-types
+  value: any // eslint-disable-line flowtype/no-weak-types
+): boolean => {
+  return operators[operator](expectedValues, value);
+};
+
+export default checkCondition;

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/rule-engine/select-rule.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/rule-engine/select-rule.js
@@ -1,0 +1,49 @@
+// @flow
+import type {Content, State} from '../../types';
+
+type Target =
+  | {
+      scope: 'state',
+      field: 'lives' | 'stars'
+    }
+  | {
+      scope: 'variables',
+      field: string
+    }
+  | {
+      scope: 'currentSlide',
+      field: 'isCorrect' | 'answer'
+    };
+
+type Condition =
+  | {
+      target: Target,
+      operator: 'EQUALS' | 'NOT_EQUALS' | 'IN' | 'NOT_IN',
+      values: Array<any> // eslint-disable-line flowtype/no-weak-types
+    }
+  | {
+      target: Target,
+      operator: 'LT' | 'LTE' | 'GT' | 'GTE' | 'BETWEEN' | 'NOT_BETWEEN',
+      values: Array<number>
+    };
+
+type Instruction = {
+  field: string,
+  type: 'add',
+  value: number
+};
+
+export type ChapterRule = {
+  source: Content,
+  destination: Content,
+  instructions: Array<Instruction>,
+  conditions: Array<Condition>,
+  priority: number,
+  ref: string
+};
+
+const selectRule = (rules: Array<ChapterRule>, state: State): ChapterRule => {
+  return rules[0] || null;
+};
+
+export default selectRule;

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/rule-engine/test/condition-operators.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/rule-engine/test/condition-operators.js
@@ -1,0 +1,110 @@
+// @flow
+import test from 'ava';
+import _checkCondition from '../condition-operators';
+
+const checkCondition = (t, [opNormal, opNegative]) => (
+  expectedResult: boolean,
+  expectedValues: any, // eslint-disable-line flowtype/no-weak-types
+  value: any // eslint-disable-line flowtype/no-weak-types
+) => {
+  t.is(_checkCondition(opNormal, expectedValues, value), expectedResult);
+  t.is(_checkCondition(opNegative, expectedValues, value), !expectedResult);
+};
+
+test('should return true for IN (false for NOT_IN) condition if value is among the expected values', t => {
+  const check = checkCondition(t, ['IN', 'NOT_IN']);
+
+  check(true, [1, 2, 3], 1);
+  check(true, [1, 2, 3], 2);
+  check(true, [1, 2, 3], 3);
+  check(true, ['foo', 'bar', 'baz'], 'bar');
+  check(true, [['foo', 'bar']], ['foo', 'bar']);
+});
+
+test('should return false for IN (true for NOT_IN) condition if value is not among the expected values', t => {
+  const check = checkCondition(t, ['IN', 'NOT_IN']);
+
+  check(false, [1, 2, 3], 4);
+  check(false, [1, 2, 3], -1);
+  check(false, [1, 2, 3], 'no');
+  check(false, ['foo', 'bar', 'baz'], 'no');
+  check(false, ['foo', 'bar', 'baz'], 1);
+  check(false, [['foo', 'bar']], ['foo', 'baz']);
+  check(false, [['foo', 'bar']], ['bar', 'foo']);
+});
+
+test('should return true for EQUALS (false for NOT_EQUALS) condition if value is among the first expected value', t => {
+  const check = checkCondition(t, ['EQUALS', 'NOT_EQUALS']);
+
+  check(true, [1], 1);
+  check(true, [1, 2, 3], 1);
+  check(true, ['foo'], 'foo');
+  check(true, [['foo', 'bar']], ['foo', 'bar']);
+});
+
+test('should return false for EQUALS (true for NOT_EQUALS) condition if value is not the first expected value', t => {
+  const check = checkCondition(t, ['EQUALS', 'NOT_EQUALS']);
+
+  check(false, [1], 4);
+  check(false, [1, 4], 4);
+  check(false, [1], -1);
+  check(false, [1], 'no');
+  check(false, ['foo', 'bar', 'baz'], 'bar');
+  check(false, ['foo', 'bar', 'baz'], 1);
+  check(false, [['foo', 'bar']], ['foo', 'baz']);
+  check(false, [['foo', 'bar']], ['bar', 'foo']);
+});
+
+test('should return true for BETWEEN (false for NOT_BETWEEN) condition if value is between the two first elements (included)', t => {
+  const check = checkCondition(t, ['BETWEEN', 'NOT_BETWEEN']);
+
+  check(true, [5, 10], 8);
+  check(true, [5, 10], 5);
+  check(true, [5, 10], 10);
+  check(true, [10, 5], 8);
+  check(true, [-100, 0], -8);
+});
+
+test('should return "false" for BETWEEN (false for NOT_BETWEEN) condition if value is not between the two first elements', t => {
+  const check = checkCondition(t, ['BETWEEN', 'NOT_BETWEEN']);
+
+  check(false, [5, 10], 4);
+  check(false, [5, 10], 10.001);
+  check(false, [10, 5], 3);
+  check(false, [10, 5], 13);
+  check(false, [-100, 0], 8);
+});
+
+test('should return true for LT (false for GTE) condition if value is less than expected value', t => {
+  const check = checkCondition(t, ['LT', 'GTE']);
+
+  check(true, [1], 0);
+  check(true, [1], -10);
+  check(true, [10], -10);
+});
+
+test('should return false for LT (true for GTE) condition if value is greater or equal than expected value', t => {
+  const check = checkCondition(t, ['LT', 'GTE']);
+
+  check(false, [1], 10);
+  check(false, [1], 1);
+  check(false, [-5], 0);
+  check(false, [-10], 10);
+});
+
+test('should return true for GT (false for LTE) condition if value is greater than expected value', t => {
+  const check = checkCondition(t, ['GT', 'LTE']);
+
+  check(true, [1], 10);
+  check(true, [-5], 0);
+  check(true, [-10], 10);
+});
+
+test('should return false for GT (true for GTE) condition if value is less or equal than expected value', t => {
+  const check = checkCondition(t, ['GT', 'LTE']);
+
+  check(false, [1], 0);
+  check(false, [1], -10);
+  check(false, [1], 1);
+  check(false, [10], -10);
+});

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/rule-engine/test/fixtures/chapter-rules.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/rule-engine/test/fixtures/chapter-rules.js
@@ -1,0 +1,213 @@
+// @flow
+import type {ChapterRule} from '../../select-rule';
+
+const rules: Array<ChapterRule> = [
+  {
+    ref: 'start point 1',
+    source: {
+      type: 'slide',
+      ref: ''
+    },
+    destination: {
+      type: 'slide',
+      ref: '1.A1.1'
+    },
+    priority: 10,
+    instructions: [],
+    conditions: []
+  },
+
+  {
+    ref: '1.A1.1 right answer',
+    source: {
+      type: 'slide',
+      ref: '1.A1.1'
+    },
+    destination: {
+      type: 'slide',
+      ref: '1.A1.2'
+    },
+    priority: 10,
+    instructions: [
+      {
+        field: 'stars',
+        type: 'add',
+        value: 4
+      }
+    ],
+    conditions: [
+      {
+        target: {
+          scope: 'state',
+          field: 'lives'
+        },
+        operator: 'EQUALS',
+        values: [3]
+      }
+    ]
+  },
+  {
+    ref: '1.A1.1 default',
+    source: {
+      type: 'slide',
+      ref: '1.A1.1'
+    },
+    destination: {
+      type: 'slide',
+      ref: '1.A1.3'
+    },
+    priority: 11,
+    instructions: [
+      {
+        field: 'lives',
+        type: 'add',
+        value: -1
+      }
+    ],
+    conditions: []
+  },
+
+  {
+    ref: '1.A1.2 right answer',
+    source: {
+      type: 'slide',
+      ref: '1.A1.2'
+    },
+    destination: {
+      type: 'slide',
+      ref: '1.A1.4'
+    },
+    priority: 10,
+    instructions: [
+      {
+        field: 'stars',
+        type: 'add',
+        value: 4
+      }
+    ],
+    conditions: [
+      {
+        target: {
+          scope: 'state',
+          field: 'lives'
+        },
+        operator: 'EQUALS',
+        values: [3]
+      },
+      {
+        target: {
+          scope: 'variables',
+          field: 'blabla'
+        },
+        operator: 'LT',
+        values: [2]
+      }
+    ]
+  },
+  {
+    ref: '1.A1.2 default',
+    source: {
+      type: 'slide',
+      ref: '1.A1.2'
+    },
+    destination: {
+      type: 'slide',
+      ref: '1.A1.5'
+    },
+    priority: 11,
+    instructions: [
+      {
+        field: 'lives',
+        type: 'add',
+        value: -1
+      }
+    ],
+    conditions: []
+  },
+
+  {
+    ref: 'non-conditional-rule correct',
+    source: {
+      type: 'slide',
+      ref: 'slideWithAnswers'
+    },
+    destination: {
+      type: 'chapter',
+      ref: '1.A3'
+    },
+    priority: 10,
+    instructions: [],
+    conditions: [
+      {
+        target: {
+          scope: 'currentSlide',
+          field: 'isCorrect'
+        },
+        operator: 'EQUALS',
+        values: [true]
+      }
+    ]
+  },
+
+  {
+    ref: 'non-conditional-rule default',
+    source: {
+      type: 'slide',
+      ref: 'slideWithAnswers'
+    },
+    destination: {
+      type: 'chapter',
+      ref: '1.A4'
+    },
+    priority: 11,
+    instructions: [],
+    conditions: []
+  },
+
+  {
+    ref: 'switch chapter',
+    source: {
+      type: 'slide',
+      ref: 'lastChapterSlide'
+    },
+    destination: {
+      type: 'chapter',
+      ref: '1.A2'
+    },
+    priority: 10,
+    instructions: [],
+    conditions: []
+  },
+
+  {
+    ref: 'complete module',
+    source: {
+      type: 'slide',
+      ref: 'lastModuleSlide'
+    },
+    destination: {
+      type: 'exitNode',
+      ref: 'exitNode-success'
+    },
+    priority: 11,
+    instructions: [],
+    conditions: []
+  },
+
+  {
+    ref: 'fail module',
+    source: {
+      type: 'slide',
+      ref: 'lastModuleSlide_FAIL'
+    },
+    destination: {
+      type: 'exitNode',
+      ref: 'exitNode-fail'
+    },
+    priority: 11,
+    instructions: [],
+    conditions: []
+  }
+];
+
+export default rules;

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/rule-engine/test/select-rule.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/rule-engine/test/select-rule.js
@@ -1,0 +1,45 @@
+// @flow
+import test from 'ava';
+import selectRule from '../select-rule';
+import rules from './fixtures/chapter-rules';
+
+const createState = nextContent => ({
+  nextContent,
+  lives: 3,
+  stars: 0,
+  livesDisabled: true,
+  isCorrect: true,
+  slides: [],
+  requestedClues: [],
+  viewedResources: [],
+  step: {
+    current: 0
+  },
+  remainingLifeRequests: 0,
+  hasViewedAResourceAtThisStep: false
+});
+
+test('should return null if no rules match', t => {
+  const state = createState({type: 'slide', ref: ''});
+  const rule = selectRule([], state);
+  t.is(rule, null);
+});
+
+test('should select the rule with source "" when state has no nextContent', t => {
+  const state = createState({type: 'slide', ref: ''}); // TODO Need to find a way to initialize states
+  const rule = selectRule(rules, state);
+  t.deepEqual(rule, {
+    ref: 'start point 1',
+    source: {
+      type: 'slide',
+      ref: ''
+    },
+    destination: {
+      type: 'slide',
+      ref: '1.A1.1'
+    },
+    priority: 10,
+    instructions: [],
+    conditions: []
+  });
+});

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.js
@@ -6,8 +6,8 @@ import merge from 'lodash/fp/merge';
 import pipe from 'lodash/fp/pipe';
 import find from 'lodash/fp/find';
 import omit from 'lodash/fp/omit';
-import type {State} from '../types';
-import computeNextStep from '../compute-next-step';
+import type {State} from '../../types';
+import computeNextStep from '..';
 import allSlides from './fixtures/slides';
 import {stateBeforeGettingNextContent} from './fixtures/states';
 

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.learner.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.learner.js
@@ -1,7 +1,7 @@
 // @flow
 import test from 'ava';
-import type {Slide, State} from '../types';
-import computeNextStep from '../compute-next-step';
+import type {Slide, State} from '../../types';
+import computeNextStep from '..';
 import allSlides from './fixtures/slides';
 import {stateBeforeGettingNextContent, failProgressionState} from './fixtures/states';
 

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.microlearning.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.microlearning.js
@@ -1,7 +1,7 @@
 // @flow
 import test from 'ava';
-import type {State} from '../types';
-import computeNextStep from '../compute-next-step';
+import type {State} from '../../types';
+import computeNextStep from '..';
 import allSlides from './fixtures/slides';
 import {
   stateBeforeGettingNextContent,

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/fixtures/slides.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/fixtures/slides.js
@@ -1,5 +1,5 @@
 // @flow
-import {type Slide} from '../../types';
+import {type Slide} from '../../../types';
 
 const slides: Array<Slide> = [
   {

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/fixtures/states.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/fixtures/states.js
@@ -1,0 +1,119 @@
+// @flow
+import {type State} from '../../../types';
+
+export const stateBeforeGettingNextContent: State = {
+  content: {
+    ref: '1.A1.1',
+    type: 'slide'
+  },
+  nextContent: {
+    ref: 'none',
+    type: 'node'
+  },
+  lives: 1,
+  livesDisabled: false,
+  stars: 0,
+  slides: ['1.A1.1'],
+  requestedClues: [],
+  viewedResources: [],
+  isCorrect: true,
+  step: {
+    current: 1
+  },
+  remainingLifeRequests: 1,
+  hasViewedAResourceAtThisStep: false
+};
+
+export const failProgressionState: State = {
+  content: {
+    ref: '1.A1.2',
+    type: 'slide'
+  },
+  nextContent: {
+    ref: 'none',
+    type: 'node'
+  },
+  lives: 0,
+  livesDisabled: false,
+  isCorrect: false,
+  slides: ['1.A1.1', '1.A1.2'],
+  step: {
+    current: 3
+  },
+  requestedClues: [],
+  viewedResources: [],
+  stars: 4,
+  remainingLifeRequests: 0,
+  hasViewedAResourceAtThisStep: false
+};
+
+export const extraLifeProgressionState: State = {
+  content: {
+    ref: '1.A1.2',
+    type: 'slide'
+  },
+  nextContent: {
+    ref: 'none',
+    type: 'node'
+  },
+  lives: 0,
+  livesDisabled: false,
+  isCorrect: false,
+  slides: ['1.A1.1', '1.A1.2'],
+  step: {
+    current: 3,
+    total: 4
+  },
+  requestedClues: [],
+  viewedResources: [],
+  stars: 4,
+  remainingLifeRequests: 1,
+  hasViewedAResourceAtThisStep: true
+};
+
+export const extraLifeAlreadyRefusedProgressionState: State = {
+  content: {
+    ref: 'extraLife',
+    type: 'node'
+  },
+  nextContent: {
+    ref: 'none',
+    type: 'node'
+  },
+  lives: 0,
+  livesDisabled: false,
+  isCorrect: false,
+  slides: ['1.A1.1', '1.A1.2'],
+  step: {
+    current: 3,
+    total: 4
+  },
+  requestedClues: [],
+  viewedResources: [],
+  stars: 4,
+  remainingLifeRequests: 4,
+  hasViewedAResourceAtThisStep: false
+};
+
+export const successProgressionState: State = {
+  content: {
+    ref: '1.A1.4',
+    type: 'slide'
+  },
+  nextContent: {
+    ref: 'none',
+    type: 'node'
+  },
+  lives: 1,
+  livesDisabled: false,
+  isCorrect: true,
+  slides: ['1.A1.1', '1.A1.3', '1.A1.2', '1.A1.4'],
+  step: {
+    current: 4
+  },
+  requestedClues: [],
+  viewedResources: [],
+  stars: 16,
+  remainingLifeRequests: 1,
+  hasViewedAResourceAtThisStep: false
+};

--- a/packages/@coorpacademy-progression-engine/src/test/fixtures/states.js
+++ b/packages/@coorpacademy-progression-engine/src/test/fixtures/states.js
@@ -1,29 +1,6 @@
 // @flow
 import {type State} from '../../types';
 
-export const stateBeforeGettingNextContent: State = {
-  content: {
-    ref: '1.A1.1',
-    type: 'slide'
-  },
-  nextContent: {
-    ref: 'none',
-    type: 'node'
-  },
-  lives: 1,
-  livesDisabled: false,
-  stars: 0,
-  slides: ['1.A1.1'],
-  requestedClues: [],
-  viewedResources: [],
-  isCorrect: true,
-  step: {
-    current: 1
-  },
-  remainingLifeRequests: 1,
-  hasViewedAResourceAtThisStep: false
-};
-
 export const stateForFirstSlide: State = {
   content: undefined,
   nextContent: {
@@ -67,29 +44,6 @@ export const stateForSecondSlide: State = {
   hasViewedAResourceAtThisStep: false
 };
 
-export const failProgressionState: State = {
-  content: {
-    ref: '1.A1.2',
-    type: 'slide'
-  },
-  nextContent: {
-    ref: 'none',
-    type: 'node'
-  },
-  lives: 0,
-  livesDisabled: false,
-  isCorrect: false,
-  slides: ['1.A1.1', '1.A1.2'],
-  step: {
-    current: 3
-  },
-  requestedClues: [],
-  viewedResources: [],
-  stars: 4,
-  remainingLifeRequests: 0,
-  hasViewedAResourceAtThisStep: false
-};
-
 export const extraLifeProgressionState: State = {
   content: {
     ref: '1.A1.2',
@@ -112,51 +66,4 @@ export const extraLifeProgressionState: State = {
   stars: 4,
   remainingLifeRequests: 1,
   hasViewedAResourceAtThisStep: true
-};
-
-export const extraLifeAlreadyRefusedProgressionState: State = {
-  content: {
-    ref: 'extraLife',
-    type: 'node'
-  },
-  nextContent: {
-    ref: 'none',
-    type: 'node'
-  },
-  lives: 0,
-  livesDisabled: false,
-  isCorrect: false,
-  slides: ['1.A1.1', '1.A1.2'],
-  step: {
-    current: 3,
-    total: 4
-  },
-  requestedClues: [],
-  viewedResources: [],
-  stars: 4,
-  remainingLifeRequests: 4,
-  hasViewedAResourceAtThisStep: false
-};
-
-export const successProgressionState: State = {
-  content: {
-    ref: '1.A1.4',
-    type: 'slide'
-  },
-  nextContent: {
-    ref: 'none',
-    type: 'node'
-  },
-  lives: 1,
-  livesDisabled: false,
-  isCorrect: true,
-  slides: ['1.A1.1', '1.A1.3', '1.A1.2', '1.A1.4'],
-  step: {
-    current: 4
-  },
-  requestedClues: [],
-  viewedResources: [],
-  stars: 16,
-  remainingLifeRequests: 1,
-  hasViewedAResourceAtThisStep: false
 };


### PR DESCRIPTION
- Début du calcul de sélection de la règle des chapterRules appropriés. La fonction est créé mais incomplète et inutilisée.
- Création de la fonction de calcul des conditions. Finie mais pas encore utilisée dans la fonction décrite ci-dessus.
- Création de fixtures pour les chapterRules, et typage des chapterRules (sous le format attendu par progression-engine)
- Quelques déplacement de fichiers
Je n'ai pas repris le travail fait dans https://github.com/CoorpAcademy/components/pull/1127, car je trouve qu'il y a énormément de changements/refactos dont je ne suis pas sûr (beaucoup de refacto qui a été fait avant qu'on en re-discute ensemble et qu'on ait proposé pas mal de changements). Je préfère faire les refactos un peu plus au fur et à mesure.

Note : Il y a peut-être un cas un poil compliqué (à vérifier) avec la condition EQUALS/NOT_EQUALS. Dans le MOOC, on traduisait le contenu, donc c'était à priori à but de comparer des réponses. Le MOOC regardait aussi s'il fallait respecter l'ordre des réponses, ce qui était fait en fonction d'un champ du slide. Je crois que dans le checkAnswer, on ne fait plus la comparaison par ordre en fonction de ce champ du slide, mais simplement en fonction du type de la slide. Pour l'instant, je n'ai pas implémenté le non-respect potentiel de l'ordre, et il faut voir si on veut l'implementer (si oui, il faudra passer plus d'infos aux conditions (et peut-être même au computeNextStep).