### PR TITLE
split progression updated onMove/onNode

### DIFF
--- a/packages/@coorpacademy-player-services/src/analytics.js
+++ b/packages/@coorpacademy-player-services/src/analytics.js
@@ -1,11 +1,6 @@
 // @flow strict
 
-import type {
-  UI_PROGRESSION_UPDATED_ON_NODE,
-  UI_PROGRESSION_UPDATED_ON_MOVE
-} from '@coorpacademy/player-store';
-import type {Lesson, Config, Progression, State} from '@coorpacademy/progression-engine';
-import {UI_PROGRESSION_ACTION_TYPES} from '@coorpacademy/player-store';
+import type {Lesson, Config, Progression} from '@coorpacademy/progression-engine';
 import type {DataEvent, ResourceTypeAPI} from './definitions';
 
 // eslint-disable-next-line no-shadow
@@ -23,31 +18,20 @@ export const sendViewedMediaAnalytics = (resource: Lesson, location: string) => 
   });
 };
 
-export const sendProgressionAnalytics = (
-  currentProgression: Progression,
-  engineConfig: Config,
-  type: UI_PROGRESSION_UPDATED_ON_MOVE | UI_PROGRESSION_UPDATED_ON_NODE
-) => {
+export const sendProgressionAnalytics = (currentProgression: Progression, engineConfig: Config) => {
   if (!currentProgression.state) {
     return;
   }
 
-  const state: State = currentProgression.state;
-  const onMove = type === UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE;
-  const isExitNode = state.nextContent.type === 'success' || state.nextContent.type === 'failure';
-
   window.dataLayer = window.dataLayer || [];
-
-  if (onMove && isExitNode) {
-    window.dataLayer.push({
-      event: 'finishProgression',
-      progression: {
-        type: currentProgression.engine.ref,
-        state: state.nextContent.type,
-        extraLife: engineConfig.remainingLifeRequests - state.remainingLifeRequests
-      }
-    });
-  }
+  window.dataLayer.push({
+    event: 'finishProgression',
+    progression: {
+      type: currentProgression.engine.ref,
+      state: currentProgression.state.nextContent.type,
+      extraLife: engineConfig.remainingLifeRequests - currentProgression.state.remainingLifeRequests
+    }
+  });
 };
 
 export type AnalyticsService = {

--- a/packages/@coorpacademy-player-services/src/analytics.js
+++ b/packages/@coorpacademy-player-services/src/analytics.js
@@ -1,6 +1,11 @@
 // @flow strict
 
+import type {
+  UI_PROGRESSION_UPDATED_ON_NODE,
+  UI_PROGRESSION_UPDATED_ON_MOVE
+} from '@coorpacademy/player-store';
 import type {Lesson, Config, Progression, State} from '@coorpacademy/progression-engine';
+import {UI_PROGRESSION_ACTION_TYPES} from '@coorpacademy/player-store';
 import type {DataEvent, ResourceTypeAPI} from './definitions';
 
 // eslint-disable-next-line no-shadow
@@ -18,15 +23,22 @@ export const sendViewedMediaAnalytics = (resource: Lesson, location: string) => 
   });
 };
 
