### PR TITLE
updating hasLessonView to check previousSlide

### DIFF
--- a/packages/@coorpacademy-player-store/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/answers.js
@@ -143,7 +143,7 @@ export const validateAnswer = () => async (
 
   if (isCorrect) {
     await dispatch(toggleAccordion(ACCORDION_TIPS));
-  } else if (nextContentRef !== 'extraLife' && hasSeenLesson(state)) {
+  } else if (nextContentRef !== 'extraLife' && hasSeenLesson(state, true)) {
     await dispatch(toggleAccordion(ACCORDION_KLF));
   } else {
     await dispatch(toggleAccordion(ACCORDION_LESSON));

--- a/packages/@coorpacademy-player-store/src/actions/ui/video.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/video.js
@@ -49,7 +49,9 @@ DispatchedAction => {
   }
 
   const selectedResourceId: string = getResourceToPlay(state);
-  const resource: Lesson = resources.filter(r => r._id === selectedResourceId)[0];
+  const resource: Lesson = selectedResourceId
+    ? resources.filter(r => r._id === selectedResourceId)[0]
+    : resources[0];
 
   await dispatch(sendMediaViewed(resource));
   await dispatch(markResourceAsViewed(progressionId, resource));

--- a/packages/@coorpacademy-player-store/src/utils/state-extract.js
+++ b/packages/@coorpacademy-player-store/src/utils/state-extract.js
@@ -483,14 +483,14 @@ export const getLives = (state: State): Lives => {
 
 export const getCoaches: State => number = getOr(0, 'ui.coaches.availableCoaches');
 
-export const hasSeenLesson = (state: State): boolean => {
+export const hasSeenLesson = (state: State, onPreviousSlide: boolean = false): boolean => {
   const progression = getCurrentProgression(state);
 
   if (!progression || !progression.state) {
     return false;
   }
 
-  const slide = getCurrentSlide(state) || getPreviousSlide(state);
+  const slide = onPreviousSlide ? getPreviousSlide(state) : getCurrentSlide(state);
 
   if (!slide) {
     return false;

--- a/packages/@coorpacademy-player-store/src/utils/test/state-extract.js
+++ b/packages/@coorpacademy-player-store/src/utils/test/state-extract.js
@@ -981,7 +981,7 @@ test('getContentInfo should return chapter.info', t => {
   });
 });
 
-test('should return true if side is at previous step and at least one lesson has been seen', t => {
+test('should return true if slide is at previous step and at least one lesson has been seen', t => {
   const state = Object.freeze(slideFixture);
   const slide = getCurrentSlide(state);
   const result = hasSeenLesson(
@@ -992,7 +992,8 @@ test('should return true if side is at previous step and at least one lesson has
         ref: slide._id
       }),
       setViewedResources(slide.lessons[0].ref, slide.chapter_id)
-    )(state)
+    )(state),
+    true
   );
 
   return t.is(result, true);


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- fixed lesson viewed check for PREVIOUS slide
- put back default resource to `action.ui.video.play()`

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [x] Unit testing
