### PR TITLE
Support onClick for BrandTab

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/brand-tabs/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-tabs/index.js
@@ -5,12 +5,17 @@ import Link from '../../atom/link';
 import style from './style.css';
 
 const buildTab = (tab, index) => {
-  const {title, href, selected} = tab;
+  const {title, href, selected, onClick} = tab;
 
   const className = selected ? style.selected : style.tab;
 
   return (
-    <div data-name={`brand_tab_${snakeCase(title)}`} className={className} key={index}>
+    <div
+      data-name={`brand_tab_${snakeCase(title)}`}
+      className={className}
+      key={index}
+      onClick={onClick}
+    >
       <Link href={href}>{title}</Link>
     </div>
   );
@@ -29,7 +34,8 @@ BrandTabs.propTypes = {
     PropTypes.shape({
       title: Link.propTypes.children,
       href: Link.propTypes.href,
-      selected: PropTypes.bool
+      selected: PropTypes.bool,
+      onClick: PropTypes.func
     })
   )
 };

--- a/packages/@coorpacademy-components/src/molecule/brand-tabs/test/fixtures/analytics.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-tabs/test/fixtures/analytics.js
@@ -14,7 +14,9 @@ export default {
       {
         title: 'SSO',
         href: '#brand/samsung/sso',
-        selected: false
+        selected: false,
+        // eslint-disable-next-line no-alert
+        onClick: () => alert('Fear the SSO!')
       },
       {
         title: 'Users',


### PR DESCRIPTION
## Detailed purpose of the PR
Ajoute la possibilité de rajouter des onClick sur le composant BrandTab.
Ceci dans le but d'une utilisation de mon extension coorp, afin d'attacher une fonction qui se chargera de changer d'onglet.


### Testing Strategy

- [x] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
