### PR TITLE
Fix SVG properties

### DIFF
--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.1.js
@@ -3,12 +3,16 @@ import React from "react";
 const SvgComponent = props => (
   <svg viewBox="0 0 21 21" {...props}>
     <path
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M13.2 12L12 10.7l.6-1.9c.1-.3-.2-.5-.4-.4l-1.9.6L9 7.8c-.2-.3-.6-.1-.5.2l.2 1.9L6.8 11c-.3.1-.2.5.1.6l1.3.3-8 8c-.3.3-.3.7 0 .9.3.3.7.3.9 0l8-8 .3 1.3c.1.3.5.3.6.1l1.1-1.9 1.9.2c.3.1.5-.3.2-.5"
       fill="currentColor"
     />
     <path
       fill="none"
       stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       d="M18.3 11H20M15.8 5.2l1.7-1.7M10 2.7V1M5.8 6L4.3 4.5M2.5 11H.8M10 17.7v2.5M15.8 15.2l1.7 1.7"
     />
   </svg>

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.1.native.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.1.native.js
@@ -4,12 +4,16 @@ import Svg, { Path } from "react-native-svg";
 const SvgComponent = props => (
   <Svg viewBox="0 0 21 21" {...props}>
     <Path
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M13.2 12L12 10.7l.6-1.9c.1-.3-.2-.5-.4-.4l-1.9.6L9 7.8c-.2-.3-.6-.1-.5.2l.2 1.9L6.8 11c-.3.1-.2.5.1.6l1.3.3-8 8c-.3.3-.3.7 0 .9.3.3.7.3.9 0l8-8 .3 1.3c.1.3.5.3.6.1l1.1-1.9 1.9.2c.3.1.5-.3.2-.5"
       fill={props.color}
     />
     <Path
       fill="none"
       stroke={props.color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
       d="M18.3 11H20M15.8 5.2l1.7-1.7M10 2.7V1M5.8 6L4.3 4.5M2.5 11H.8M10 17.7v2.5M15.8 15.2l1.7 1.7"
     />
   </Svg>

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/profile.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/profile.js
@@ -5,7 +5,14 @@ const SvgComponent = props => (
     <g fill="currentColor">
       <path d="M13.502 12.506c1.8 0 3.2-1.5 3.2-3.2s-1.4-3.3-3.2-3.3-3.3 1.5-3.3 3.2 1.5 3.3 3.3 3.3zM13.502 13.306c-3.8 0-6.5 2-6.5 4.9v.8h13v-.8c0-2.9-2.7-4.9-6.5-4.9z" />
     </g>
-    <circle fill="none" stroke="currentColor" cx={13.5} cy={13.5} r={12.5} />
+    <circle
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      cx={13.5}
+      cy={13.5}
+      r={12.5}
+    />
   </svg>
 );
 

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/profile.native.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/profile.native.js
@@ -6,7 +6,14 @@ const SvgComponent = props => (
     <G fill={props.color}>
       <Path d="M13.502 12.506c1.8 0 3.2-1.5 3.2-3.2s-1.4-3.3-3.2-3.3-3.3 1.5-3.3 3.2 1.5 3.3 3.3 3.3zM13.502 13.306c-3.8 0-6.5 2-6.5 4.9v.8h13v-.8c0-2.9-2.7-4.9-6.5-4.9z" />
     </G>
-    <Circle fill="none" stroke={props.color} cx={13.5} cy={13.5} r={12.5} />
+    <Circle
+      fill="none"
+      stroke={props.color}
+      strokeWidth={2}
+      cx={13.5}
+      cy={13.5}
+      r={12.5}
+    />
   </Svg>
 );
 

--- a/packages/@coorpacademy-nova-icons/third-party/nova-composition.iconjar/icons/magic-wand.1.svg
+++ b/packages/@coorpacademy-nova-icons/third-party/nova-composition.iconjar/icons/magic-wand.1.svg
@@ -5,16 +5,16 @@
 <g>
 	<g id="Group-17" transform="translate(0.000000, 1.000000)">
 		<g id="Group-16" transform="translate(0.000000, -0.000000)">
-			<path id="Fill-1" fillRule="evenodd" clipRule="evenodd" d="M13.2,11L12,9.7l0.6-1.9c0.1-0.3-0.2-0.5-0.4-0.4L10.3,8L9,6.8C8.8,6.5,8.4,6.7,8.5,7l0.2,1.9
+			<path id="Fill-1" fill-rule="evenodd" clip-rule="evenodd" d="M13.2,11L12,9.7l0.6-1.9c0.1-0.3-0.2-0.5-0.4-0.4L10.3,8L9,6.8C8.8,6.5,8.4,6.7,8.5,7l0.2,1.9
 				L6.8,10c-0.3,0.1-0.2,0.5,0.1,0.6l1.3,0.3l-8,8c-0.3,0.3-0.3,0.7,0,0.9c0.3,0.3,0.7,0.3,0.9,0l8-8l0.3,1.3
 				c0.1,0.3,0.5,0.3,0.6,0.1l1.1-1.9l1.9,0.2C13.3,11.6,13.5,11.2,13.2,11" fill="#757575" />
-			<path id="Stroke-3" fill="none" stroke="#757575" strokeLinecap="round" strokeLinejoin="round" d="M18.3,10H20"/>
-			<path id="Stroke-5" fill="none" stroke="#757575" strokeLinecap="round" strokeLinejoin="round" d="M15.8,4.2l1.7-1.7"/>
-			<path id="Stroke-7" fill="none" stroke="#757575" strokeLinecap="round" strokeLinejoin="round" d="M10,1.7V0"/>
-			<path id="Stroke-9" fill="none" stroke="#757575" strokeLinecap="round" strokeLinejoin="round" d="M5.8,5L4.3,3.5"/>
-			<path id="Stroke-11" fill="none" stroke="#757575" strokeLinecap="round" strokeLinejoin="round" d="M2.5,10H0.8"/>
-			<path id="Stroke-13" fill="none" stroke="#757575" strokeLinecap="round" strokeLinejoin="round" d="M10,16.7v2.5"/>
-			<path id="Stroke-15" fill="none" stroke="#757575" strokeLinecap="round" strokeLinejoin="round" d="M15.8,14.2l1.7,1.7"/>
+			<path id="Stroke-3" fill="none" stroke="#757575" stroke-linecap="round" stroke-linejoin="round" d="M18.3,10H20"/>
+			<path id="Stroke-5" fill="none" stroke="#757575" stroke-linecap="round" stroke-linejoin="round" d="M15.8,4.2l1.7-1.7"/>
+			<path id="Stroke-7" fill="none" stroke="#757575" stroke-linecap="round" stroke-linejoin="round" d="M10,1.7V0"/>
+			<path id="Stroke-9" fill="none" stroke="#757575" stroke-linecap="round" stroke-linejoin="round" d="M5.8,5L4.3,3.5"/>
+			<path id="Stroke-11" fill="none" stroke="#757575" stroke-linecap="round" stroke-linejoin="round" d="M2.5,10H0.8"/>
+			<path id="Stroke-13" fill="none" stroke="#757575" stroke-linecap="round" stroke-linejoin="round" d="M10,16.7v2.5"/>
+			<path id="Stroke-15" fill="none" stroke="#757575" stroke-linecap="round" stroke-linejoin="round" d="M15.8,14.2l1.7,1.7"/>
 		</g>
 	</g>
 </g>

--- a/packages/@coorpacademy-nova-icons/third-party/nova-composition.iconjar/icons/profile.svg
+++ b/packages/@coorpacademy-nova-icons/third-party/nova-composition.iconjar/icons/profile.svg
@@ -16,7 +16,7 @@
 				</g>
 			</g>
 		</g>
-		<circle id="Oval" fill="none" stroke="#757575" strokeWidth="2" cx="13.5" cy="13.5" r="12.5"/>
+		<circle id="Oval" fill="none" stroke="#757575" stroke-width="2" cx="13.5" cy="13.5" r="12.5"/>
 	</g>
 </g>
 </svg>


### PR DESCRIPTION
**Detailed purpose of the PR**

This PR fixes incorrect SVG properties

**Result and observation**

Once published and updated on mobile, the profile icon should have the correct stroke width applied.

- [ ] **Breaking changes ?** 
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
