### PR TITLE
Update createProgression workflow

### DIFF
--- a/packages/@coorpacademy-player-services/src/progressions.js
+++ b/packages/@coorpacademy-player-services/src/progressions.js
@@ -9,7 +9,6 @@ import {
   getConfig,
   getConfigForProgression
 } from '@coorpacademy/progression-engine';
-import uniqueId from 'lodash/fp/uniqueId';
 import update from 'lodash/fp/update';
 import pipe from 'lodash/fp/pipe';
 import filter from 'lodash/fp/filter';
@@ -41,7 +40,7 @@ type AcceptExtraLife = (
   }
 ) => Promise<Progression>;
 
-type CreateProgression = (Engine, GenericContent, EngineConfig) => Promise<Progression>;
+type CreateProgression = (string, Engine, GenericContent, EngineConfig) => Promise<Progression>;
 
 type FindBestOf = (
   engineRef: string,
@@ -86,8 +85,6 @@ type ProgressionsService = {|
   requestClue: RequestClue,
   save: Progression => Progression
 |};
-
-const generateId = () => uniqueId('progression');
 
 const findById = (dataLayer: DataLayer): FindById => async (
   id: string
@@ -294,12 +291,11 @@ const refuseExtraLife = (dataLayer: DataLayer): RefuseExtraLife => async (
 };
 
 const create = (dataLayer: DataLayer): CreateProgression => async (
+  _id: string,
   engine: Engine,
   content: GenericContent,
   engineOptions: EngineConfig
 ): Promise<Progression> => {
-  const _id = generateId();
-
   const _getAvailableContent = getAvailableContent(dataLayer);
   const availableContent = await _getAvailableContent(content);
 

--- a/packages/@coorpacademy-player-services/src/test/answers.js
+++ b/packages/@coorpacademy-player-services/src/test/answers.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import find from 'lodash/fp/find';
+import uniqueId from 'lodash/fp/uniqueId';
 import createAnswersService from '../answers';
 import createProgressionsService from '../progressions';
 import slidesData from './fixtures/data/slides';
@@ -14,7 +15,10 @@ const engine = {
 };
 
 test('findById should return the correct answer and corrections for the given answer', async t => {
-  const progression = await ProgressionsService.create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await ProgressionsService.create(uniqueId(), engine, {
+    type: 'chapter',
+    ref: '5.C7'
+  });
   const answer = ['bar'];
   const progressionWithAnswer = await ProgressionsService.postAnswer(progression._id, {
     content: progression.state.nextContent,
@@ -40,7 +44,10 @@ test('findById should return the correct answer and corrections for the given an
 });
 
 test("findById should throw error if slide doesn't exist", async t => {
-  const progression = await ProgressionsService.create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await ProgressionsService.create(uniqueId(), engine, {
+    type: 'chapter',
+    ref: '5.C7'
+  });
   return t.throws(
     findById(progression._id, progression.state.nextContent.ref, ['foo', 'bar']),
     'Answer is not available'
@@ -52,7 +59,10 @@ test('should fail with wrong progressionId', t => {
 });
 
 test('should fail to acceptExtraLife with progression without state', async t => {
-  const progression = await ProgressionsService.create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await ProgressionsService.create(uniqueId(), engine, {
+    type: 'chapter',
+    ref: '5.C7'
+  });
   delete progression.state;
   ProgressionsService.save(progression);
 

--- a/packages/@coorpacademy-player-services/src/test/clues.js
+++ b/packages/@coorpacademy-player-services/src/test/clues.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import find from 'lodash/fp/find';
 import get from 'lodash/fp/get';
 import pipe from 'lodash/fp/pipe';
+import uniqueId from 'lodash/fp/uniqueId';
 import set from 'lodash/fp/set';
 import createCluesService from '../clues';
 
@@ -18,7 +19,7 @@ const engine = {
 };
 
 test('should findById', async t => {
-  const progression = await Progressions.create(engine, {
+  const progression = await Progressions.create(uniqueId(), engine, {
     type: 'chapter',
     ref: '5.C7'
   });
@@ -37,7 +38,7 @@ test('should fail for wrong progressionId', t => {
 });
 
 test("should throw error if slide doesn't exist", async t => {
-  const progression = await Progressions.create(engine, {
+  const progression = await Progressions.create(uniqueId(), engine, {
     type: 'chapter',
     ref: '5.C7'
   });
@@ -48,7 +49,7 @@ test("should throw error if slide doesn't exist", async t => {
 });
 
 test("should throw error if clue haven't been requested", async t => {
-  const progression = await Progressions.create(engine, {
+  const progression = await Progressions.create(uniqueId(), engine, {
     type: 'chapter',
     ref: '5.C7'
   });
@@ -60,7 +61,7 @@ test('should fail with wrong progressionId', t => {
 });
 
 test('should fail to acceptExtraLife with progression without state', async t => {
-  const progression = await Progressions.create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await Progressions.create(uniqueId(), engine, {type: 'chapter', ref: '5.C7'});
   delete progression.state;
   Progressions.save(progression);
 

--- a/packages/@coorpacademy-player-services/src/test/extra-life.js
+++ b/packages/@coorpacademy-player-services/src/test/extra-life.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import uniqueId from 'lodash/fp/uniqueId';
 import createContentService from '../progressions';
 import * as fixtures from './fixtures';
 
@@ -10,7 +11,7 @@ const engine = {
 };
 
 test('should add one extra life if call accept', async t => {
-  const progression = await Progressions.create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await Progressions.create(uniqueId(), engine, {type: 'chapter', ref: '5.C7'});
   const progressionWithAnswer = await Progressions.postAnswer(progression._id, {
     content: progression.state.nextContent,
     answer: []
@@ -35,7 +36,7 @@ test('should fail to refuseExtraLife with wrong progressionId', t => {
 });
 
 test('should fail to acceptExtraLife with progression without state', async t => {
-  const progression = await Progressions.create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await Progressions.create(uniqueId(), engine, {type: 'chapter', ref: '5.C7'});
   delete progression.state;
   return t.throws(
     Progressions.acceptExtraLife(progression._id, {}),
@@ -44,7 +45,7 @@ test('should fail to acceptExtraLife with progression without state', async t =>
 });
 
 test('should fail to refuseExtraLife with progression without state', async t => {
-  const progression = await Progressions.create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await Progressions.create(uniqueId(), engine, {type: 'chapter', ref: '5.C7'});
   delete progression.state;
   return t.throws(
     Progressions.refuseExtraLife(progression._id, {}),
@@ -53,7 +54,7 @@ test('should fail to refuseExtraLife with progression without state', async t =>
 });
 
 test('should forward to failure if call refuse', async t => {
-  const progression = await Progressions.create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await Progressions.create(uniqueId(), engine, {type: 'chapter', ref: '5.C7'});
   const progressionWithAnswer = await Progressions.postAnswer(progression._id, {
     content: progression.state.nextContent,
     answer: []

--- a/packages/@coorpacademy-player-services/src/test/progressions.js
+++ b/packages/@coorpacademy-player-services/src/test/progressions.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import omit from 'lodash/fp/omit';
 import isObject from 'lodash/fp/isObject';
+import uniqueId from 'lodash/fp/uniqueId';
 import isString from 'lodash/fp/isString';
 import {getConfig} from '@coorpacademy/progression-engine';
 
@@ -39,27 +40,28 @@ test('should call getAvailableContent function', t =>
   ));
 
 test('should create progression for a non-adaptive chapter', async t => {
-  const progression = await create(engine, {type: 'chapter', ref: '5.C7'});
+  const _id = uniqueId();
+  const progression = await create(_id, engine, {type: 'chapter', ref: '5.C7'});
   t.true(isString(progression._id));
   t.true(isString(progression.actions[0].payload.nextContent.ref));
   t.is(progression.state.nextContent.ref, progression.actions[0].payload.nextContent.ref);
-  t.deepEqual(
-    omit(['_id', 'state', ['actions', 0, 'payload', 'nextContent', 'ref']], progression),
-    {
-      engine,
-      engineOptions: undefined,
-      content: {type: 'chapter', ref: '5.C7'},
-      actions: [{type: 'move', payload: {instructions: null, nextContent: {type: 'slide'}}}]
-    }
-  );
+  t.deepEqual(omit(['state', ['actions', 0, 'payload', 'nextContent', 'ref']], progression), {
+    _id,
+    engine,
+    engineOptions: undefined,
+    content: {type: 'chapter', ref: '5.C7'},
+    actions: [{type: 'move', payload: {instructions: null, nextContent: {type: 'slide'}}}]
+  });
 });
 
 test('should create progression for an adaptive chapter', async t => {
-  const progression = await create(engine, {type: 'chapter', ref: 'cha_N19MiQrYG'});
+  const _id = uniqueId();
+  const progression = await create(_id, engine, {type: 'chapter', ref: 'cha_N19MiQrYG'});
   t.true(isString(progression._id));
   t.true(isString(progression.actions[0].payload.nextContent.ref));
   t.is(progression.state.nextContent.ref, progression.actions[0].payload.nextContent.ref);
-  t.deepEqual(omit(['_id', 'state'], progression), {
+  t.deepEqual(omit(['state'], progression), {
+    _id,
     engine,
     engineOptions: undefined,
     content: {type: 'chapter', ref: 'cha_N19MiQrYG'},
@@ -82,35 +84,34 @@ test('should create progression for an adaptive chapter', async t => {
 });
 
 test('should create progression for a level', async t => {
+  const _id = uniqueId();
   const learnerEngine = {
     ref: 'learner',
     version: '1'
   };
-  const progression = await create(learnerEngine, {type: 'level', ref: '1.A'});
+  const progression = await create(_id, learnerEngine, {type: 'level', ref: '1.A'});
   t.true(isString(progression._id));
   t.true(isString(progression.actions[0].payload.nextContent.ref));
   t.is(progression.state.nextContent.ref, progression.actions[0].payload.nextContent.ref);
-  t.deepEqual(
-    omit(['_id', 'state', ['actions', 0, 'payload', 'nextContent', 'ref']], progression),
-    {
-      engine: learnerEngine,
-      content: {type: 'level', ref: '1.A'},
-      engineOptions: undefined,
-      actions: [
-        {
-          type: 'move',
-          payload: {
-            instructions: null,
-            nextContent: {type: 'slide'}
-          }
+  t.deepEqual(omit(['state', ['actions', 0, 'payload', 'nextContent', 'ref']], progression), {
+    _id,
+    engine: learnerEngine,
+    content: {type: 'level', ref: '1.A'},
+    engineOptions: undefined,
+    actions: [
+      {
+        type: 'move',
+        payload: {
+          instructions: null,
+          nextContent: {type: 'slide'}
         }
-      ]
-    }
-  );
+      }
+    ]
+  });
 });
 
 test('should find progression', async t => {
-  const progression = await create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await create(uniqueId(), engine, {type: 'chapter', ref: '5.C7'});
 
   t.deepEqual(await findById(progression._id), progression);
 });
@@ -126,7 +127,7 @@ test('should find 0 stars when there is no best score so far', async t => {
 });
 
 test('should add answer action', async t => {
-  const progression = await create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await create(uniqueId(), engine, {type: 'chapter', ref: '5.C7'});
   const progressionWithAnswer = await postAnswer(progression._id, {
     content: progression.state.nextContent,
     answer: ['bar']
@@ -142,13 +143,13 @@ test('should fail to postAnswer for wrong progressionId', t => {
 });
 
 test('should fail for progression with no state', async t => {
-  const progression = await create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await create(uniqueId(), engine, {type: 'chapter', ref: '5.C7'});
   delete progression.state;
   return t.throws(postAnswer(progression._id, {}), `progression "${progression._id}" has no state`);
 });
 
 test('should mark a resource as viewed', async t => {
-  const progression = await create(engine, {type: 'chapter', ref: '5.C7'});
+  const progression = await create(uniqueId(), engine, {type: 'chapter', ref: '5.C7'});
   const result = await markResourceAsViewed(progression._id, {
     content: {type: 'chapter', ref: '5.C7'},
     resource: {ref: 'foo'}

--- a/packages/@coorpacademy-player-store/src/actions/api/progressions.js
+++ b/packages/@coorpacademy-player-store/src/actions/api/progressions.js
@@ -1,7 +1,5 @@
 // @flow strict
 
-import keys from 'lodash/fp/keys';
-import last from 'lodash/fp/last';
 import get from 'lodash/fp/get';
 import pipe from 'lodash/fp/pipe';
 import includes from 'lodash/fp/includes';
@@ -16,7 +14,6 @@ import type {
   ProgressionId
 } from '@coorpacademy/progression-engine';
 import type {Services} from '../../definitions/services';
-import {selectProgression} from '../ui/progressions';
 import {
   getProgression,
   getBestScore,
@@ -41,10 +38,11 @@ export const PROGRESSION_CREATE_SUCCESS: string = '@@progression/CREATE_SUCCESS'
 export const PROGRESSION_CREATE_FAILURE: string = '@@progression/CREATE_FAILURE';
 
 export const createProgression = (
+  _id: string,
   engine: Engine,
   content: Content,
   config: EngineConfig
-): ThunkAction => async (
+): ThunkAction => (
   dispatch: Function,
   getState: GetState,
   {services}: {services: Services}
@@ -54,14 +52,11 @@ DispatchedAction => {
 
   const action = buildTask({
     types: [PROGRESSION_CREATE_REQUEST, PROGRESSION_CREATE_SUCCESS, PROGRESSION_CREATE_FAILURE],
-    task: () => Progressions.create(engine, content, config),
+    task: () => Progressions.create(_id, engine, content, config),
     meta: {}
   });
 
-  await dispatch(action);
-  const state = getState();
-  const progressionId = last(keys(state.data.progressions.entities));
-  return dispatch(selectProgression(progressionId));
+  return dispatch(action);
 };
 
 export const PROGRESSION_FETCH_REQUEST: string = '@@progression/FETCH_REQUEST';

--- a/packages/@coorpacademy-player-store/src/actions/api/test/progressions.create.js
+++ b/packages/@coorpacademy-player-store/src/actions/api/test/progressions.create.js
@@ -2,26 +2,11 @@ import test from 'ava';
 import set from 'lodash/fp/set';
 import macro from '../../test/helpers/macro';
 
-import {RANK_FETCH_START_REQUEST, RANK_FETCH_START_SUCCESS} from '../rank';
-import {
-  CONTENT_FETCH_REQUEST,
-  CONTENT_FETCH_SUCCESS,
-  CONTENT_INFO_FETCH_REQUEST,
-  CONTENT_INFO_FETCH_SUCCESS
-} from '../contents';
-
 import {
   createProgression,
-  PROGRESSION_FETCH_REQUEST,
-  PROGRESSION_FETCH_BESTOF_REQUEST,
-  PROGRESSION_FETCH_BESTOF_SUCCESS,
-  ENGINE_CONFIG_FETCH_REQUEST,
-  ENGINE_CONFIG_FETCH_SUCCESS,
   PROGRESSION_CREATE_REQUEST,
   PROGRESSION_CREATE_SUCCESS
 } from '../progressions';
-import {UI_PROGRESSION_ACTION_TYPES} from '../../ui/progressions';
-import {UI_SELECT_ROUTE} from '../../ui/route';
 
 const slide = {_id: 'bar', chapter_id: 'baz', foo: 1};
 
@@ -39,40 +24,13 @@ const engineOptions = {
   lives: 888
 };
 
-const ContentService = t => ({
-  find: (type, ref) => {
-    switch (type) {
-      case 'chapter':
-        t.is(ref, 'baz');
-        return {_id: 'baz', foo: 3};
-
-      case 'slide':
-        t.is(ref, 'bar');
-        return slide;
-
-      case 'level':
-        t.is(ref, content.ref);
-        return {level: 'base', ref: '1B'};
-
-      default:
-        t.fail();
-    }
-  },
-  getInfo: (contentRef, engineRef, version) => {
-    t.is(contentRef, content.ref);
-    t.is(engineRef, engine.ref);
-    t.is(version, engine.version);
-    return 'info';
-  }
-});
-
 test(
   'should throw error if progression has no state',
   macro,
   set('data.progressions.entities.foo._id', 'foo', {}),
   t => ({
     Progressions: {
-      create: (_engine, _content, _engineOptions) => {
+      create: (_id, _engine, _content, _engineOptions) => {
         return {
           _id: 'foo',
           engine: _engine,
@@ -82,37 +40,10 @@ test(
             nextContent: {type: 'slide', ref: slide._id}
           }
         };
-      },
-      findById: id => {
-        t.is(id, 'foo');
-        return {
-          _id: 'foo',
-          state: {
-            nextContent: {type: 'slide', ref: slide._id}
-          },
-          content,
-          engine
-        };
-      },
-      findBestOf: (type, contentType, ref, id) => {
-        t.is(contentType, 'level');
-        t.is(ref, '1B');
-        return 16;
-      },
-      getEngineConfig: () => {
-        t.pass();
-        return 42;
       }
-    },
-    LeaderBoard: {
-      getRank: () => {
-        t.pass();
-        return 1;
-      }
-    },
-    Content: ContentService(t, false)
+    }
   }),
-  createProgression(engine, content, engineOptions),
+  createProgression('foo', engine, content, engineOptions),
   [
     {
       type: PROGRESSION_CREATE_REQUEST,
@@ -133,81 +64,7 @@ test(
         content,
         engineOptions
       }
-    },
-    {
-      type: UI_PROGRESSION_ACTION_TYPES.SELECT_PROGRESSION,
-      payload: {id: 'foo'}
-    },
-    {
-      type: PROGRESSION_FETCH_REQUEST,
-      meta: {id: 'foo'}
-    },
-    {
-      type: RANK_FETCH_START_REQUEST
-    },
-    {
-      type: RANK_FETCH_START_SUCCESS,
-      payload: 1
-    },
-    {
-      type: CONTENT_FETCH_REQUEST,
-      meta: {type: 'level', ref: '1B'}
-    },
-    {
-      type: CONTENT_FETCH_SUCCESS,
-      meta: {type: 'level', ref: '1B'},
-      payload: {level: 'base', ref: '1B'}
-    },
-    {
-      type: PROGRESSION_FETCH_BESTOF_REQUEST,
-      meta: {type: 'level', ref: '1B'}
-    },
-    {
-      type: PROGRESSION_FETCH_BESTOF_SUCCESS,
-      meta: {type: 'level', ref: '1B'},
-      payload: 16
-    },
-    {
-      type: ENGINE_CONFIG_FETCH_REQUEST,
-      meta: {engine}
-    },
-    {
-      type: ENGINE_CONFIG_FETCH_SUCCESS,
-      meta: {engine},
-      payload: 42
-    },
-    {
-      type: CONTENT_INFO_FETCH_REQUEST,
-      meta: content
-    },
-    {
-      type: CONTENT_INFO_FETCH_SUCCESS,
-      meta: content,
-      payload: 'info'
-    },
-    {
-      type: CONTENT_FETCH_REQUEST,
-      meta: {type: 'slide', ref: 'bar'}
-    },
-    {
-      type: CONTENT_FETCH_SUCCESS,
-      meta: {type: 'slide', ref: 'bar'},
-      payload: slide
-    },
-    {
-      type: CONTENT_FETCH_REQUEST,
-      meta: {type: 'chapter', ref: 'baz'}
-    },
-    {
-      type: CONTENT_FETCH_SUCCESS,
-      meta: {type: 'chapter', ref: 'baz'},
-      payload: {_id: 'baz', foo: 3}
-    },
-    {
-      type: UI_SELECT_ROUTE,
-      meta: {progressionId: 'foo'},
-      payload: 'answer'
     }
   ],
-  10
+  0
 );

--- a/packages/@coorpacademy-player-store/src/definitions/services/progressions.js
+++ b/packages/@coorpacademy-player-store/src/definitions/services/progressions.js
@@ -20,7 +20,7 @@ type AcceptExtraLife = (
   }
 ) => Promise<Progression>;
 
-type CreateProgression = (Engine, Content, EngineConfig) => Promise<Progression>;
+type CreateProgression = (string, Engine, Content, EngineConfig) => Promise<Progression>;
 
 type FindBestOf = (
   engineRef: string,


### PR DESCRIPTION
- `createProgression` ne doit pas gérer **la création du progressionId**. Il le reçoit maintenant en 1er paramètre.
- **Une action API ne doit pas dispatch une action UI**. `createProgression` ne dispatch plus `selectProgression`.