### PR TITLE
truncate label in multi select overlay

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/titled-checkbox/index.js
+++ b/packages/@coorpacademy-components/src/molecule/titled-checkbox/index.js
@@ -22,7 +22,9 @@ const TitledCheckbox = (props, context) => {
         {choice.selected && <Check className={style.icon} color="white" />}
         <Checkbox className={style.input} checked={choice.selected} onChange={handleChange} />
       </label>
-      <span title={label}>{label}</span>
+      <span title={label} className={style.label}>
+        {label}
+      </span>
     </div>
   );
 };

--- a/packages/@coorpacademy-components/src/molecule/titled-checkbox/style.css
+++ b/packages/@coorpacademy-components/src/molecule/titled-checkbox/style.css
@@ -12,6 +12,7 @@
   border-radius: 3px;
   cursor: pointer;
   order: 1;
+  flex: 0 22px;
 }
 
 .icon {
@@ -26,4 +27,12 @@
 .input {
   position: absolute;
   left: -9999px;
+}
+
+.label {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  user-select: none;
+  flex: 1;
 }


### PR DESCRIPTION
before:
<img width="377" alt="capture d ecran 2019-01-22 a 15 23 11" src="https://user-images.githubusercontent.com/15608581/51541673-b0e17900-1e59-11e9-8ca4-0d01453dbe27.png">

after:
<img width="377" alt="capture d ecran 2019-01-22 a 15 22 46" src="https://user-images.githubusercontent.com/15608581/51541682-b939b400-1e59-11e9-87b5-f7d58575d8b7.png">




<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
