### PR TITLE
export ERRORS enum on progression-engine

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/index.js
+++ b/packages/@coorpacademy-progression-engine/src/index.js
@@ -51,7 +51,6 @@ export type {
   LEVEL,
   SLIDE,
   NODE,
-  ERRORS,
   FAILURE,
   SUCCESS,
   Action,
@@ -91,5 +90,6 @@ export {
   createState,
   createProgression,
   getConfig,
-  getConfigForProgression
+  getConfigForProgression,
+  ERRORS
 };


### PR DESCRIPTION
fix mooc error in conflit case (409)

`Cannot read property \'STATE_VALIDATION_ERROR\' of undefined'`

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
