### PR TITLE
Move config folder to TypeScript

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/config/index.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/index.ts
@@ -1,10 +1,15 @@
-import {find} from 'lodash';
+import find from 'lodash/fp/find';
 
 import {Config, Engine, Progression} from '../types';
 import microlearning from './microlearning';
 import learner from './learner';
 
-const engineConfigurations = {
+type EngineConfigurations = {
+  microlearning: typeof microlearning,
+  learner: typeof learner
+};
+
+const engineConfigurations: EngineConfigurations = {
   microlearning,
   learner
 };
@@ -22,9 +27,7 @@ export const getConfig = (engine: Engine): Config => {
   );
 };
 
-export const getConfigForProgression = (progression: Progression): Config => {
-  return {
-    ...getConfig(progression.engine),
-    ...progression.engineOptions
-  };
-};
+export const getConfigForProgression = (progression: Progression): Config => ({
+  ...getConfig(progression.engine),
+  ...progression.engineOptions
+});

--- a/packages/@coorpacademy-progression-engine/src/config/index.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/index.ts
@@ -1,6 +1,6 @@
-// @flow
-import find from 'lodash/fp/find';
-import type {Config, Engine, Progression} from '../types';
+import {find} from 'lodash';
+
+import {Config, Engine, Progression} from '../types';
 import microlearning from './microlearning';
 import learner from './learner';
 