-export const sendProgressionAnalytics = (currentProgression: Progression, engineConfig: Config) => {
+export const sendProgressionAnalytics = (
+  currentProgression: Progression,
+  engineConfig: Config,
+  type: UI_PROGRESSION_UPDATED_ON_MOVE | UI_PROGRESSION_UPDATED_ON_NODE
+) => {
   if (!currentProgression.state) {
     return;
   }
 
   const state: State = currentProgression.state;
+  const onMove = type === UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE;
+  const isExitNode = state.nextContent.type === 'success' || state.nextContent.type === 'failure';
+
   window.dataLayer = window.dataLayer || [];
 
-  if (state.nextContent.type === 'success' || state.nextContent.type === 'failure') {
+  if (onMove && isExitNode) {
     window.dataLayer.push({
       event: 'finishProgression',
       progression: {

--- a/packages/@coorpacademy-player-services/src/analytics.js
+++ b/packages/@coorpacademy-player-services/src/analytics.js
@@ -25,7 +25,7 @@ export const sendProgressionUpdated = (currentProgression: Progression, engineCo
 
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
-    event: 'updatedProgression',
+    event: 'updateProgression',
     progression: {
       type: currentProgression.engine.ref,
       state: currentProgression.state.nextContent.type,
@@ -41,7 +41,7 @@ export const sendProgressionFinished = (currentProgression: Progression, engineC
 
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
-    event: 'finishedProgression',
+    event: 'finishProgression',
     progression: {
       type: currentProgression.engine.ref,
       state: currentProgression.state.nextContent.type,

--- a/packages/@coorpacademy-player-services/src/analytics.js
+++ b/packages/@coorpacademy-player-services/src/analytics.js
@@ -18,14 +18,30 @@ export const sendViewedMediaAnalytics = (resource: Lesson, location: string) => 
   });
 };
 
-export const sendProgressionAnalytics = (currentProgression: Progression, engineConfig: Config) => {
+export const sendProgressionUpdated = (currentProgression: Progression, engineConfig: Config) => {
   if (!currentProgression.state) {
     return;
   }
 
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
-    event: 'finishProgression',
+    event: 'updatedProgression',
+    progression: {
+      type: currentProgression.engine.ref,
+      state: currentProgression.state.nextContent.type,
+      extraLife: engineConfig.remainingLifeRequests - currentProgression.state.remainingLifeRequests
+    }
+  });
+};
+
+export const sendProgressionFinished = (currentProgression: Progression, engineConfig: Config) => {
+  if (!currentProgression.state) {
+    return;
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    event: 'finishedProgression',
     progression: {
       type: currentProgression.engine.ref,
       state: currentProgression.state.nextContent.type,
@@ -36,5 +52,6 @@ export const sendProgressionAnalytics = (currentProgression: Progression, engine
 
 export type AnalyticsService = {
   sendViewedMediaAnalytics: typeof sendViewedMediaAnalytics,
-  sendProgressionAnalytics: typeof sendProgressionAnalytics
+  sendProgressionUpdated: typeof sendProgressionUpdated,
+  sendProgressionFinished: typeof sendProgressionFinished
 };

--- a/packages/@coorpacademy-player-services/src/definitions.js
+++ b/packages/@coorpacademy-player-services/src/definitions.js
@@ -74,8 +74,8 @@ type StartProgressionEvent = {|
   }
 |};
 
-type FinishProgressionEvent = {|
-  event: 'finishProgression',
+type FinishedProgressionEvent = {|
+  event: 'finishedProgression',
   progression?: {
     type: string,
     state: string,
@@ -83,7 +83,20 @@ type FinishProgressionEvent = {|
   }
 |};
 
-type DataEvent = MediaViewedEvent | StartProgressionEvent | FinishProgressionEvent;
+type UpdatedProgressionEvent = {|
+  event: 'updatedProgression',
+  progression?: {
+    type: string,
+    state: string,
+    extraLife: number
+  }
+|};
+
+type DataEvent =
+  | MediaViewedEvent
+  | StartProgressionEvent
+  | FinishedProgressionEvent
+  | UpdatedProgressionEvent;
 
 // eslint-disable-next-line no-shadow
 type Window = {|

--- a/packages/@coorpacademy-player-services/src/definitions.js
+++ b/packages/@coorpacademy-player-services/src/definitions.js
@@ -74,8 +74,8 @@ type StartProgressionEvent = {|
   }
 |};
 
-type FinishedProgressionEvent = {|
-  event: 'finishedProgression',
+type FinishProgressionEvent = {|
+  event: 'finishProgression',
   progression?: {
     type: string,
     state: string,
@@ -83,8 +83,8 @@ type FinishedProgressionEvent = {|
   }
 |};
 
-type UpdatedProgressionEvent = {|
-  event: 'updatedProgression',
+type UpdateProgressionEvent = {|
+  event: 'updateProgression',
   progression?: {
     type: string,
     state: string,
@@ -95,8 +95,8 @@ type UpdatedProgressionEvent = {|
 type DataEvent =
   | MediaViewedEvent
   | StartProgressionEvent
-  | FinishedProgressionEvent
-  | UpdatedProgressionEvent;
+  | FinishProgressionEvent
+  | UpdateProgressionEvent;
 
 // eslint-disable-next-line no-shadow
 type Window = {|

--- a/packages/@coorpacademy-player-services/src/test/analytics.send-progression-analytics.js
+++ b/packages/@coorpacademy-player-services/src/test/analytics.send-progression-analytics.js
@@ -28,7 +28,7 @@ const engineConfig: Config = {
   remainingLifeRequests: 3
 };
 
-test('should push a finished event even if dataLayer is not defined previously', t => {
+test('should push a finish event even if dataLayer is not defined previously', t => {
   global.window = {dataLayer: undefined};
 
   const currentProgression = pipe(
@@ -41,7 +41,7 @@ test('should push a finished event even if dataLayer is not defined previously',
 
   const res = [
     {
-      event: 'finishedProgression',
+      event: 'finishProgression',
       progression: {type: 'microlearning', state: 'success', extraLife: 2}
     }
   ];
@@ -49,7 +49,7 @@ test('should push a finished event even if dataLayer is not defined previously',
   t.deepEqual(global.window.dataLayer, res);
 });
 
-test('should push a updated event even if dataLayer is not defined previously', t => {
+test('should push a update event even if dataLayer is not defined previously', t => {
   global.window = {dataLayer: undefined};
 
   const currentProgression = pipe(
@@ -62,7 +62,7 @@ test('should push a updated event even if dataLayer is not defined previously', 
 
   const res = [
     {
-      event: 'updatedProgression',
+      event: 'updateProgression',
       progression: {type: 'microlearning', state: 'success', extraLife: 2}
     }
   ];
@@ -70,14 +70,14 @@ test('should push a updated event even if dataLayer is not defined previously', 
   t.deepEqual(global.window.dataLayer, res);
 });
 
-test('should send a `finishedProgression` event to the tag manager when finishing a progression successfully', t => {
+test('should send a `finishProgression` event to the tag manager when finishing a progression successfully', t => {
   t.plan(1);
 
   global.window = {
     dataLayer: {
       push: evt => {
         t.deepEqual(evt, {
-          event: 'finishedProgression',
+          event: 'finishProgression',
           progression: {type: 'microlearning', state: 'whatever', extraLife: 2}
         });
       }
@@ -108,14 +108,14 @@ test('should do nothing if progression has no state', t => {
   t.pass();
 });
 
-test('should send a `updatedProgression` event to the tag manager when Updating a progression successfully', t => {
+test('should send a `updateProgression` event to the tag manager when Updating a progression successfully', t => {
   t.plan(1);
 
   global.window = {
     dataLayer: {
       push: evt => {
         t.deepEqual(evt, {
-          event: 'updatedProgression',
+          event: 'updateProgression',
           progression: {type: 'microlearning', state: 'whatever', extraLife: 2}
         });
       }

--- a/packages/@coorpacademy-player-services/src/test/analytics.send-progression-analytics.js
+++ b/packages/@coorpacademy-player-services/src/test/analytics.send-progression-analytics.js
@@ -3,6 +3,7 @@
 import test from 'ava';
 import set from 'lodash/fp/set';
 import pipe from 'lodash/fp/pipe';
+import {UI_PROGRESSION_ACTION_TYPES} from '@coorpacademy/player-store';
 import type {Config} from '@coorpacademy/progression-engine';
 import type {DataEvent} from '../definitions';
 import {sendProgressionAnalytics} from '../analytics';
@@ -37,7 +38,11 @@ test('should push an event even if dataLayer is not defined previously', t => {
     set('state.remainingLifeRequests', 1)
   )({});
 
-  sendProgressionAnalytics(currentProgression, engineConfig);
+  sendProgressionAnalytics(
+    currentProgression,
+    engineConfig,
+    UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE
+  );
 
   const res = [
     {
@@ -69,7 +74,11 @@ test('should send a `finishProgression` event to the tag manager when finishing 
     set('state.remainingLifeRequests', 1)
   )({});
 
-  sendProgressionAnalytics(currentProgression, engineConfig);
+  sendProgressionAnalytics(
+    currentProgression,
+    engineConfig,
+    UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE
+  );
 });
 
 test('should send a `finishProgression` event to the tag manager when failing a progression', t => {
@@ -92,7 +101,11 @@ test('should send a `finishProgression` event to the tag manager when failing a 
     set('state.remainingLifeRequests', 1)
   )({});
 
-  sendProgressionAnalytics(currentProgression, engineConfig);
+  sendProgressionAnalytics(
+    currentProgression,
+    engineConfig,
+    UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE
+  );
 });
 
 test('should do nothing if neither success nor failure', t => {
@@ -109,7 +122,34 @@ test('should do nothing if neither success nor failure', t => {
     set('state.nextContent.type', 'foo')
   )({});
 
-  sendProgressionAnalytics(currentProgression, engineConfig);
+  sendProgressionAnalytics(
+    currentProgression,
+    engineConfig,
+    UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE
+  );
+  t.pass();
+});
+
+test('should not send `finishProgression` event if sendProgressionAnalytics is not a from MOVE update', t => {
+  global.window = {
+    dataLayer: {
+      push: evt => {
+        t.fail();
+      }
+    }
+  };
+
+  const currentProgression = pipe(
+    set('engine.ref', 'microlearning'),
+    set('state.nextContent.type', 'failure'),
+    set('state.remainingLifeRequests', 1)
+  )({});
+
+  sendProgressionAnalytics(
+    currentProgression,
+    engineConfig,
+    UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE
+  );
   t.pass();
 });
 

--- a/packages/@coorpacademy-player-services/src/test/analytics.send-progression-analytics.js
+++ b/packages/@coorpacademy-player-services/src/test/analytics.send-progression-analytics.js
@@ -3,7 +3,6 @@
 import test from 'ava';
 import set from 'lodash/fp/set';
 import pipe from 'lodash/fp/pipe';
-import {UI_PROGRESSION_ACTION_TYPES} from '@coorpacademy/player-store';
 import type {Config} from '@coorpacademy/progression-engine';
 import type {DataEvent} from '../definitions';
 import {sendProgressionAnalytics} from '../analytics';
@@ -38,11 +37,7 @@ test('should push an event even if dataLayer is not defined previously', t => {
     set('state.remainingLifeRequests', 1)
   )({});
 
-  sendProgressionAnalytics(
-    currentProgression,
-    engineConfig,
-    UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE
-  );
+  sendProgressionAnalytics(currentProgression, engineConfig);
 
   const res = [
     {
@@ -62,7 +57,7 @@ test('should send a `finishProgression` event to the tag manager when finishing 
       push: evt => {
         t.deepEqual(evt, {
           event: 'finishProgression',
-          progression: {type: 'microlearning', state: 'success', extraLife: 2}
+          progression: {type: 'microlearning', state: 'whatever', extraLife: 2}
         });
       }
     }
@@ -70,87 +65,11 @@ test('should send a `finishProgression` event to the tag manager when finishing 
 
   const currentProgression = pipe(
     set('engine.ref', 'microlearning'),
-    set('state.nextContent.type', 'success'),
+    set('state.nextContent.type', 'whatever'),
     set('state.remainingLifeRequests', 1)
   )({});
 
-  sendProgressionAnalytics(
-    currentProgression,
-    engineConfig,
-    UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE
-  );
-});
-
-test('should send a `finishProgression` event to the tag manager when failing a progression', t => {
-  t.plan(1);
-
-  global.window = {
-    dataLayer: {
-      push: evt => {
-        t.deepEqual(evt, {
-          event: 'finishProgression',
-          progression: {type: 'microlearning', state: 'failure', extraLife: 2}
-        });
-      }
-    }
-  };
-
-  const currentProgression = pipe(
-    set('engine.ref', 'microlearning'),
-    set('state.nextContent.type', 'failure'),
-    set('state.remainingLifeRequests', 1)
-  )({});
-
-  sendProgressionAnalytics(
-    currentProgression,
-    engineConfig,
-    UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE
-  );
-});
-
-test('should do nothing if neither success nor failure', t => {
-  global.window = {
-    dataLayer: {
-      push: evt => {
-        t.fail();
-      }
-    }
-  };
-
-  const currentProgression = pipe(
-    set('engine.ref', 'microlearning'),
-    set('state.nextContent.type', 'foo')
-  )({});
-
-  sendProgressionAnalytics(
-    currentProgression,
-    engineConfig,
-    UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE
-  );
-  t.pass();
-});
-
-test('should not send `finishProgression` event if sendProgressionAnalytics is not a from MOVE update', t => {
-  global.window = {
-    dataLayer: {
-      push: evt => {
-        t.fail();
-      }
-    }
-  };
-
-  const currentProgression = pipe(
-    set('engine.ref', 'microlearning'),
-    set('state.nextContent.type', 'failure'),
-    set('state.remainingLifeRequests', 1)
-  )({});
-
-  sendProgressionAnalytics(
-    currentProgression,
-    engineConfig,
-    UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE
-  );
-  t.pass();
+  sendProgressionAnalytics(currentProgression, engineConfig);
 });
 
 test('should do nothing if progression has no state', t => {

--- a/packages/@coorpacademy-player-store/src/actions/api/analytics.js
+++ b/packages/@coorpacademy-player-store/src/actions/api/analytics.js
@@ -11,6 +11,10 @@ import type {
   GetState,
   ThunkAction
 } from '../../definitions/redux';
+import type {
+  UI_PROGRESSION_UPDATED_ON_MOVE,
+  UI_PROGRESSION_UPDATED_ON_NODE
+} from '../ui/progressions';
 
 export const MEDIA_VIEWED_ANALYTICS_REQUEST: string = '@@analytics/MEDIA_VIEWED_REQUEST';
 export const MEDIA_VIEWED_ANALYTICS_SUCCESS: string = '@@analytics/MEDIA_VIEWED_SUCCESS';
@@ -43,7 +47,10 @@ export const SEND_PROGRESSION_ANALYTICS_REQUEST: string = '@@analytics/SEND_PROG
 export const SEND_PROGRESSION_ANALYTICS_SUCCESS: string = '@@analytics/SEND_PROGRESSION_SUCCESS';
 export const SEND_PROGRESSION_ANALYTICS_FAILURE: string = '@@analytics/SEND_PROGRESSION_FAILURE';
 
-export const sendProgressionAnalytics = (progressionId: string): ThunkAction => (
+export const sendProgressionAnalytics = (
+  progressionId: string,
+  type: UI_PROGRESSION_UPDATED_ON_MOVE | UI_PROGRESSION_UPDATED_ON_NODE
+): ThunkAction => (
   dispatch: Function,
   getState: GetState,
   {services}: {services: Services}
@@ -75,7 +82,7 @@ DispatchedAction => {
       SEND_PROGRESSION_ANALYTICS_SUCCESS,
       SEND_PROGRESSION_ANALYTICS_FAILURE
     ],
-    task: () => Analytics.sendProgressionAnalytics(currentProgression, engineConfig),
+    task: () => Analytics.sendProgressionAnalytics(currentProgression, engineConfig, type),
     meta: {id: progressionId}
   });
 

--- a/packages/@coorpacademy-player-store/src/actions/api/analytics.js
+++ b/packages/@coorpacademy-player-store/src/actions/api/analytics.js
@@ -15,6 +15,7 @@ import type {
   UI_PROGRESSION_UPDATED_ON_MOVE,
   UI_PROGRESSION_UPDATED_ON_NODE
 } from '../ui/progressions';
+import {UI_PROGRESSION_ACTION_TYPES} from '../ui/progressions';
 
 export const MEDIA_VIEWED_ANALYTICS_REQUEST: string = '@@analytics/MEDIA_VIEWED_REQUEST';
 export const MEDIA_VIEWED_ANALYTICS_SUCCESS: string = '@@analytics/MEDIA_VIEWED_SUCCESS';
@@ -82,7 +83,21 @@ DispatchedAction => {
       SEND_PROGRESSION_ANALYTICS_SUCCESS,
       SEND_PROGRESSION_ANALYTICS_FAILURE
     ],
-    task: () => Analytics.sendProgressionAnalytics(currentProgression, engineConfig, type),
+    task: () => {
+      const progressionState = currentProgression.state;
+      if (!progressionState) {
+        return;
+      }
+
+      const onMove = type === UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE;
+      const isExitNode =
+        progressionState.nextContent.type === 'success' ||
+        progressionState.nextContent.type === 'failure';
+
+      if (onMove && isExitNode) {
+        Analytics.sendProgressionAnalytics(currentProgression, engineConfig);
+      }
+    },
     meta: {id: progressionId}
   });
 

--- a/packages/@coorpacademy-player-store/src/actions/api/analytics.js
+++ b/packages/@coorpacademy-player-store/src/actions/api/analytics.js
@@ -2,13 +2,14 @@
 
 import buildTask from '@coorpacademy/redux-task';
 import type {Lesson, ProgressionId} from '@coorpacademy/progression-engine';
-import {getCurrentProgression, getRoute} from '../../utils/state-extract';
+import {getCurrentProgression, getEngineConfig, getRoute} from '../../utils/state-extract';
 import type {Services} from '../../definitions/services';
 import type {
   Dispatch,
   DispatchedAction,
   Action,
   GetState,
+  Options,
   ThunkAction
 } from '../../definitions/redux';
 
@@ -71,6 +72,15 @@ DispatchedAction => {
     });
   }
 
+  const engineConfig = getEngineConfig(state);
+
+  if (!engineConfig) {
+    return dispatch({
+      type: PROGRESSION_UPDATED_FAILURE,
+      payload: `progression "${id}" has no config.`
+    });
+  }
+
   const progressionUpdatedRequest = await dispatch({
     type,
     meta: {
@@ -85,9 +95,9 @@ DispatchedAction => {
 
   const {Analytics} = services;
   if (onMove && isExitNode) {
-    Analytics.sendProgressionFinished(currentProgression);
+    Analytics.sendProgressionFinished(currentProgression, engineConfig);
   } else {
-    Analytics.sendProgressionUpdated(currentProgression);
+    Analytics.sendProgressionUpdated(currentProgression, engineConfig);
   }
 
   return progressionUpdatedRequest;

--- a/packages/@coorpacademy-player-store/src/actions/api/test/analytics.js
+++ b/packages/@coorpacademy-player-store/src/actions/api/test/analytics.js
@@ -12,12 +12,7 @@ import {
 test(
   'should fail if progression is not found',
   macro,
-  pipe(
-    set('ui.current.progressionId', 'bar'),
-    set('data.configs.entities.microlearning@1', {
-      version: '1'
-    })
-  )({}),
+  set('ui.current.progressionId', 'bar')({}),
   t => ({}),
   progressionUpdated('foo', PROGRESSION_UPDATED_ON_MOVE),
   [
@@ -38,9 +33,6 @@ test(
       _id: 'foo',
       content: {ref: '1.B', type: 'level'},
       engine: {version: '1', ref: 'microlearning'}
-    }),
-    set('data.configs.entities.microlearning@1', {
-      version: '1'
     })
   )({}),
   t => ({}),
@@ -49,6 +41,29 @@ test(
     {
       type: PROGRESSION_UPDATED_FAILURE,
       payload: 'progression "foo" has no state.'
+    }
+  ],
+  0
+);
+
+test(
+  'should fail if progression has no config.',
+  macro,
+  pipe(
+    set('ui.current.progressionId', 'foo'),
+    set('data.progressions.entities.foo', {
+      _id: 'foo',
+      content: {ref: '1.B', type: 'level'},
+      engine: {version: '1', ref: 'microlearning'},
+      state: {nextContent: {type: 'success'}}
+    })
+  )({}),
+  t => ({}),
+  progressionUpdated('foo', PROGRESSION_UPDATED_ON_MOVE),
+  [
+    {
+      type: PROGRESSION_UPDATED_FAILURE,
+      payload: 'progression "foo" has no config.'
     }
   ],
   0

--- a/packages/@coorpacademy-player-store/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/answers.js
@@ -19,7 +19,7 @@ import {fetchSlideChapter} from '../api/contents';
 import type {DispatchedAction, GetState, Options} from '../../definitions/redux';
 import type {PostAnswerPartialPayload} from '../../definitions/services/progressions';
 import {selectRoute} from './route';
-import {progressionUpdated, selectProgression} from './progressions';
+import {UI_PROGRESSION_ACTION_TYPES, progressionUpdated, selectProgression} from './progressions';
 import {toggleAccordion, ACCORDION_KLF, ACCORDION_TIPS, ACCORDION_LESSON} from './corrections';
 
 export const EDIT_ANSWER_ERROR = '@@answer/EDIT_ANSWER_ERROR';
@@ -150,6 +150,8 @@ export const validateAnswer = (partialPayload: PostAnswerPartialPayload) => asyn
     await dispatch(toggleAccordion(ACCORDION_LESSON));
   }
 
-  await dispatch(progressionUpdated(progressionId));
+  await dispatch(
+    progressionUpdated(progressionId, UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE)
+  );
   return dispatch(fetchAnswer(progressionId, slideId, answer));
 };

--- a/packages/@coorpacademy-player-store/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/answers.js
@@ -18,8 +18,9 @@ import {fetchAnswer} from '../api/answers';
 import {fetchSlideChapter} from '../api/contents';
 import type {DispatchedAction, GetState, Options} from '../../definitions/redux';
 import type {PostAnswerPartialPayload} from '../../definitions/services/progressions';
+import {PROGRESSION_UPDATED_ON_MOVE, progressionUpdated} from '../api/analytics';
 import {selectRoute} from './route';
-import {UI_PROGRESSION_ACTION_TYPES, progressionUpdated, selectProgression} from './progressions';
+import {selectProgression} from './progressions';
 import {toggleAccordion, ACCORDION_KLF, ACCORDION_TIPS, ACCORDION_LESSON} from './corrections';
 
 export const EDIT_ANSWER_ERROR = '@@answer/EDIT_ANSWER_ERROR';
@@ -150,8 +151,6 @@ export const validateAnswer = (partialPayload: PostAnswerPartialPayload) => asyn
     await dispatch(toggleAccordion(ACCORDION_LESSON));
   }
 
-  await dispatch(
-    progressionUpdated(progressionId, UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE)
-  );
+  await dispatch(progressionUpdated(progressionId, PROGRESSION_UPDATED_ON_MOVE));
   return dispatch(fetchAnswer(progressionId, slideId, answer));
 };

--- a/packages/@coorpacademy-player-store/src/actions/ui/clues.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/clues.js
@@ -2,7 +2,7 @@ import get from 'lodash/fp/get';
 import {getCurrentSlide, getCurrentProgressionId} from '../../utils/state-extract';
 import {fetchClue} from '../api/clues';
 import {requestClue} from '../api/progressions';
-import {UI_PROGRESSION_ACTION_TYPES, progressionUpdated} from './progressions';
+import {PROGRESSION_UPDATED_ON_NODE, progressionUpdated} from '../api/analytics';
 import {selectRoute} from './route';
 
 const getId = get('_id');
@@ -19,7 +19,5 @@ export const getClue = async (dispatch, getState) => {
 
   await dispatch(requestClue(progressionId, slideId));
   await dispatch(fetchClue(progressionId, slideId));
-  return dispatch(
-    progressionUpdated(progressionId, UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE)
-  );
+  return dispatch(progressionUpdated(progressionId, PROGRESSION_UPDATED_ON_NODE));
 };

--- a/packages/@coorpacademy-player-store/src/actions/ui/clues.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/clues.js
@@ -2,7 +2,7 @@ import get from 'lodash/fp/get';
 import {getCurrentSlide, getCurrentProgressionId} from '../../utils/state-extract';
 import {fetchClue} from '../api/clues';
 import {requestClue} from '../api/progressions';
-import {progressionUpdated} from './progressions';
+import {UI_PROGRESSION_ACTION_TYPES, progressionUpdated} from './progressions';
 import {selectRoute} from './route';
 
 const getId = get('_id');
@@ -19,5 +19,7 @@ export const getClue = async (dispatch, getState) => {
 
   await dispatch(requestClue(progressionId, slideId));
   await dispatch(fetchClue(progressionId, slideId));
-  return dispatch(progressionUpdated(progressionId));
+  return dispatch(
+    progressionUpdated(progressionId, UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE)
+  );
 };

--- a/packages/@coorpacademy-player-store/src/actions/ui/extra-life.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/extra-life.js
@@ -4,13 +4,15 @@ import type {ProgressionId} from '@coorpacademy/progression-engine';
 import {registerAcceptExtraLife, registerRefuseExtraLife} from '../api/progressions';
 import {getCurrentProgressionId} from '../../utils/state-extract';
 import type {DispatchedAction, GetState} from '../../definitions/redux';
-import {selectProgression, progressionUpdated} from './progressions';
+import {UI_PROGRESSION_ACTION_TYPES, selectProgression, progressionUpdated} from './progressions';
 
 const reset = (progressionId: ProgressionId) => async (
   dispatch: Function,
   getState: GetState
 ): DispatchedAction => {
-  await dispatch(progressionUpdated(progressionId));
+  await dispatch(
+    progressionUpdated(progressionId, UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE)
+  );
   return dispatch(selectProgression(progressionId));
 };
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/extra-life.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/extra-life.js
@@ -4,15 +4,14 @@ import type {ProgressionId} from '@coorpacademy/progression-engine';
 import {registerAcceptExtraLife, registerRefuseExtraLife} from '../api/progressions';
 import {getCurrentProgressionId} from '../../utils/state-extract';
 import type {DispatchedAction, GetState} from '../../definitions/redux';
-import {UI_PROGRESSION_ACTION_TYPES, selectProgression, progressionUpdated} from './progressions';
+import {PROGRESSION_UPDATED_ON_MOVE, progressionUpdated} from '../api/analytics';
+import {selectProgression} from './progressions';
 
 const reset = (progressionId: ProgressionId) => async (
   dispatch: Function,
   getState: GetState
 ): DispatchedAction => {
-  await dispatch(
-    progressionUpdated(progressionId, UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE)
-  );
+  await dispatch(progressionUpdated(progressionId, PROGRESSION_UPDATED_ON_MOVE));
   return dispatch(selectProgression(progressionId));
 };
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/progressions.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/progressions.js
@@ -73,6 +73,7 @@ DispatchedAction => {
       id
     }
   });
+
   return dispatch(sendProgressionAnalytics(id, type));
 };
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/progressions.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/progressions.js
@@ -32,7 +32,8 @@ import type {ExitNodeRef} from '../../definitions/models';
 import {selectRoute} from './route';
 
 /* eslint-disable flowtype/type-id-match */
-type UI_PROGRESSION_UPDATED = '@@ui/UI_PROGRESSION_UPDATED';
+export type UI_PROGRESSION_UPDATED_ON_MOVE = '@@ui/PROGRESSION_UPDATED_ON_MOVE';
+export type UI_PROGRESSION_UPDATED_ON_NODE = '@@ui/PROGRESSION_UPDATED_ON_NODE';
 type UI_SELECT_PROGRESSION = '@@ui/SELECT_PROGRESSION';
 type UI_SELECT_PROGRESSION_FAILURE = '@@ui/SELECT_PROGRESSION_FAILURE';
 type OPEN_ASSISTANCE_REQUEST = '@@progression/OPEN_ASSISTANCE_REQUEST';
@@ -43,31 +44,36 @@ type OPEN_ASSISTANCE_FAILURE = '@@progression/OPEN_ASSISTANCE_FAILURE';
 export const UI_PROGRESSION_ACTION_TYPES: {
   SELECT_PROGRESSION: UI_SELECT_PROGRESSION,
   SELECT_PROGRESSION_FAILURE: UI_SELECT_PROGRESSION_FAILURE,
-  PROGRESSION_UPDATED: UI_PROGRESSION_UPDATED,
+  PROGRESSION_UPDATED_ON_MOVE: UI_PROGRESSION_UPDATED_ON_MOVE,
+  PROGRESSION_UPDATED_ON_NODE: UI_PROGRESSION_UPDATED_ON_NODE,
   OPEN_ASSISTANCE_REQUEST: OPEN_ASSISTANCE_REQUEST,
   OPEN_ASSISTANCE_SUCCESS: OPEN_ASSISTANCE_SUCCESS,
   OPEN_ASSISTANCE_FAILURE: OPEN_ASSISTANCE_FAILURE
 } = {
   SELECT_PROGRESSION: '@@ui/SELECT_PROGRESSION',
   SELECT_PROGRESSION_FAILURE: '@@ui/SELECT_PROGRESSION_FAILURE',
-  PROGRESSION_UPDATED: '@@ui/UI_PROGRESSION_UPDATED',
+  PROGRESSION_UPDATED_ON_MOVE: '@@ui/PROGRESSION_UPDATED_ON_MOVE',
+  PROGRESSION_UPDATED_ON_NODE: '@@ui/PROGRESSION_UPDATED_ON_NODE',
   OPEN_ASSISTANCE_REQUEST: '@@progression/OPEN_ASSISTANCE_REQUEST',
   OPEN_ASSISTANCE_SUCCESS: '@@progression/OPEN_ASSISTANCE_SUCCESS',
   OPEN_ASSISTANCE_FAILURE: '@@progression/OPEN_ASSISTANCE_FAILURE'
 };
 
-export const progressionUpdated = (id: ProgressionId): ThunkAction => async (
+export const progressionUpdated = (
+  id: ProgressionId,
+  type: UI_PROGRESSION_UPDATED_ON_MOVE | UI_PROGRESSION_UPDATED_ON_NODE
+): ThunkAction => async (
   dispatch: Function,
   getState: GetState
 ): // $FlowFixMe circular declaration issue with gen-flow-files : type ThunkAction = (Dispatch, GetState, Options) => DispatchedAction
 DispatchedAction => {
   await dispatch({
-    type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
+    type,
     meta: {
       id
     }
   });
-  return dispatch(sendProgressionAnalytics(id));
+  return dispatch(sendProgressionAnalytics(id, type));
 };
 
 type SelectProgressionPayload = {

--- a/packages/@coorpacademy-player-store/src/actions/ui/progressions.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/progressions.js
@@ -11,7 +11,7 @@ import {fetchExitNode} from '../api/exit-nodes';
 import {fetchContent, fetchContentInfo, fetchSlideChapter} from '../api/contents';
 import {fetchRecommendations} from '../api/recommendations';
 import {fetchNext} from '../api/next-content';
-import {sendProgressionAnalytics} from '../api/analytics';
+
 import {fetchAnswer} from '../api/answers';
 import {
   getEngine,
@@ -21,19 +21,11 @@ import {
   getPrevStepContent,
   getSlide
 } from '../../utils/state-extract';
-import type {
-  Action,
-  DispatchedAction,
-  GetState,
-  Options,
-  ThunkAction
-} from '../../definitions/redux';
+import type {Action, DispatchedAction, GetState, Options} from '../../definitions/redux';
 import type {ExitNodeRef} from '../../definitions/models';
 import {selectRoute} from './route';
 
 /* eslint-disable flowtype/type-id-match */
-export type UI_PROGRESSION_UPDATED_ON_MOVE = '@@ui/PROGRESSION_UPDATED_ON_MOVE';
-export type UI_PROGRESSION_UPDATED_ON_NODE = '@@ui/PROGRESSION_UPDATED_ON_NODE';
 type UI_SELECT_PROGRESSION = '@@ui/SELECT_PROGRESSION';
 type UI_SELECT_PROGRESSION_FAILURE = '@@ui/SELECT_PROGRESSION_FAILURE';
 type OPEN_ASSISTANCE_REQUEST = '@@progression/OPEN_ASSISTANCE_REQUEST';
@@ -44,37 +36,15 @@ type OPEN_ASSISTANCE_FAILURE = '@@progression/OPEN_ASSISTANCE_FAILURE';
 export const UI_PROGRESSION_ACTION_TYPES: {
   SELECT_PROGRESSION: UI_SELECT_PROGRESSION,
   SELECT_PROGRESSION_FAILURE: UI_SELECT_PROGRESSION_FAILURE,
-  PROGRESSION_UPDATED_ON_MOVE: UI_PROGRESSION_UPDATED_ON_MOVE,
-  PROGRESSION_UPDATED_ON_NODE: UI_PROGRESSION_UPDATED_ON_NODE,
   OPEN_ASSISTANCE_REQUEST: OPEN_ASSISTANCE_REQUEST,
   OPEN_ASSISTANCE_SUCCESS: OPEN_ASSISTANCE_SUCCESS,
   OPEN_ASSISTANCE_FAILURE: OPEN_ASSISTANCE_FAILURE
 } = {
   SELECT_PROGRESSION: '@@ui/SELECT_PROGRESSION',
   SELECT_PROGRESSION_FAILURE: '@@ui/SELECT_PROGRESSION_FAILURE',
-  PROGRESSION_UPDATED_ON_MOVE: '@@ui/PROGRESSION_UPDATED_ON_MOVE',
-  PROGRESSION_UPDATED_ON_NODE: '@@ui/PROGRESSION_UPDATED_ON_NODE',
   OPEN_ASSISTANCE_REQUEST: '@@progression/OPEN_ASSISTANCE_REQUEST',
   OPEN_ASSISTANCE_SUCCESS: '@@progression/OPEN_ASSISTANCE_SUCCESS',
   OPEN_ASSISTANCE_FAILURE: '@@progression/OPEN_ASSISTANCE_FAILURE'
-};
-
-export const progressionUpdated = (
-  id: ProgressionId,
-  type: UI_PROGRESSION_UPDATED_ON_MOVE | UI_PROGRESSION_UPDATED_ON_NODE
-): ThunkAction => async (
-  dispatch: Function,
-  getState: GetState
-): // $FlowFixMe circular declaration issue with gen-flow-files : type ThunkAction = (Dispatch, GetState, Options) => DispatchedAction
-DispatchedAction => {
-  await dispatch({
-    type,
-    meta: {
-      id
-    }
-  });
-
-  return dispatch(sendProgressionAnalytics(id, type));
 };
 
 type SelectProgressionPayload = {

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-accordion.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-accordion.js
@@ -114,7 +114,7 @@ const services = result => t => ({
     }
   },
   Analytics: {
-    sendProgressionAnalytics: (currentProgression, engineConfig) => {
+    sendProgressionUpdated: (currentProgression, engineConfig) => {
       t.is(currentProgression.engine.ref, 'microlearning');
       t.deepEqual(currentProgression.state.nextContent, result.state.nextContent);
       return 'sent';

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-exit-node.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-exit-node.js
@@ -33,7 +33,7 @@ const services = t => ({
     }
   },
   Analytics: {
-    sendProgressionAnalytics: (currentProgression, engineConfig) => {
+    sendProgressionFinished: (currentProgression, engineConfig) => {
       t.is(currentProgression.engine.ref, 'learner');
       t.deepEqual(currentProgression.state.nextContent, {type: 'success', ref: 'successExitNode'});
       return 'sent';

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-failure.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-failure.js
@@ -149,7 +149,7 @@ test(
       }
     },
     Analytics: {
-      sendProgressionAnalytics: (currentProgression, engineConfig) => {
+      sendProgressionFinished: (currentProgression, engineConfig) => {
         t.is(currentProgression.engine.ref, 'learner');
         t.deepEqual(currentProgression.state.nextContent, {
           type: 'success',

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-success.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-success.js
@@ -149,7 +149,7 @@ test(
       }
     },
     Analytics: {
-      sendProgressionAnalytics: (currentProgression, engineConfig) => {
+      sendProgressionUpdated: (currentProgression, engineConfig) => {
         t.is(currentProgression.engine.ref, 'learner');
         t.deepEqual(currentProgression.state.nextContent, postAnswerPayload.state.nextContent);
         return 'sent';

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/helpers/shared.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/helpers/shared.js
@@ -8,7 +8,7 @@ import {
 
 export const progressionUpdated = [
   {
-    type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
+    type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE,
     meta: {
       id: 'foo'
     }

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/helpers/shared.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/helpers/shared.js
@@ -1,30 +1,13 @@
 import {UI_TOGGLE_ACCORDION} from '../../../corrections';
 import {ANSWER_FETCH_REQUEST, ANSWER_FETCH_SUCCESS} from '../../../../api/answers';
-import {UI_PROGRESSION_ACTION_TYPES} from '../../../progressions';
-import {
-  SEND_PROGRESSION_ANALYTICS_REQUEST,
-  SEND_PROGRESSION_ANALYTICS_SUCCESS
-} from '../../../../api/analytics';
+import {PROGRESSION_UPDATED_ON_MOVE} from '../../../../api/analytics';
 
 export const progressionUpdated = [
   {
-    type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE,
+    type: PROGRESSION_UPDATED_ON_MOVE,
     meta: {
       id: 'foo'
     }
-  },
-  {
-    type: SEND_PROGRESSION_ANALYTICS_REQUEST,
-    meta: {
-      id: 'foo'
-    }
-  },
-  {
-    type: SEND_PROGRESSION_ANALYTICS_SUCCESS,
-    meta: {
-      id: 'foo'
-    },
-    payload: 'sent'
   }
 ];
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/clues.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/clues.js
@@ -8,12 +8,8 @@ import {
   PROGRESSION_REQUEST_CLUE_REQUEST,
   PROGRESSION_REQUEST_CLUE_SUCCESS
 } from '../../api/progressions';
-import {UI_PROGRESSION_ACTION_TYPES} from '../progressions';
 import {CLUE_FETCH_REQUEST, CLUE_FETCH_SUCCESS} from '../../api/clues';
-import {
-  SEND_PROGRESSION_ANALYTICS_REQUEST,
-  SEND_PROGRESSION_ANALYTICS_SUCCESS
-} from '../../api/analytics';
+import {PROGRESSION_UPDATED_ON_NODE} from '../../api/analytics';
 
 const slide = {
   ref: 'bar',
@@ -57,7 +53,10 @@ test(
   )({}),
   t => ({
     Analytics: {
-      sendProgressionAnalytics: (currentProgression, engineConfig) => {
+      sendProgressionFinished: (currentProgression, engineConfig) => {
+        t.fail();
+      },
+      sendProgressionUpdated: (currentProgression, engineConfig) => {
         t.is(currentProgression.engine.ref, 'microlearning');
         t.deepEqual(currentProgression.state.nextContent, {type: 'slide', ref: 'bar'});
         return 'sent';
@@ -111,23 +110,10 @@ test(
       payload: ['Clue']
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE,
+      type: PROGRESSION_UPDATED_ON_NODE,
       meta: {
         id: 'foo'
       }
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_REQUEST,
-      meta: {
-        id: 'foo'
-      }
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_SUCCESS,
-      meta: {
-        id: 'foo'
-      },
-      payload: 'sent'
     }
   ],
   6

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/clues.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/clues.js
@@ -111,7 +111,7 @@ test(
       payload: ['Clue']
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
+      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE,
       meta: {
         id: 'foo'
       }

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/extra-life.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/extra-life.js
@@ -23,10 +23,7 @@ import {
   CONTENT_INFO_FETCH_REQUEST,
   CONTENT_INFO_FETCH_SUCCESS
 } from '../../api/contents';
-import {
-  SEND_PROGRESSION_ANALYTICS_REQUEST,
-  SEND_PROGRESSION_ANALYTICS_SUCCESS
-} from '../../api/analytics';
+import {PROGRESSION_UPDATED_ON_MOVE} from '../../api/analytics';
 
 test(
   'should dispatch refuse and reset progression',
@@ -43,7 +40,7 @@ test(
   )({}),
   t => ({
     Analytics: {
-      sendProgressionAnalytics: (currentProgression, engineConfig) => {
+      sendProgressionUpdated: (currentProgression, engineConfig) => {
         t.is(currentProgression.engine.ref, 'microlearning');
         t.deepEqual(currentProgression.state.nextContent, {type: 'slide', ref: 'slideRef'});
         return 'sent';
@@ -103,23 +100,10 @@ test(
       }
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE,
+      type: PROGRESSION_UPDATED_ON_MOVE,
       meta: {
         id: 'foo'
       }
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_REQUEST,
-      meta: {
-        id: 'foo'
-      }
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_SUCCESS,
-      meta: {
-        id: 'foo'
-      },
-      payload: 'sent'
     },
     {
       type: UI_PROGRESSION_ACTION_TYPES.SELECT_PROGRESSION,
@@ -208,7 +192,7 @@ test(
   )({}),
   t => ({
     Analytics: {
-      sendProgressionAnalytics: (currentProgression, engineConfig) => {
+      sendProgressionUpdated: (currentProgression, engineConfig) => {
         t.is(currentProgression.engine.ref, 'microlearning');
         t.deepEqual(currentProgression.state.nextContent, {type: 'slide', ref: 'slideRef'});
         return 'sent';
@@ -264,23 +248,10 @@ test(
       }
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE,
+      type: PROGRESSION_UPDATED_ON_MOVE,
       meta: {
         id: 'foo'
       }
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_REQUEST,
-      meta: {
-        id: 'foo'
-      }
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_SUCCESS,
-      meta: {
-        id: 'foo'
-      },
-      payload: 'sent'
     },
     {
       type: UI_PROGRESSION_ACTION_TYPES.SELECT_PROGRESSION,

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/extra-life.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/extra-life.js
@@ -103,7 +103,7 @@ test(
       }
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
+      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE,
       meta: {
         id: 'foo'
       }
@@ -264,7 +264,7 @@ test(
       }
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
+      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_MOVE,
       meta: {
         id: 'foo'
       }

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/video.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/video.js
@@ -144,7 +144,7 @@ test(
       payload: set('state.viewedResources', [content.ref], {})
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
+      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE,
       meta: {id: 'foo'}
     },
     {
@@ -229,7 +229,7 @@ test(
       payload: set('state.viewedResources', [content.ref], {})
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
+      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE,
       meta: {id: 'foo'}
     },
     {
@@ -384,7 +384,7 @@ test(
       payload: 'foo'
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED,
+      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE,
       meta: {id: 'foo'}
     },
     {

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/video.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/video.js
@@ -12,13 +12,11 @@ import {
   resume,
   ended
 } from '../video';
-import {UI_PROGRESSION_ACTION_TYPES} from '../progressions';
 
 import {
   MEDIA_VIEWED_ANALYTICS_REQUEST,
   MEDIA_VIEWED_ANALYTICS_SUCCESS,
-  SEND_PROGRESSION_ANALYTICS_REQUEST,
-  SEND_PROGRESSION_ANALYTICS_SUCCESS
+  PROGRESSION_UPDATED_ON_NODE
 } from '../../api/analytics';
 
 import {
@@ -82,7 +80,7 @@ test(
     set('ui.corrections.playResource', resource._id),
     set('ui.route.foo', 'question'),
     set('data.progressions.entities.foo._id', 'foo'),
-    set('data.progressions.entities.foo.state.nextContent.ref', 'slideRef'),
+    set('data.progressions.entities.foo.state', {nextContent: {type: 'slide', ref: 'slideRef'}}),
     set('data.progressions.entities.foo.engine', {
       version: '1',
       ref: 'microlearning'
@@ -99,9 +97,11 @@ test(
       sendViewedMediaAnalytics: (media, location) => {
         t.pass();
       },
-      sendProgressionAnalytics: () => {
+      sendProgressionUpdated: () => {
         t.pass();
-        return 'qux';
+      },
+      sendProgressionFinished: () => {
+        t.fail();
       }
     },
     Progressions: {
@@ -119,7 +119,11 @@ test(
           }
         });
 
-        return set('state.viewedResources', [content.ref], {});
+        return set(
+          'state',
+          {viewedResources: [content.ref], nextContent: {type: 'slide', ref: 'slideRef'}},
+          {}
+        );
       }
     }
   }),
@@ -141,20 +145,15 @@ test(
     {
       type: PROGRESSION_RESOURCE_VIEWED_SUCCESS,
       meta: {progressionId: 'foo', resource},
-      payload: set('state.viewedResources', [content.ref], {})
+      payload: set(
+        'state',
+        {viewedResources: [content.ref], nextContent: {type: 'slide', ref: 'slideRef'}},
+        {}
+      )
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE,
+      type: PROGRESSION_UPDATED_ON_NODE,
       meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_REQUEST,
-      meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_SUCCESS,
-      meta: {id: 'foo'},
-      payload: 'qux'
     }
   ],
   4
@@ -167,7 +166,7 @@ test(
     set('ui.current.progressionId', 'foo'),
     set('ui.route.foo', 'question'),
     set('data.progressions.entities.foo._id', 'foo'),
-    set('data.progressions.entities.foo.state.nextContent.ref', 'slideRef'),
+    set('data.progressions.entities.foo.state', {nextContent: {type: 'slide', ref: 'slideRef'}}),
     set('data.progressions.entities.foo.engine', {
       version: '1',
       ref: 'microlearning'
@@ -184,9 +183,11 @@ test(
       sendViewedMediaAnalytics: (media, location) => {
         t.pass();
       },
-      sendProgressionAnalytics: () => {
+      sendProgressionUpdated: () => {
         t.pass();
-        return 'qux';
+      },
+      sendProgressionFinished: () => {
+        t.fail();
       }
     },
     Progressions: {
@@ -204,7 +205,11 @@ test(
           }
         });
 
-        return set('state.viewedResources', [content.ref], {});
+        return set(
+          'state',
+          {viewedResources: [content.ref], nextContent: {type: 'slide', ref: 'slideRef'}},
+          {}
+        );
       }
     }
   }),
@@ -226,20 +231,15 @@ test(
     {
       type: PROGRESSION_RESOURCE_VIEWED_SUCCESS,
       meta: {progressionId: 'foo', resource},
-      payload: set('state.viewedResources', [content.ref], {})
+      payload: set(
+        'state',
+        {viewedResources: [content.ref], nextContent: {type: 'slide', ref: 'slideRef'}},
+        {}
+      )
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE,
+      type: PROGRESSION_UPDATED_ON_NODE,
       meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_REQUEST,
-      meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_SUCCESS,
-      meta: {id: 'foo'},
-      payload: 'qux'
     }
   ],
   4
@@ -351,7 +351,7 @@ test(
       sendViewedMediaAnalytics: (media, location) => {
         t.pass();
       },
-      sendProgressionAnalytics: () => {
+      sendProgressionUpdated: () => {
         t.pass();
         return 'qux';
       }
@@ -384,17 +384,8 @@ test(
       payload: 'foo'
     },
     {
-      type: UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE,
+      type: PROGRESSION_UPDATED_ON_NODE,
       meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_REQUEST,
-      meta: {id: 'foo'}
-    },
-    {
-      type: SEND_PROGRESSION_ANALYTICS_SUCCESS,
-      meta: {id: 'foo'},
-      payload: 'qux'
     }
   ],
   3

--- a/packages/@coorpacademy-player-store/src/actions/ui/video.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/video.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {Lesson, Slide} from '@coorpacademy/progression-engine';
-import {sendMediaViewed} from '../api/analytics';
+import {PROGRESSION_UPDATED_ON_NODE, progressionUpdated, sendMediaViewed} from '../api/analytics';
 import {markResourceAsViewed} from '../api/progressions';
 import {
   getRoute,
@@ -11,7 +11,6 @@ import {
   getPreviousSlide
 } from '../../utils/state-extract';
 import type {DispatchedAction, GetState, ReduxState, ThunkAction} from '../../definitions/redux';
-import {UI_PROGRESSION_ACTION_TYPES, progressionUpdated} from './progressions';
 
 export const UI_VIDEO_ERROR = '@@ui/VIDEO_ERROR';
 export const UI_VIDEO_PAUSE = '@@ui/VIDEO_PAUSE';
@@ -55,9 +54,7 @@ DispatchedAction => {
 
   await dispatch(sendMediaViewed(resource));
   await dispatch(markResourceAsViewed(progressionId, resource));
-  return dispatch(
-    progressionUpdated(progressionId, UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE)
-  );
+  return dispatch(progressionUpdated(progressionId, PROGRESSION_UPDATED_ON_NODE));
 };
 
 export const pause = (resource: Lesson) => ({

--- a/packages/@coorpacademy-player-store/src/actions/ui/video.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/video.js
@@ -11,7 +11,7 @@ import {
   getPreviousSlide
 } from '../../utils/state-extract';
 import type {DispatchedAction, GetState, ReduxState, ThunkAction} from '../../definitions/redux';
-import {progressionUpdated} from './progressions';
+import {UI_PROGRESSION_ACTION_TYPES, progressionUpdated} from './progressions';
 
 export const UI_VIDEO_ERROR = '@@ui/VIDEO_ERROR';
 export const UI_VIDEO_PAUSE = '@@ui/VIDEO_PAUSE';
@@ -55,7 +55,9 @@ DispatchedAction => {
 
   await dispatch(sendMediaViewed(resource));
   await dispatch(markResourceAsViewed(progressionId, resource));
-  return dispatch(progressionUpdated(progressionId));
+  return dispatch(
+    progressionUpdated(progressionId, UI_PROGRESSION_ACTION_TYPES.PROGRESSION_UPDATED_ON_NODE)
+  );
 };
 
 export const pause = (resource: Lesson) => ({

--- a/packages/@coorpacademy-player-store/src/test/index.js
+++ b/packages/@coorpacademy-player-store/src/test/index.js
@@ -3,9 +3,9 @@ import keys from 'lodash/fp/keys';
 import * as api from '..';
 
 // this test is somehow a snapshot;
-// use this to update the test according to your changes:
-// add this inside the test =>  console.dir({k: keys(api)}, {depth: 10, maxArrayLength: null, colors: true});
-// and launch that specific test with   npx ava src/test/index.js
+// use this to update the test according to your changes: uncomment the next line
+// console.dir({k: keys(api)}, {depth: 10, maxArrayLength: null, colors: true});
+// and launch this specific test with `NODE_ENV=test npx ava src/test/index.js`
 
 test('it should expose all api', t => {
   t.deepEqual(keys(api), [
@@ -68,10 +68,11 @@ test('it should expose all api', t => {
     'MEDIA_VIEWED_ANALYTICS_SUCCESS',
     'MEDIA_VIEWED_ANALYTICS_FAILURE',
     'sendMediaViewed',
-    'SEND_PROGRESSION_ANALYTICS_REQUEST',
-    'SEND_PROGRESSION_ANALYTICS_SUCCESS',
-    'SEND_PROGRESSION_ANALYTICS_FAILURE',
-    'sendProgressionAnalytics',
+    'PROGRESSION_UPDATED_FAILURE',
+    'PROGRESSION_UPDATED_ON_MOVE',
+    'PROGRESSION_UPDATED_ON_NODE',
+    'PROGRESSION_FINISHED',
+    'progressionUpdated',
     'ANSWER_FETCH_REQUEST',
     'ANSWER_FETCH_SUCCESS',
     'ANSWER_FETCH_FAILURE',
@@ -196,7 +197,6 @@ test('it should expose all api', t => {
     'LOCATION_OPEN_RECOMMENDATION_FAILURE',
     'openRecommendation',
     'UI_PROGRESSION_ACTION_TYPES',
-    'progressionUpdated',
     'unselectProgression',
     'selectProgression',
     'openAssistance',


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

```
- quand tu regardes un media sur la dernière popin interquestion du niveau (j’ai donc déjà gagné ou perdu), cela re-trigger un nouveau finish progression à chaque fois que je regarde un media
```

--> split `progressionUpdated` for node and move changes;
then 'finishProgression' will be tested `onMove` only
![20190502_174651](https://user-images.githubusercontent.com/910636/57088526-c7be2400-6d02-11e9-9bc2-59c093050697.jpg)



**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [x] Unit testing
