### PR TITLE
removed progression-updated tracking on video play

### DIFF
--- a/packages/@coorpacademy-player-store/package.json
+++ b/packages/@coorpacademy-player-store/package.json
@@ -39,6 +39,7 @@
     "@babel/polyfill": "^7.4.3",
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-flow": "^7.0.0",
+    "@babel/register": "^7.4.4",
     "ava": "^1.4.1",
     "babel-plugin-istanbul": "^4.1.4",
     "browser-env": "^3.2.5",

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/video.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/video.js
@@ -12,14 +12,8 @@ import {
   resume,
   ended
 } from '../video';
-import {UI_PROGRESSION_ACTION_TYPES} from '../progressions';
 
-import {
-  MEDIA_VIEWED_ANALYTICS_REQUEST,
-  MEDIA_VIEWED_ANALYTICS_SUCCESS,
-  SEND_PROGRESSION_ANALYTICS_REQUEST,
-  SEND_PROGRESSION_ANALYTICS_SUCCESS
-} from '../../api/analytics';
+import {MEDIA_VIEWED_ANALYTICS_REQUEST, MEDIA_VIEWED_ANALYTICS_SUCCESS} from '../../api/analytics';
 
 import {
   PROGRESSION_RESOURCE_VIEWED_REQUEST,
@@ -98,10 +92,6 @@ test(
     Analytics: {
       sendViewedMediaAnalytics: (media, location) => {
         t.pass();
-      },
-      sendProgressionAnalytics: () => {
-        t.pass();
-        return 'qux';
       }
     },
     Progressions: {
@@ -142,22 +132,9 @@ test(
       type: PROGRESSION_RESOURCE_VIEWED_SUCCESS,
       meta: {progressionId: 'foo', resource},
       payload: set('state.viewedResources', [content.ref], {})
-    },
-    {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
-      meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_REQUEST,
-      meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_SUCCESS,
-      meta: {id: 'foo'},
-      payload: 'qux'
     }
   ],
-  4
+  3
 );
 
 test(
@@ -183,10 +160,6 @@ test(
     Analytics: {
       sendViewedMediaAnalytics: (media, location) => {
         t.pass();
-      },
-      sendProgressionAnalytics: () => {
-        t.pass();
-        return 'qux';
       }
     },
     Progressions: {
@@ -227,22 +200,9 @@ test(
       type: PROGRESSION_RESOURCE_VIEWED_SUCCESS,
       meta: {progressionId: 'foo', resource},
       payload: set('state.viewedResources', [content.ref], {})
-    },
-    {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
-      meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_REQUEST,
-      meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_SUCCESS,
-      meta: {id: 'foo'},
-      payload: 'qux'
     }
   ],
-  4
+  3
 );
 
 test(
@@ -350,10 +310,6 @@ test(
     Analytics: {
       sendViewedMediaAnalytics: (media, location) => {
         t.pass();
-      },
-      sendProgressionAnalytics: () => {
-        t.pass();
-        return 'qux';
       }
     },
     Progressions: {
@@ -382,20 +338,7 @@ test(
       type: PROGRESSION_RESOURCE_VIEWED_SUCCESS,
       meta: {progressionId: 'foo', resource},
       payload: 'foo'
-    },
-    {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
-      meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_REQUEST,
-      meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_SUCCESS,
-      meta: {id: 'foo'},
-      payload: 'qux'
     }
   ],
-  3
+  2
 );

--- a/packages/@coorpacademy-player-store/src/actions/ui/video.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/video.js
@@ -11,7 +11,6 @@ import {
   getPreviousSlide
 } from '../../utils/state-extract';
 import type {DispatchedAction, GetState, ReduxState, ThunkAction} from '../../definitions/redux';
-import {progressionUpdated} from './progressions';
 
 export const UI_VIDEO_ERROR = '@@ui/VIDEO_ERROR';
 export const UI_VIDEO_PAUSE = '@@ui/VIDEO_PAUSE';
@@ -54,8 +53,7 @@ DispatchedAction => {
     : resources[0];
 
   await dispatch(sendMediaViewed(resource));
-  await dispatch(markResourceAsViewed(progressionId, resource));
-  return dispatch(progressionUpdated(progressionId));
+  return dispatch(markResourceAsViewed(progressionId, resource));
 };
 
 export const pause = (resource: Lesson) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,6 +1109,18 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
+"@babel/register@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.npmjs.org/@babel/register/-/register-7.4.4.tgz#370a68ba36f08f015a8b35d4864176c6b65d7a23"
+  integrity sha512-sn51H88GRa00+ZoMqCVgOphmswG4b7mhf9VOB0LUBAieykq2GnRFerlN+JQkO/ntT7wz4jaHNSRPg9IdMPEUkA==
+  dependencies:
+    core-js "^3.0.0"
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.11"
+    mkdirp "^0.5.1"
+    pirates "^4.0.0"
+    source-map-support "^0.5.9"
+
 "@babel/runtime@7.3.1":
   version "7.3.1"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

```
- quand tu regardes un media sur la dernière popin interquestion du niveau (j’ai donc déjà gagné ou perdu), cela re-trigger un nouveau finish progression à chaque fois que je regarde un media
```

--> removed `progressionUpdated` on video play

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [x] Unit testing
