### PR TITLE
Fix videos export and add tests in player-services

### DIFF
--- a/packages/@coorpacademy-player-services/src/index.js
+++ b/packages/@coorpacademy-player-services/src/index.js
@@ -10,7 +10,8 @@ import type {
   ChapterRule,
   LessonAPI,
   Question,
-  Answer
+  Answer,
+  VideoProvider
 } from './definitions';
 
 import type {AnalyticsService} from './analytics';
@@ -21,6 +22,7 @@ import type {ProgressionsService} from './progressions';
 import type {RecommendationsService} from './recommendations';
 import type {SlidesService} from './slides';
 import type {ExitNodesService} from './exit-nodes';
+import type {VideosService} from './videos';
 
 import * as _Analytics from './analytics';
 import createAnswersService from './answers';
@@ -34,6 +36,7 @@ import * as LocationService from './location';
 import createProgressionsService from './progressions';
 import createRecommendationsService from './recommendations';
 import createSlidesService from './slides';
+import createVideosService from './videos';
 
 export type {
   SlideAPI,
@@ -52,7 +55,9 @@ export type {
   LessonAPI,
   Question,
   ContentService,
-  ChapterRule
+  ChapterRule,
+  VideoProvider,
+  VideosService
 };
 
 export const Analytics = _Analytics;
@@ -68,3 +73,4 @@ export const Logger = console; // eslint-disable-line no-console
 export const Progressions: DataLayer => ProgressionsService = createProgressionsService;
 export const Recommendations: DataLayer => RecommendationsService = createRecommendationsService;
 export const Slides: DataLayer => SlidesService = createSlidesService;
+export const Videos: DataLayer => VideosService = createVideosService;

--- a/packages/@coorpacademy-player-services/src/test/fixtures/data/videos.js
+++ b/packages/@coorpacademy-player-services/src/test/fixtures/data/videos.js
@@ -1,0 +1,5 @@
+const videos = {
+  url: 'https://foo.bar/baz.mp4'
+};
+
+export default videos;

--- a/packages/@coorpacademy-player-services/src/test/fixtures/index.js
+++ b/packages/@coorpacademy-player-services/src/test/fixtures/index.js
@@ -14,6 +14,7 @@ import {
 } from './progressions';
 import {find as findRecommendations, getNextLevel} from './recommendations';
 import {findById as findSlideById, findByChapter as findSlideByChapter} from './slides';
+import {findUriById as findVideoUriById} from './videos';
 
 export {
   getAllProgressions,
@@ -29,5 +30,6 @@ export {
   findRecommendations,
   findSlideByChapter,
   findSlideById,
-  saveProgression
+  saveProgression,
+  findVideoUriById
 };

--- a/packages/@coorpacademy-player-services/src/test/fixtures/videos.js
+++ b/packages/@coorpacademy-player-services/src/test/fixtures/videos.js
@@ -1,0 +1,8 @@
+// @flow strict
+
+import type {VideoProvider} from '../../definitions';
+import videosData from './data/videos';
+
+// eslint-disable-next-line import/prefer-default-export
+export const findUriById = (id: string, provider: VideoProvider): Promise<string> =>
+  Promise.resolve(videosData.url);

--- a/packages/@coorpacademy-player-services/src/test/index.js
+++ b/packages/@coorpacademy-player-services/src/test/index.js
@@ -17,6 +17,7 @@ test('should expose services', t => {
     'Logger',
     'Progressions',
     'Recommendations',
-    'Slides'
+    'Slides',
+    'Videos'
   ]);
 });

--- a/packages/@coorpacademy-player-services/src/test/videos.js
+++ b/packages/@coorpacademy-player-services/src/test/videos.js
@@ -1,0 +1,11 @@
+import test from 'ava';
+
+import createVideosService from '../videos';
+import videosData from './fixtures/data/videos';
+import * as fixtures from './fixtures';
+
+const {findUriById} = createVideosService(fixtures);
+
+test('should find a video uri', async t => {
+  t.deepEqual(await findUriById('foobar', 'baz'), videosData.url);
+});


### PR DESCRIPTION

**Detailed purpose of the PR**

This PR fixes videos types and const exported in `player-services` package.

**Result and observation**

You should have them defined so.

- [ ] **Breaking changes ?**  
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
