### PR TITLE
Add v2 configuration for microlearning

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/config/microlearning.js
+++ b/packages/@coorpacademy-progression-engine/src/config/microlearning.js
@@ -13,10 +13,22 @@ const configurations: Array<Config> = [
     starsPerCorrectAnswer: 4,
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
+  },
+  {
+    version: '2',
+    lives: 0,
+    livesDisabled: true,
+    maxTypos: 2,
+    slidesToComplete: 4,
+    answerBoundaryLimit: 5,
+    starsPerAskingClue: -1,
+    starsPerCorrectAnswer: 4,
+    starsPerResourceViewed: 4,
+    remainingLifeRequests: 1
   }
 ];
 
 export default {
   configurations,
-  defaultConfiguration: configurations[0]
+  defaultConfiguration: configurations[1]
 };

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.js
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.js
@@ -3,24 +3,24 @@ import test from 'ava';
 import {getConfigForProgression} from '..';
 import type {Progression} from '../../types';
 
-const progression: Progression = {
-  engine: {ref: 'microlearning', version: '1'},
+const createProgression = ({ref, version}: {ref: string, version: string}): Progression => ({
+  engine: {ref, version},
   engineOptions: {
-    version: '1'
+    version
   },
   content: {type: 'chapter', ref: '1.A1'},
   actions: []
-};
+});
 
 test('should throw an error if the engine ref is unknown', t => {
   t.throws(
-    () => getConfigForProgression({...progression, engine: {ref: 'foobar', version: '1'}}),
+    () => getConfigForProgression(createProgression({ref: 'foobar', version: '1'})),
     'Unknown engine foobar'
   );
 });
 
 test('should return the configuration with the given version if it exists', t => {
-  t.deepEqual(getConfigForProgression(progression), {
+  t.deepEqual(getConfigForProgression(createProgression({ref: 'microlearning', version: '1'})), {
     version: '1',
     lives: 1,
     livesDisabled: false,
@@ -32,22 +32,19 @@ test('should return the configuration with the given version if it exists', t =>
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
   });
-  t.deepEqual(
-    getConfigForProgression({...progression, engine: {ref: 'microlearning', version: '2'}}),
-    {
-      version: '2',
-      lives: 0,
-      livesDisabled: true,
-      maxTypos: 2,
-      slidesToComplete: 4,
-      answerBoundaryLimit: 5,
-      starsPerAskingClue: -1,
-      starsPerCorrectAnswer: 4,
-      starsPerResourceViewed: 4,
-      remainingLifeRequests: 1
-    }
-  );
-  t.deepEqual(getConfigForProgression({...progression, engine: {ref: 'learner', version: '1'}}), {
+  t.deepEqual(getConfigForProgression(createProgression({ref: 'microlearning', version: '2'})), {
+    version: '2',
+    lives: 0,
+    livesDisabled: true,
+    maxTypos: 2,
+    slidesToComplete: 4,
+    answerBoundaryLimit: 5,
+    starsPerAskingClue: -1,
+    starsPerCorrectAnswer: 4,
+    starsPerResourceViewed: 4,
+    remainingLifeRequests: 1
+  });
+  t.deepEqual(getConfigForProgression(createProgression({ref: 'learner', version: '1'})), {
     version: '1',
     lives: 3,
     livesDisabled: false,
@@ -59,8 +56,8 @@ test('should return the configuration with the given version if it exists', t =>
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
   });
-  t.deepEqual(getConfigForProgression({...progression, engine: {ref: 'learner', version: '2'}}), {
-    version: '1',
+  t.deepEqual(getConfigForProgression(createProgression({ref: 'learner', version: '2'})), {
+    version: '2',
     lives: 4,
     livesDisabled: false,
     maxTypos: 2,
@@ -74,17 +71,23 @@ test('should return the configuration with the given version if it exists', t =>
 });
 
 test('should merge the engineOptions values from the progression into the resulting configuration', t => {
-  const engineOptions = {livesDisabled: true, maxTypos: 100, version: '1'};
-  t.deepEqual(getConfigForProgression({...progression, engineOptions}), {
-    version: '1',
-    lives: 1,
-    livesDisabled: true,
-    maxTypos: 100,
-    slidesToComplete: 4,
-    answerBoundaryLimit: 5,
-    starsPerAskingClue: -1,
-    starsPerCorrectAnswer: 4,
-    starsPerResourceViewed: 4,
-    remainingLifeRequests: 1
-  });
+  const engineOptions = {livesDisabled: true, maxTypos: 100, version: 'foobar'};
+  t.deepEqual(
+    getConfigForProgression({
+      ...createProgression({ref: 'microlearning', version: '1'}),
+      engineOptions
+    }),
+    {
+      version: 'foobar',
+      lives: 1,
+      livesDisabled: true,
+      maxTypos: 100,
+      slidesToComplete: 4,
+      answerBoundaryLimit: 5,
+      starsPerAskingClue: -1,
+      starsPerCorrectAnswer: 4,
+      starsPerResourceViewed: 4,
+      remainingLifeRequests: 1
+    }
+  );
 });

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.js
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.js
@@ -32,6 +32,21 @@ test('should return the configuration with the given version if it exists', t =>
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
   });
+  t.deepEqual(
+    getConfigForProgression({...progression, engine: {ref: 'microlearning', version: '2'}}),
+    {
+      version: '2',
+      lives: 0,
+      livesDisabled: true,
+      maxTypos: 2,
+      slidesToComplete: 4,
+      answerBoundaryLimit: 5,
+      starsPerAskingClue: -1,
+      starsPerCorrectAnswer: 4,
+      starsPerResourceViewed: 4,
+      remainingLifeRequests: 1
+    }
+  );
   t.deepEqual(getConfigForProgression({...progression, engine: {ref: 'learner', version: '1'}}), {
     version: '1',
     lives: 3,

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config.js
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config.js
@@ -19,6 +19,18 @@ test('should return the configuration with the given version if it exists', t =>
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
   });
+  t.deepEqual(getConfig({ref: 'microlearning', version: '2'}), {
+    version: '2',
+    lives: 0,
+    livesDisabled: true,
+    maxTypos: 2,
+    slidesToComplete: 4,
+    answerBoundaryLimit: 5,
+    starsPerAskingClue: -1,
+    starsPerCorrectAnswer: 4,
+    starsPerResourceViewed: 4,
+    remainingLifeRequests: 1
+  });
   t.deepEqual(getConfig({ref: 'learner', version: '1'}), {
     version: '1',
     lives: 3,
@@ -47,9 +59,9 @@ test('should return the configuration with the given version if it exists', t =>
 
 test('should return the default configuration if the engine does not have the given version', t => {
   t.deepEqual(getConfig({ref: 'microlearning', version: 'foobar'}), {
-    version: '1',
-    lives: 1,
-    livesDisabled: false,
+    version: '2',
+    lives: 0,
+    livesDisabled: true,
     maxTypos: 2,
     slidesToComplete: 4,
     answerBoundaryLimit: 5,


### PR DESCRIPTION
**Detailed purpose of the PR**

This PR adds v2 configuration for microlearning progression engine.

**Result and observation**

You should be able to use the v2 configuration that makes lives infinite.

- [ ] **Breaking changes ?** 
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing
