### PR TITLE
Ignore extra field in template

### DIFF
--- a/packages/@coorpacademy-components/scripts/fixture-tests.js
+++ b/packages/@coorpacademy-components/scripts/fixture-tests.js
@@ -16,7 +16,7 @@ const readFixtureTests$ = (cwd, macro) =>
         concat(
           of(
             `import test from 'ava';`,
-            `import _ from 'lodash';`,
+            `import forEach from 'lodash/forEach';`,
             `import renderComponentMacro from '${join(
               relative(testPath, dirname(macro)),
               basename(macro, '.js')
@@ -33,7 +33,7 @@ const readFixtureTests$ = (cwd, macro) =>
             ``,
             `test('${type} › ${title} > should have valid propTypes', t => {`,
             `  t.pass();`,
-            `  _.forEach(${title}.propTypes, (value, key) => {`,
+            `  forEach(${title}.propTypes, (value, key) => {`,
             `    t.not(value, undefined, \`PropType for "${type}.${title}.propTypes.$\{key}" may not be undefined. Did you mistype the propTypes definition?\`);`,
             `  });`,
             `});`,

--- a/packages/@coorpacademy-components/src/molecule/questions/template/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/index.js
@@ -24,6 +24,7 @@ const Template = props => {
     }
     if (type === 'answerField') {
       const field = find({name: part.value}, props.answers);
+      if (!field) return null;
       const fieldView =
         field.type === 'text' ? (
           <FreeText {...field} className={style.text} />

--- a/packages/@coorpacademy-components/src/molecule/questions/template/test/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/test/index.js
@@ -1,0 +1,18 @@
+import browserEnv from 'browser-env';
+import test from 'ava';
+import React from 'react';
+import {configure, shallow} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import Template from '..';
+import fixture from './fixtures/default';
+
+browserEnv();
+configure({adapter: new Adapter()});
+
+test('should instanciate Range without props', t => {
+  const expected = shallow(<Template {...fixture.props} />);
+  const actual = shallow(
+    <Template {...{...fixture.props, template: `${fixture.props.template}{{wrongInput}}`}} />
+  );
+  t.deepEqual(actual.html(), expected.html());
+});


### PR DESCRIPTION
https://app.datadoghq.eu/logs?agg_m=count&agg_q=%40http.url_details.path&agg_t=count&cols=log_platform%2Clog_brand%2Clog_job_id%2Clog_job_exit_code%2Clog_syslog.procid&event&from_ts=1561990745223&index=main&live=true&query=%22Unable+to+get+property+%27type%27+of+undefined+or+null+reference%22&step=auto&stream_sort=desc&to_ts=1564582745223&top_n=100&viz=query_table

Il y a des questions templates qui on encore de vielles locales incluant des champs supprimés. Le player explose et l'apprenant ne peut plus jouer.

Comme sur le mobile, si le champ n'existe pas, on l'ignore.