### PR TITLE
Check answer: Trim answer before checking the correctness

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
+++ b/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
@@ -11,6 +11,7 @@ import reverse from 'lodash/fp/reverse';
 import some from 'lodash/fp/some';
 import split from 'lodash/fp/split';
 import toLower from 'lodash/fp/toLower';
+import trim from 'lodash/fp/trim';
 import zip from 'lodash/fp/zip';
 import FuzzyMatching from 'fuzzy-matching';
 import type {
@@ -192,7 +193,7 @@ export default function checkAnswerCorrectness(
   question: Question,
   givenAnswer: Answer
 ): AnswerCorrection {
-  const matches = matchGivenAnswerToQuestion(config, question, givenAnswer);
+  const matches = matchGivenAnswerToQuestion(config, question, givenAnswer.map(trim));
   if (matches.length === 0) {
     return {
       isCorrect: false,

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.basic.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.basic.js
@@ -70,6 +70,16 @@ test('should allow typos by default', t => {
   assertIncorrect(t, config, question, ['foooooooooaaa'], [false]);
 });
 
+test('should trim the given answer before comparing', t => {
+  const question = createQuestion([['foo']], 0);
+
+  assertCorrect(t, configWithTypos, question, ['foo ']);
+  assertCorrect(t, configWithTypos, question, [' foo']);
+  assertCorrect(t, configWithTypos, question, ['     foo     ']);
+  assertIncorrect(t, configWithTypos, question, ['  fooo'], [false]);
+  assertIncorrect(t, configWithTypos, question, ['A foo'], [false]);
+});
+
 test('should be able to define the number of typos in the question', t => {
   const question = createQuestion([['foooooooooooo']], 3);
 

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.template.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.template.js
@@ -84,6 +84,21 @@ test('should allow typos in text inputs', t => {
   assertIncorrect(t, config, question, ['saut', 'parachutZZZe'], [true, false]);
 });
 
+test('should allow and ignore blank spaces in text inputs', t => {
+  const question = createQuestion(
+    [['2', 'un'], ['deux', 'un'], ['saut', 'parachute']],
+    ['text', 'text']
+  );
+
+  assertCorrect(t, config, question, ['saut  ', 'parachute']);
+  assertCorrect(t, config, question, ['  saut', 'parachute']);
+  assertCorrect(t, config, question, ['saut', '  parachute']);
+  assertCorrect(t, config, question, ['saut', 'parachute  ']);
+  assertCorrect(t, config, question, ['  saut  ', '  parachute  ']);
+  assertIncorrect(t, config, question, ['  sauZZZZZt', '  parachute'], [false, true]);
+  assertIncorrect(t, config, question, ['saut  ', 'parachutZZZe  '], [true, false]);
+});
+
 test('should use the maxTypos value from the question if available', t => {
   const questionWithTypos0 = createQuestion([['parachute']], ['text'], 0);
   const questionWithTypos3 = createQuestion([['parachute']], ['text'], 3);

--- a/packages/@coorpacademy-progression-engine/src/test/helpers/assert-check-answer-correctness.js
+++ b/packages/@coorpacademy-progression-engine/src/test/helpers/assert-check-answer-correctness.js
@@ -1,6 +1,7 @@
 // @flow
 import map from 'lodash/fp/map';
 import pipe from 'lodash/fp/pipe';
+import trim from 'lodash/fp/trim';
 import zip from 'lodash/fp/zip';
 import checkAnswerCorrectness from '../../check-answer-correctness';
 import type {Question, Answer, Config} from '../../types';
@@ -11,7 +12,7 @@ export function assertCorrect(t: any, config: Config, question: Question, givenA
   t.true(result.isCorrect, 'Answer should have been considered as correct');
   t.deepEqual(
     result.corrections,
-    givenAnswer.map(answer => ({answer, isCorrect: true})),
+    givenAnswer.map(answer => ({answer: trim(answer), isCorrect: true})),
     'All sub-answers should be considered correct'
   );
 }
@@ -32,7 +33,7 @@ export function assertIncorrect(
   t.false(result.isCorrect, 'Answer should have been considered as incorrect');
   t.deepEqual(
     result.corrections,
-    pipe(zip(givenAnswer), map(([answer, isCorrect]) => ({answer, isCorrect})))(
+    pipe(zip(givenAnswer), map(([answer, isCorrect]) => ({answer: trim(answer), isCorrect})))(
       expectedCorrections
     ),
     'Some sub-answers were not correctly marked as correct'


### PR DESCRIPTION
Des utilisateurs ont remonté qu'ils avaient faux lorsqu'ils rentraient `foo ` alors qu'on attendait `foo`. Du coup, maintenant on trim les réponses avant de les comparer.