### PR TITLE
Embed regenerator-runtime in the Webpack Config

### DIFF
--- a/packages/@coorpacademy-webpack-config/package.json
+++ b/packages/@coorpacademy-webpack-config/package.json
@@ -39,6 +39,7 @@
     "mini-css-extract-plugin": "^0.5.0",
     "nyc": "^13.1.0",
     "postcss-loader": "^3.0.0",
+    "regenerator-runtime": "^0.13.3",
     "style-loader": "^0.23.1",
     "webpack-bundle-analyzer": "^3.1.0"
   },


### PR DESCRIPTION
Je suis en train de refaire les images docker du mooc.
J'ai constaté qu'on ne peut builder (`npm run build`), actuellement, avec seul les dépendance de production.
Ceci en raison de la non présence explicite de `regenerator-runtime` dans les dépendances de production.

Du coup, on rajoute cette dépendance à webpack-config, qui lui est inclu en dépendance de production de nos projet.

J'ai fait un canary, et ça résoud le problème dans le mooc.

Je m'occuperait du publish, et ferait une version majeur de `webpack-config` 