### PR TITLE
Check answer: Trim allowed answers before checking the correctness

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
+++ b/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
@@ -56,10 +56,11 @@ function containsAnswer(config: Config, allowedAnswer: string, givenAnswer: stri
 
 function isTextCorrect(
   config: Config,
-  allowedAnswers: Answer,
+  _allowedAnswers: Answer,
   answerWithCase: string,
   _maxTypos: ?number
 ): boolean {
+  const allowedAnswers = _allowedAnswers.map(trim);
   const fm = new FuzzyMatching(allowedAnswers);
   const maxTypos = _maxTypos === 0 ? _maxTypos : _maxTypos || config.maxTypos;
   const answer = toLower(answerWithCase);
@@ -161,7 +162,7 @@ function matchGivenAnswerToQuestion(
   question: Question,
   givenAnswer: Answer
 ): Array<Array<PartialCorrection>> {
-  const allowedAnswers = question.content.answers;
+  const allowedAnswers = question.content.answers.map(answer => answer.map(trim));
   switch (question.type) {
     case 'basic': {
       return matchAnswerForBasic(config, question, givenAnswer);

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.basic.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.basic.js
@@ -80,6 +80,16 @@ test('should trim the given answer before comparing', t => {
   assertIncorrect(t, configWithTypos, question, ['A foo'], [false]);
 });
 
+test('should trim the accepted answers before comparing', t => {
+  const question = createQuestion([[' foo ']], 0);
+
+  assertCorrect(t, configWithTypos, question, ['foo ']);
+  assertCorrect(t, configWithTypos, question, [' foo']);
+  assertCorrect(t, configWithTypos, question, ['     foo     ']);
+  assertIncorrect(t, configWithTypos, question, ['  fooo'], [false]);
+  assertIncorrect(t, configWithTypos, question, ['A foo'], [false]);
+});
+
 test('should be able to define the number of typos in the question', t => {
   const question = createQuestion([['foooooooooooo']], 3);
 

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm.js
@@ -98,3 +98,11 @@ test('should return false when there are no correct answers', t => {
   assertIncorrectEmptyAnswer(t, config, question, []);
   assertIncorrectEmptyAnswer(t, config, question, ['foo']);
 });
+
+test('should trim the given and accepted answers before comparing', t => {
+  const question = createQuestion([['  answer1', '  answer3   ']]);
+
+  assertCorrect(t, config, question, ['answer1', 'answer3']);
+  assertCorrect(t, config, question, ['answer1   ', '  answer3']);
+  assertIncorrect(t, config, question, ['answer2', 'answer3'], [false, true]);
+});


### PR DESCRIPTION
Améliore la vérification des réponses en trimmant la réponse des deux côtés (car des espaces se sont infiltrés côté Cockpit et donc dans les contenus)