### PR TITLE
Icon Coach color modification -> light

### DIFF
--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/slides-footer/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/slides-footer/style.css
@@ -46,7 +46,7 @@
 }
 
 .disabled .logo {
-  color: xtraLightGrey;
+  color: light;
 }
 
 .disabled .title {


### PR DESCRIPTION
Nova Icon Logo disabled color Modification (from xtraLightGrey to light) as the text below it.