### PR TITLE
Fix bug with computeNextSlide

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
@@ -165,9 +165,15 @@ const computeNextSlide = (
     pipe(get('_id'), (slideId: string) => !state || !includes(slideId, state.slides)),
     chapterContent.slides
   );
+  const nextSlide = pickNextSlide(remainingSlides);
+  if (isEmpty(nextSlide)) {
+    throw new Error('There is 0 remaining slides');
+  }
+
+  const nextSlideId = get('_id', nextSlide);
   return {
     type: 'slide',
-    ref: pickNextSlide(remainingSlides)._id
+    ref: nextSlideId
   };
 };
 

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.js
@@ -102,3 +102,24 @@ test('computeNextStepForNewChapter --> should return null when computeNextStep r
   const result = computeNextStepForNewChapter(config, state, chapterRule, false, availableContent);
   t.is(result, null);
 });
+
+test('computeNextStep --> should warn when there are no more slides', t => {
+  const state: State = Object.freeze(stateBeforeGettingNextContent);
+  t.throws(
+    () =>
+      computeNextStep(
+        config,
+        state,
+        [
+          {
+            ref: '1.A1',
+            slides: filter({_id: '1.A1.1'}, allSlides),
+            rules: null
+          }
+        ],
+        // $FlowFixMe
+        {type: 'foo'}
+      ),
+    'There is 0 remaining slides'
+  );
+});


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

This PR was found in the mobile project. 
When we only have a slide and try to play, we get an error because there a 0 remaining slide, so if we try to get an empty _id the app crashes because there aren't any verification to avoid this 

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
