### PR TITLE
Moving select route correction

### DIFF
--- a/packages/@coorpacademy-player-store/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/answers.js
@@ -11,6 +11,7 @@ import {createAnswer} from '../api/progressions';
 import {fetchAnswer} from '../api/answers';
 import {fetchSlideChapter} from '../api/contents';
 import type {DispatchedAction, GetState, Options} from '../../definitions/redux';
+import {selectRoute} from './route';
 import {progressionUpdated, selectProgression} from './progressions';
 import {toggleAccordion, ACCORDION_KLF, ACCORDION_TIPS, ACCORDION_LESSON} from './corrections';
 
@@ -93,6 +94,7 @@ export const validateAnswer = (progressionId: ProgressionId, body: {answer: Answ
 ): DispatchedAction => {
   const createAnswerResponse = await dispatch(createAnswer(progressionId, body.answer));
   if (createAnswerResponse.error) return createAnswerResponse;
+  await dispatch(selectRoute('correction'));
 
   const payload = createAnswerResponse.payload;
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/route.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/route.js
@@ -1,8 +1,14 @@
+// @flow
+
 import {getCurrentProgressionId} from '../../utils/state-extract';
+import type {GetState, ThunkAction} from '../../definitions/redux';
 
 export const UI_SELECT_ROUTE = '@@ui/SELECT_ROUTE';
 
-export const selectRoute = route => (dispatch, getState) => {
+export const selectRoute = (route: string) => (
+  dispatch: Function,
+  getState: GetState
+): ThunkAction => {
   const state = getState();
   const progressionId = getCurrentProgressionId(state);
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-accordion.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-accordion.js
@@ -144,6 +144,13 @@ const answer = result => [
       }
     },
     payload: result
+  },
+  {
+    type: UI_SELECT_ROUTE,
+    payload: 'correction',
+    meta: {
+      progressionId: 'foo'
+    }
   }
 ];
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-exit-node.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-exit-node.js
@@ -9,6 +9,7 @@ import {
   PROGRESSION_CREATE_ANSWER_SUCCESS
 } from '../../../api/progressions';
 import {ANSWER_FETCH_REQUEST, ANSWER_FETCH_SUCCESS} from '../../../api/answers';
+import {UI_SELECT_ROUTE} from '../../route';
 import {accordionIsOpenAt, progressionUpdated} from './helpers/shared';
 
 const services = t => ({
@@ -83,6 +84,13 @@ test(
         set('state.content.ref', 'slideRef'),
         set('state.nextContent', {type: 'success', ref: 'successExitNode'})
       )({})
+    },
+    {
+      type: UI_SELECT_ROUTE,
+      payload: 'correction',
+      meta: {
+        progressionId: 'foo'
+      }
     },
     accordionIsOpenAt(0),
     progressionUpdated,

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-failure.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-failure.js
@@ -5,6 +5,7 @@ import flatten from 'lodash/fp/flatten';
 import macro from '../../../test/helpers/macro';
 import {validateAnswer} from '../../answers';
 import {UI_TOGGLE_ACCORDION} from '../../corrections';
+import {UI_SELECT_ROUTE} from '../../route';
 import {
   PROGRESSION_CREATE_ANSWER_REQUEST,
   PROGRESSION_CREATE_ANSWER_SUCCESS,
@@ -163,6 +164,13 @@ test(
         set('state.isCorrect', false),
         set('state.viewedResources', [])
       )({})
+    },
+    {
+      type: UI_SELECT_ROUTE,
+      payload: 'correction',
+      meta: {
+        progressionId: 'foo'
+      }
     },
     {
       type: UI_TOGGLE_ACCORDION,

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-success.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-success.js
@@ -9,6 +9,7 @@ import {
   PROGRESSION_CREATE_ANSWER_REQUEST,
   PROGRESSION_CREATE_ANSWER_SUCCESS
 } from '../../../api/progressions';
+import {UI_SELECT_ROUTE} from '../../route';
 import {ANSWER_FETCH_REQUEST, ANSWER_FETCH_SUCCESS} from '../../../api/answers';
 import {CONTENT_FETCH_REQUEST, CONTENT_FETCH_SUCCESS} from '../../../api/contents';
 import {accordionIsOpenAt, progressionUpdated} from './helpers/shared';
@@ -156,6 +157,13 @@ test(
   validateAnswer('foo', {answer: ['bar']}),
   flatten([
     createCorrectAnswer,
+    {
+      type: UI_SELECT_ROUTE,
+      payload: 'correction',
+      meta: {
+        progressionId: 'foo'
+      }
+    },
     contentFetchActions,
     accordionIsOpenAt(2),
     progressionUpdated,

--- a/packages/@coorpacademy-player-store/src/reducers/ui/route.js
+++ b/packages/@coorpacademy-player-store/src/reducers/ui/route.js
@@ -1,26 +1,11 @@
 import set from 'lodash/fp/set';
 import unset from 'lodash/fp/unset';
 import isNull from 'lodash/fp/isNull';
-import {
-  PROGRESSION_CREATE_ANSWER_REQUEST,
-  PROGRESSION_CREATE_ANSWER_SUCCESS
-} from '../../actions/api/progressions';
 import {UI_SELECT_ROUTE} from '../../actions/ui/route';
 import {UI_PROGRESSION_ACTION_TYPES} from '../../actions/ui/progressions';
 
 const uiRouteReducer = (state = {}, {type, payload, meta}) => {
   switch (type) {
-    case PROGRESSION_CREATE_ANSWER_SUCCESS: {
-      const {progressionId} = meta;
-      const {state: {isCorrect}} = payload;
-
-      if (!isNull(isCorrect)) return state;
-      return unset(progressionId, state);
-    }
-    case PROGRESSION_CREATE_ANSWER_REQUEST: {
-      const {progressionId} = meta;
-      return set(progressionId, 'correction', state);
-    }
     case UI_PROGRESSION_ACTION_TYPES.SELECT_PROGRESSION: {
       const {id: progressionId} = payload;
       return unset(progressionId, state);

--- a/packages/@coorpacademy-player-store/src/reducers/ui/test/route.js
+++ b/packages/@coorpacademy-player-store/src/reducers/ui/test/route.js
@@ -1,7 +1,6 @@
 import test from 'ava';
 import reducer from '../route';
 import {UI_SELECT_ROUTE} from '../../../actions/ui/route';
-import {PROGRESSION_CREATE_ANSWER_REQUEST} from '../../../actions/api/progressions';
 import macro from '../../test/helpers/macro';
 
 test('should have initial value', macro, reducer, undefined, {}, {});
@@ -39,22 +38,5 @@ test(
   },
   {
     foo: 'answer'
-  }
-);
-
-test(
-  'should redirect to correction page',
-  macro,
-  reducer,
-  undefined,
-  {
-    type: PROGRESSION_CREATE_ANSWER_REQUEST,
-    meta: {
-      progressionId: 'foo'
-    },
-    payload: 'correction'
-  },
-  {
-    foo: 'correction'
   }
 );


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

`ui.route = correction` was updated on CREATE_ANSWER which is not what we want on mobile app.

**Result and observation**

- manually call `selectRoute('correction')` just after `createAnswer()` for web action `validateAnswer`.
- mobile app can now implement a custom `validateAnswer` and call `selectRoute('correction')` when it is suited.

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [x] Unit testing
