### PR TITLE
Fix image qr-code(small screens, ie11)

### DIFF
--- a/packages/@coorpacademy-components/src/organism/get-the-app/style.css
+++ b/packages/@coorpacademy-components/src/organism/get-the-app/style.css
@@ -156,6 +156,7 @@
 
 .qrcodeWrapper > img {
   height: 240px;
+  width: 240px;
 }
 
 .qrcodeWrapper {


### PR DESCRIPTION
The image was too small and in a rectangular form, that makes it impossible to scan it