### PR TITLE
Disable lives in correction popin when lives are disabled

### DIFF
--- a/packages/@coorpacademy-player-web/src/map-state-to-props/popin-correction.js
+++ b/packages/@coorpacademy-player-web/src/map-state-to-props/popin-correction.js
@@ -126,16 +126,15 @@ export const popinCorrectionStateToProps = (options, store) => state => {
   const extraLifeGranted = isExtraLifeActive && hasViewedAResourceAtThisStep(state);
   const mayAcceptExtraLife = isExtraLifeActive && !extraLifeGranted;
   const noMoreExtraLife = isExtraLifeAvailable && !isCorrect && remainingLifeRequests === 0;
-  const {count: lives} = getLives(state);
+  const {hide, count: lives} = getLives(state);
   const header = isNil(answerResult)
     ? {}
     : {
         title: translate(isCorrect ? 'Good job' : 'Ouch'),
         subtitle: translate(isCorrect ? 'Good answer' : 'Wrong answer'),
         failed: isLoading ? null : !isCorrect,
-        lives
+        lives: hide ? null : lives
       };
-
   const question = {
     header: getOr('', 'question.header', slide),
     answerPrefix: translate('Correct answer'),
@@ -149,7 +148,7 @@ export const popinCorrectionStateToProps = (options, store) => state => {
       ? {type: 'popinCorrection'}
       : {
           type: 'popinCorrection',
-          lives: 1,
+          lives: 10,
           title: '',
           subtitle: '',
           corrections,

--- a/packages/@coorpacademy-player-web/src/map-state-to-props/popin-correction.js
+++ b/packages/@coorpacademy-player-web/src/map-state-to-props/popin-correction.js
@@ -148,7 +148,7 @@ export const popinCorrectionStateToProps = (options, store) => state => {
       ? {type: 'popinCorrection'}
       : {
           type: 'popinCorrection',
-          lives: 10,
+          lives: 1,
           title: '',
           subtitle: '',
           corrections,

--- a/packages/@coorpacademy-player-web/src/map-state-to-props/test/popin-correction.js
+++ b/packages/@coorpacademy-player-web/src/map-state-to-props/test/popin-correction.js
@@ -56,3 +56,36 @@ test('should put revival to false if current step is not extra life, even if les
   t.is(props.quit, undefined);
   t.is(props.overlay, undefined);
 });
+
+test('should return lives', t => {
+  const progressionId = getCurrentProgressionId(popinFailure);
+  let state = set(
+    ['data', 'progressions', 'entities', progressionId, 'state', 'livesDisabled'],
+    false,
+    popinExtraLife
+  );
+  state = set(
+    ['data', 'progressions', 'entities', progressionId, 'state', 'lives'],
+    42,
+    popinExtraLife
+  );
+  const props = popinCorrectionStateToProps({translate: mockTranslate}, {dispatch: identity})(
+    state
+  );
+
+  t.is(props.header.lives, 42);
+});
+
+test('should return empty lives if disabled', t => {
+  const progressionId = getCurrentProgressionId(popinFailure);
+  const state = set(
+    ['data', 'progressions', 'entities', progressionId, 'state', 'livesDisabled'],
+    true,
+    popinExtraLife
+  );
+  const props = popinCorrectionStateToProps({translate: mockTranslate}, {dispatch: identity})(
+    state
+  );
+
+  t.is(props.header.lives, null);
+});

--- a/packages/@coorpacademy-progression-engine/src/config/microlearning.js
+++ b/packages/@coorpacademy-progression-engine/src/config/microlearning.js
@@ -16,7 +16,7 @@ const configurations: Array<Config> = [
   },
   {
     version: '2',
-    lives: 0,
+    lives: 1,
     livesDisabled: true,
     maxTypos: 2,
     slidesToComplete: 4,

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.js
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.js
@@ -34,7 +34,7 @@ test('should return the configuration with the given version if it exists', t =>
   });
   t.deepEqual(getConfigForProgression(createProgression({ref: 'microlearning', version: '2'})), {
     version: '2',
-    lives: 0,
+    lives: 1,
     livesDisabled: true,
     maxTypos: 2,
     slidesToComplete: 4,

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config.js
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config.js
@@ -21,7 +21,7 @@ test('should return the configuration with the given version if it exists', t =>
   });
   t.deepEqual(getConfig({ref: 'microlearning', version: '2'}), {
     version: '2',
-    lives: 0,
+    lives: 1,
     livesDisabled: true,
     maxTypos: 2,
     slidesToComplete: 4,
@@ -60,7 +60,7 @@ test('should return the configuration with the given version if it exists', t =>
 test('should return the default configuration if the engine does not have the given version', t => {
   t.deepEqual(getConfig({ref: 'microlearning', version: 'foobar'}), {
     version: '2',
-    lives: 0,
+    lives: 1,
     livesDisabled: true,
     maxTypos: 2,
     slidesToComplete: 4,


### PR DESCRIPTION
**Detailed purpose of the PR**

This PR disables lives in correction popin when lives are disabled in engine (not done yet because adaptive mode, which is the only other way to have lives disabled, doesn't use the correction popin).

It also fixes the lives in engine config, because lives to 0 causes direct failure in player.

**Result and observation**

You should be able to use the microlearning v2 engine without any lives displayed in correction popin header.

- [ ] **Breaking changes ?**
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing
