### PR TITLE
Add video player onError prop to be able to log every error

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
@@ -59,9 +59,12 @@ class JWPlayer extends React.Component {
   }
 
   handleError(error) {
+    const {onError, mimeType, jwpOptions} = this.props;
     const {code} = error;
 
-    if (this.props.mimeType === 'application/kontiki') {
+    onError && onError(error);
+
+    if (mimeType === 'application/kontiki') {
       return;
     }
 
@@ -69,7 +72,7 @@ class JWPlayer extends React.Component {
     // Since IE11 dont kinda support M3U8 sometimes,
     // We've decided to switch from M3U8 to mp4 whenever it appears
     if (code === 214000) {
-      const {file: videoUrl} = this.props.jwpOptions;
+      const {file: videoUrl} = jwpOptions;
       const regex = /^https:\/\/content.jwplatform\.com\/manifests\/(\w+).m3u8/;
       const matched = videoUrl.match(regex);
 
@@ -120,7 +123,8 @@ JWPlayer.propTypes = {
   onPlay: PropTypes.func,
   onResume: PropTypes.func,
   onPause: PropTypes.func,
-  onEnded: PropTypes.func
+  onEnded: PropTypes.func,
+  onError: PropTypes.func
 };
 
 export default JWPlayer;

--- a/packages/@coorpacademy-components/src/molecule/video-player/test/jwplayer.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/test/jwplayer.js
@@ -86,7 +86,7 @@ test('should call handlers within props, then add autoplay props', t => {
   instance.handlePause();
   instance.handleResume();
   instance.handleEnded();
-  instance.handleError();
+  instance.handleError(new Error('Foo bar'));
 
   window.jwplayer = () => ({
     play: props.onPlay

--- a/packages/@coorpacademy-components/src/molecule/video-player/test/jwplayer.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/test/jwplayer.js
@@ -51,7 +51,7 @@ test.serial('should do nothing if autoplay is triggered and jwplayer script is n
 });
 
 test('should call handlers within props, then add autoplay props', t => {
-  t.plan(5);
+  t.plan(6);
 
   const props = {
     video: 'baz',
@@ -59,6 +59,7 @@ test('should call handlers within props, then add autoplay props', t => {
     onPlay: () => t.pass(),
     onResume: () => t.pass(),
     onEnded: () => t.pass(),
+    onError: () => t.pass(),
     jwpOptions: {
       playerId: '3',
       file: 'https://simoocdigital.credit-agricole.fr/media/content/bigdata/159363386.mp4',
@@ -85,6 +86,7 @@ test('should call handlers within props, then add autoplay props', t => {
   instance.handlePause();
   instance.handleResume();
   instance.handleEnded();
+  instance.handleError();
 
   window.jwplayer = () => ({
     play: props.onPlay


### PR DESCRIPTION

**Detailed purpose of the PR**

This PR adds `onError` prop for the video player, to be able to log every error.

**Result and observation**

- [ ] **Breaking changes ?**
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing
