### PR TITLE
Fixes the locales path for the web player

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -10,5 +10,5 @@ source_file=packages/@coorpacademy-components/locales/en/global.json
 [components.player]
 source_lang=en
 type=KEYVALUEJSON
-file_filter=packages/@coorpacademy-app-player/locales/<lang>/player.json
-source_file=packages/@coorpacademy-app-player/locales/en/player.json
+file_filter=packages/@coorpacademy-player-web/locales/<lang>/player.json
+source_file=packages/@coorpacademy-player-web/locales/en/player.json


### PR DESCRIPTION
**Detailed purpose of the PR**

This PR fixes the locales path for the web player (after it was done with refacto).

**Result and observation**

No UI change, the translations should be in transiflex as before.

- [ ] **Breaking changes ?**
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