@@ -11,9 +11,11 @@ const engineConfigurations = {
 
 export const getConfig = (engine: Engine): Config => {
   const engineConfiguration = engineConfigurations[engine.ref];
+
   if (!engineConfiguration) {
     throw new Error(`Unknown engine ${engine.ref}`);
   }
+
   return (
     find({version: engine.version}, engineConfiguration.configurations) ||
     engineConfiguration.defaultConfiguration

--- a/packages/@coorpacademy-progression-engine/src/config/learner.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/learner.ts
@@ -1,5 +1,4 @@
-// @flow
-import type {Config} from '../types';
+import {Config} from '../types';
 
 const configurations: Array<Config> = [
   {

--- a/packages/@coorpacademy-progression-engine/src/config/microlearning.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/microlearning.ts
@@ -1,5 +1,4 @@
-// @flow
-import type {Config} from '../types';
+import {Config} from '../types';
 
 const configurations: Array<Config> = [
   {

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.ts
@@ -1,13 +1,26 @@
-// @flow
 import test from 'ava';
-import {getConfig} from '..';
+
+import {getConfigForProgression} from '..';
+import {Progression} from '../../types';
+
+const progression: Progression = {
+  engine: {ref: 'microlearning', version: '1'},
+  engineOptions: {
+    version: '1'
+  },
+  content: {type: 'chapter', ref: '1.A1'},
+  actions: []
+};
 
 test('should throw an error if the engine ref is unknown', t => {
-  t.throws(() => getConfig({ref: 'foobar', version: '1'}), 'Unknown engine foobar');
+  t.throws(
+    () => getConfigForProgression({...progression, engine: {ref: 'foobar', version: '1'}}),
+    'Unknown engine foobar'
+  );
 });
 
 test('should return the configuration with the given version if it exists', t => {
-  t.deepEqual(getConfig({ref: 'microlearning', version: '1'}), {
+  t.deepEqual(getConfigForProgression(progression), {
     version: '1',
     lives: 1,
     livesDisabled: false,
@@ -19,7 +32,7 @@ test('should return the configuration with the given version if it exists', t =>
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
   });
-  t.deepEqual(getConfig({ref: 'learner', version: '1'}), {
+  t.deepEqual(getConfigForProgression({...progression, engine: {ref: 'learner', version: '1'}}), {
     version: '1',
     lives: 3,
     livesDisabled: false,
@@ -33,24 +46,13 @@ test('should return the configuration with the given version if it exists', t =>
   });
 });
 
-test('should return the default configuration if the engine does not have the given version', t => {
-  t.deepEqual(getConfig({ref: 'microlearning', version: 'foobar'}), {
+test('should merge the engineOptions values from the progression into the resulting configuration', t => {
+  const engineOptions = {livesDisabled: true, maxTypos: 100, version: '1'};
+  t.deepEqual(getConfigForProgression({...progression, engineOptions}), {
     version: '1',
     lives: 1,
-    livesDisabled: false,
-    maxTypos: 2,
-    slidesToComplete: 4,
-    answerBoundaryLimit: 5,
-    starsPerAskingClue: -1,
-    starsPerCorrectAnswer: 4,
-    starsPerResourceViewed: 4,
-    remainingLifeRequests: 1
-  });
-  t.deepEqual(getConfig({ref: 'learner', version: 'foobar'}), {
-    version: '1',
-    lives: 3,
-    livesDisabled: false,
-    maxTypos: 2,
+    livesDisabled: true,
+    maxTypos: 100,
     slidesToComplete: 4,
     answerBoundaryLimit: 5,
     starsPerAskingClue: -1,

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.ts
@@ -1,19 +1,20 @@
 import test from 'ava';
 
 import {getConfigForProgression} from '..';
-import {Progression} from '../../types';
+import {Progression, EngineRef, ContentType} from '../../types';
 
 const progression: Progression = {
-  engine: {ref: 'microlearning', version: '1'},
+  engine: {ref: EngineRef.MICROLEARNING, version: '1'},
   engineOptions: {
     version: '1'
   },
-  content: {type: 'chapter', ref: '1.A1'},
+  content: {type: ContentType.CHAPTER, ref: '1.A1'},
   actions: []
 };
 
 test('should throw an error if the engine ref is unknown', t => {
   t.throws(
+    // @ts-ignore: Voluntary bad ref
     () => getConfigForProgression({...progression, engine: {ref: 'foobar', version: '1'}}),
     'Unknown engine foobar'
   );
@@ -32,7 +33,7 @@ test('should return the configuration with the given version if it exists', t =>
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
   });
-  t.deepEqual(getConfigForProgression({...progression, engine: {ref: 'learner', version: '1'}}), {
+  t.deepEqual(getConfigForProgression({...progression, engine: {ref: EngineRef.LEARNER, version: '1'}}), {
     version: '1',
     lives: 3,
     livesDisabled: false,

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config.ts
@@ -1,26 +1,13 @@
-// @flow
 import test from 'ava';
-import {getConfigForProgression} from '..';
-import type {Progression} from '../../types';
 
-const progression: Progression = {
-  engine: {ref: 'microlearning', version: '1'},
-  engineOptions: {
-    version: '1'
-  },
-  content: {type: 'chapter', ref: '1.A1'},
-  actions: []
-};
+import {getConfig} from '..';
 
 test('should throw an error if the engine ref is unknown', t => {
-  t.throws(
-    () => getConfigForProgression({...progression, engine: {ref: 'foobar', version: '1'}}),
-    'Unknown engine foobar'
-  );
+  t.throws(() => getConfig({ref: 'foobar', version: '1'}), 'Unknown engine foobar');
 });
 
 test('should return the configuration with the given version if it exists', t => {
-  t.deepEqual(getConfigForProgression(progression), {
+  t.deepEqual(getConfig({ref: 'microlearning', version: '1'}), {
     version: '1',
     lives: 1,
     livesDisabled: false,
@@ -32,7 +19,7 @@ test('should return the configuration with the given version if it exists', t =>
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
   });
-  t.deepEqual(getConfigForProgression({...progression, engine: {ref: 'learner', version: '1'}}), {
+  t.deepEqual(getConfig({ref: 'learner', version: '1'}), {
     version: '1',
     lives: 3,
     livesDisabled: false,
@@ -46,13 +33,24 @@ test('should return the configuration with the given version if it exists', t =>
   });
 });
 
-test('should merge the engineOptions values from the progression into the resulting configuration', t => {
-  const engineOptions = {livesDisabled: true, maxTypos: 100, version: '1'};
-  t.deepEqual(getConfigForProgression({...progression, engineOptions}), {
+test('should return the default configuration if the engine does not have the given version', t => {
+  t.deepEqual(getConfig({ref: 'microlearning', version: 'foobar'}), {
     version: '1',
     lives: 1,
-    livesDisabled: true,
-    maxTypos: 100,
+    livesDisabled: false,
+    maxTypos: 2,
+    slidesToComplete: 4,
+    answerBoundaryLimit: 5,
+    starsPerAskingClue: -1,
+    starsPerCorrectAnswer: 4,
+    starsPerResourceViewed: 4,
+    remainingLifeRequests: 1
+  });
+  t.deepEqual(getConfig({ref: 'learner', version: 'foobar'}), {
+    version: '1',
+    lives: 3,
+    livesDisabled: false,
+    maxTypos: 2,
     slidesToComplete: 4,
     answerBoundaryLimit: 5,
     starsPerAskingClue: -1,

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config.ts
@@ -1,13 +1,15 @@
 import test from 'ava';
 
 import {getConfig} from '..';
+import {EngineRef} from '../../types';
 
 test('should throw an error if the engine ref is unknown', t => {
+  // @ts-ignore: Voluntary bad ref
   t.throws(() => getConfig({ref: 'foobar', version: '1'}), 'Unknown engine foobar');
 });
 
 test('should return the configuration with the given version if it exists', t => {
-  t.deepEqual(getConfig({ref: 'microlearning', version: '1'}), {
+  t.deepEqual(getConfig({ref: EngineRef.MICROLEARNING, version: '1'}), {
     version: '1',
     lives: 1,
     livesDisabled: false,
@@ -19,7 +21,7 @@ test('should return the configuration with the given version if it exists', t =>
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
   });
-  t.deepEqual(getConfig({ref: 'learner', version: '1'}), {
+  t.deepEqual(getConfig({ref: EngineRef.LEARNER, version: '1'}), {
     version: '1',
     lives: 3,
     livesDisabled: false,
@@ -34,7 +36,7 @@ test('should return the configuration with the given version if it exists', t =>
 });
 
 test('should return the default configuration if the engine does not have the given version', t => {
-  t.deepEqual(getConfig({ref: 'microlearning', version: 'foobar'}), {
+  t.deepEqual(getConfig({ref: EngineRef.MICROLEARNING, version: 'foobar'}), {
     version: '1',
     lives: 1,
     livesDisabled: false,
@@ -46,7 +48,7 @@ test('should return the default configuration if the engine does not have the gi
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
   });
-  t.deepEqual(getConfig({ref: 'learner', version: 'foobar'}), {
+  t.deepEqual(getConfig({ref: EngineRef.LEARNER, version: 'foobar'}), {
     version: '1',
     lives: 3,
     livesDisabled: false,

--- a/packages/@coorpacademy-progression-engine/src/config/test/learner.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/test/learner.ts
@@ -1,8 +1,9 @@
 import test from 'ava';
-import uniqBy from 'lodash/fp/uniqBy';
-import microlearning from '../microlearning';
+import {uniqBy} from 'lodash';
 
-const {configurations} = microlearning;
+import learner from '../learner';
+
+const {configurations} = learner;
 
 test("Configurations shouldn't have conflicting version numbers", t => {
   t.is(configurations.length, uniqBy('version', configurations).length);

--- a/packages/@coorpacademy-progression-engine/src/config/test/learner.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/test/learner.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {uniqBy} from 'lodash';
+import uniqBy from 'lodash/fp/uniqBy';
 
 import learner from '../learner';
 

--- a/packages/@coorpacademy-progression-engine/src/config/test/microlearning.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/test/microlearning.ts
@@ -1,8 +1,9 @@
 import test from 'ava';
-import uniqBy from 'lodash/fp/uniqBy';
-import learner from '../learner';
+import {uniqBy} from 'lodash';
 
-const {configurations} = learner;
+import microlearning from '../microlearning';
+
+const {configurations} = microlearning;
 
 test("Configurations shouldn't have conflicting version numbers", t => {
   t.is(configurations.length, uniqBy('version', configurations).length);

--- a/packages/@coorpacademy-progression-engine/src/config/test/microlearning.ts
+++ b/packages/@coorpacademy-progression-engine/src/config/test/microlearning.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {uniqBy} from 'lodash';
+import uniqBy from 'lodash/fp/uniqBy';
 
 import microlearning from '../microlearning';
 

--- a/packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
+++ b/packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
@@ -1,9 +1,5 @@
 import {Content} from '../types';
-<<<<<<< HEAD:packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
 import {OPERATORS} from './condition-operators';
-=======
-import {OperatorKeys} from './condition-operators';
->>>>>>> Fix errors:packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
 
 export type Target =
   | {
@@ -22,14 +18,11 @@ export type Condition = {
   values: Array<number | boolean | string | Array<string>>
 };
 
-<<<<<<< HEAD:packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
-=======
 export enum InstructionType {
   ADD = 'add',
   SET = 'set'
 }
 
->>>>>>> Fix errors:packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
 export type Instruction = {
   field: string,
   type: InstructionType,

--- a/packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
+++ b/packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
@@ -1,5 +1,9 @@
 import {Content} from '../types';
+<<<<<<< HEAD:packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
 import {OPERATORS} from './condition-operators';
+=======
+import {OperatorKeys} from './condition-operators';
+>>>>>>> Fix errors:packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
 
 export type Target =
   | {
@@ -18,9 +22,17 @@ export type Condition = {
   values: Array<number | boolean | string | Array<string>>
 };
 
+<<<<<<< HEAD:packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
+=======
+export enum InstructionType {
+  ADD = 'add',
+  SET = 'set'
+}
+
+>>>>>>> Fix errors:packages/@coorpacademy-progression-engine/src/rule-engine/types.ts
 export type Instruction = {
   field: string,
-  type: 'add' | 'set',
+  type: InstructionType,
   value: number | boolean | string
 };
 

--- a/packages/@coorpacademy-progression-engine/src/types.ts
+++ b/packages/@coorpacademy-progression-engine/src/types.ts
@@ -33,16 +33,13 @@ export enum ContentType {
   SLIDE = 'slide',
   NODE = 'node',
   FAILURE = 'failure',
-  SUCCESS = 'success',
-  IMG = LessonType.IMG,
-  VIDEO = LessonType.VIDEO,
-  PDF = LessonType.PDF
+  SUCCESS = 'success'
 }
 
 export type Url = string;
 
 export interface ContentSlide {
-  type: SLIDE,
+  type: ContentType.SLIDE,
   ref: string
 };
 

--- a/packages/@coorpacademy-progression-engine/src/types.ts
+++ b/packages/@coorpacademy-progression-engine/src/types.ts
@@ -15,44 +15,29 @@ export type ResourceMimeType =
 
 export type Answer = Array<string>;
 
-export type MICROLEARNING = 'microlearning';
-export type LEARNER = 'learner';
+export enum EngineRef {
+  MICROLEARNING = 'microlearning',
+  LEARNER = 'learner'
+}
 
-export type Engines = MICROLEARNING | LEARNER;
+export enum LessonType {
+  IMG = 'img',
+  VIDEO = 'video',
+  PDF = 'pdf'
+}
 
-export type CHAPTER = 'chapter';
-
-export type DISCIPLINE = 'discipline';
-
-export type LEVEL = 'level';
-
-export type SLIDE = 'slide';
-
-export type NODE = 'node';
-
-export type FAILURE = 'failure';
-
-export type SUCCESS = 'success';
-
-export type IMG = 'img';
-
-export type VIDEO = 'video';
-
-export type PDF = 'pdf';
-
-export type ContentType =
-  | DISCIPLINE
-  | CHAPTER
-  | LEVEL
-  | SLIDE
-  | NODE
-  | FAILURE
-  | SUCCESS
-  | IMG
-  | PDF
-  | VIDEO;
-
-export type LessonType = VIDEO | PDF | IMG;
+export enum ContentType {
+  CHAPTER = 'chapter',
+  DISCIPLINE = 'discipline',
+  LEVEL = 'level',
+  SLIDE = 'slide',
+  NODE = 'node',
+  FAILURE = 'failure',
+  SUCCESS = 'success',
+  IMG = LessonType.IMG,
+  VIDEO = LessonType.VIDEO,
+  PDF = LessonType.PDF
+}
 
 export type Url = string;
 
@@ -191,7 +176,7 @@ export type Action =
   | MoveAction;
 
 export interface Engine {
-  ref: string,
+  ref: EngineRef,
   version: string
 };
 


### PR DESCRIPTION
**Detailed purpose of the PR**

This PR moves the config folder to TypeScript.

**Result and observation**

Nothing UI.

- [ ] **Breaking changes ?**
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing

```console
  ✖ No tests found in src/config/learner.ts, make sure to import "ava" at the top of your test file [16:21:27]
  ✖ No tests found in src/config/microlearning.ts, make sure to import "ava" at the top of your test file
  ✖ No tests found in src/config/index.ts, make sure to import "ava" at the top of your test file

  8 tests passed

  Type `r` and press enter to rerun tests
  Type `u` and press enter to update snapshots
```

**How to test**

`npx ava src/config`