### PR TITLE
Fix logo mobile

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -514,7 +514,6 @@
 
   .logoMobile img {
     height: 100%;
-    width: 100%;
     max-height: 50px;
     max-width: 100px;
     display: block;

--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -102,7 +102,7 @@
 }
 
 .caret {
-  margin: 2px 0 0 10px;
+  margin: 2px 0 0 15px;
   color: medium;
   width: 10px;
   height: 10px;


### PR DESCRIPTION
https://trello.com/c/ixOXHAhP/700-logo-header-avec-les-svg
`width: 100%` étirait les logos sur chrome
Le badge de notifications était trop sur le logo en mobile.