### PR TITLE
Fix lives icon display in adaptive mode

### DIFF
--- a/packages/@coorpacademy-app-player/src/store/utils/state-extract.js
+++ b/packages/@coorpacademy-app-player/src/store/utils/state-extract.js
@@ -75,6 +75,10 @@ export const getCurrentChapter = state => {
   const chapterId = getCurrentChapterId(state);
   return getContent('chapter', chapterId)(state);
 };
+export const isContentAdaptive = state => {
+  const chapter = getCurrentChapter(state);
+  return getOr(false, 'isConditional', chapter);
+};
 export const hasViewedAResourceAtThisStep = pipe(
   getCurrentProgression,
   get('state.hasViewedAResourceAtThisStep')

--- a/packages/@coorpacademy-app-player/src/store/utils/test/state-extract.js
+++ b/packages/@coorpacademy-app-player/src/store/utils/test/state-extract.js
@@ -25,7 +25,8 @@ import {
   getResourceToPlay,
   getNextContent,
   hasViewedAResourceAtThisStep,
-  getQuestionMedia
+  getQuestionMedia,
+  isContentAdaptive
 } from '../state-extract';
 
 test('getChoices should get choices from state', t => {
@@ -366,4 +367,24 @@ test('getQuestionMedia should return video media from state', t => {
     mimeType: 'application/vimeo',
     videoId: '231095700'
   });
+});
+
+test('isContentAdaptive should return if content is adaptive or not', t => {
+  const slide = {_id: 42, chapter_id: 1337};
+  const nextContent = {ref: 42, type: 'slide'};
+  const progression = {state: {nextContent}};
+
+  const getState = isConditional => {
+    const chapter = {_id: 1337, isConditional};
+
+    return pipe(
+      set('ui.current.progressionId', 12),
+      set('data.progressions.entities', {12: progression}),
+      set('data.contents.chapter.entities', {1337: chapter}),
+      set('data.contents.slide.entities', {42: slide})
+    )({});
+  };
+
+  t.true(isContentAdaptive(getState(true)));
+  t.false(isContentAdaptive(getState(false)));
 });

--- a/packages/@coorpacademy-app-player/src/store/view/state-to-props/header.js
+++ b/packages/@coorpacademy-app-player/src/store/view/state-to-props/header.js
@@ -1,7 +1,13 @@
 import get from 'lodash/fp/get';
 import getOr from 'lodash/fp/getOr';
 import indexOf from 'lodash/fp/indexOf';
-import {getCurrentChapter, getEngine, getLives, getCurrentContent} from '../../utils/state-extract';
+import {
+  getCurrentChapter,
+  getEngine,
+  getLives,
+  getCurrentContent,
+  isContentAdaptive
+} from '../../utils/state-extract';
 import {back} from '../../actions/ui/location';
 
 const headerContent = (engineRef, state) => {
@@ -46,6 +52,10 @@ const headerSubcontent = (engineRef, state) => {
 const headerProps = (options, {dispatch}) => state => {
   const engine = getEngine(state);
   const {ref: engineRef} = engine;
+  const lives = !isContentAdaptive(state) && {
+    count: getLives(state)
+  };
+
   return {
     type: engineRef,
     content: {
@@ -53,9 +63,7 @@ const headerProps = (options, {dispatch}) => state => {
       ...headerContent(engineRef, state)
     },
     subcontent: headerSubcontent(engineRef, state),
-    lives: {
-      count: getLives(state)
-    }
+    lives
   };
 };
 

--- a/packages/@coorpacademy-app-player/src/store/view/state-to-props/player.js
+++ b/packages/@coorpacademy-app-player/src/store/view/state-to-props/player.js
@@ -2,12 +2,10 @@ import includes from 'lodash/fp/includes';
 import isEmpty from 'lodash/fp/isEmpty';
 import some from 'lodash/fp/some';
 import get from 'lodash/fp/get';
-import getOr from 'lodash/fp/getOr';
 import isNil from 'lodash/fp/isNil';
 import {
   getCoaches,
   getCurrentContent,
-  getCurrentChapter,
   getCurrentProgression,
   getCurrentSlide,
   getCurrentProgressionId,
@@ -16,7 +14,8 @@ import {
   getCurrentClue,
   getRoute,
   getQuestionMedia,
-  getNbSlides
+  getNbSlides,
+  isContentAdaptive
 } from '../../utils/state-extract';
 import hasSeenLesson from '../../utils/has-seen-lesson';
 import {validateAnswer} from '../../actions/ui/answers';
@@ -32,11 +31,6 @@ const ROUTES = ['media', 'clue', 'context', 'answer'];
 const STARS_DIFF = {
   media: 'starsPerResourceViewed',
   clue: 'starsPerAskingClue'
-};
-
-const isContentAdaptive = state => {
-  const chapter = getCurrentChapter(state);
-  return getOr(false, 'isConditional', chapter);
 };
 
 const getProgressionStep = state => {


### PR DESCRIPTION
**Detailed purpose of the PR**

![capture d ecran 2018-11-20 a 12 33 41](https://user-images.githubusercontent.com/8419208/48771071-94da2380-ecc0-11e8-8484-c1220981d4cf.png)

Lives icon is displayed even in adaptive mode: [Live demo](https://onboarding.coorpacademy.com/learner/mod_VyYDaJal7/5bf3dbf3f28223001864789a)

**Result and observation**

![capture d ecran 2018-11-20 a 12 35 11](https://user-images.githubusercontent.com/8419208/48771130-c357fe80-ecc0-11e8-89c5-b2127612d4f5.png)

Now, the lives icon is not displayed anymore in adaptive mode: [Live demo](https://wonderwoman-staging.coorpacademy.com/learner/mod_VyYDaJal7/5bf3fce20039e800183e5957)

- [ ]  **Breaking changes ?**
- [ ] **Extra lib ?** 

**How tested ?**
 - [ ] Already covered by tests
 - [x] Manual testing
 - [ ] Unit testing
