### PR TITLE
Fix findBestOf function

### DIFF
--- a/packages/@coorpacademy-player-services/src/test/progressions.js
+++ b/packages/@coorpacademy-player-services/src/test/progressions.js
@@ -117,13 +117,13 @@ test('should find progression', async t => {
 });
 
 test('should find best score', async t => {
-  const progression = await findBestOf('learner', 'chapter', '5.C7');
-  t.is(progression.state.stars, 16);
+  const result = await findBestOf('learner', 'chapter', '5.C7');
+  t.is(result.stars, 16);
 });
 
 test('should find 0 stars when there is no best score so far', async t => {
-  const progression = await findBestOf('none');
-  t.is(progression.state.stars, 0);
+  const result = await findBestOf('none');
+  t.is(result.stars, 0);
 });
 
 test('should add answer action', async t => {

--- a/packages/@coorpacademy-player-store/src/definitions/services/progressions.js
+++ b/packages/@coorpacademy-player-store/src/definitions/services/progressions.js
@@ -27,7 +27,7 @@ type FindBestOf = (
   contentType: ContentType,
   contentRef: string,
   progressionId: string
-) => Progression;
+) => Promise<{|stars: number|}>;
 type FindById = (id: string) => Promise<Progression | void>;
 type GetAvailableContent = Content => Promise<AvailableContent>;
 type MarkResourceAsViewed = (

--- a/packages/@coorpacademy-player-web/sandbox/fixtures/progressions.js
+++ b/packages/@coorpacademy-player-web/sandbox/fixtures/progressions.js
@@ -20,7 +20,7 @@ const findById = async id => {
 };
 
 const getAll = () => {
-  return [...progressionStore.values()];
+  return Promise.resolve([...progressionStore.values()]);
 };
 
 const save = progression => {


### PR DESCRIPTION
**Detailed purpose of the PR**

This PR changes the `findBestOf` and `getAllProgressions` functions need to be used as a promise because in mobile environment, we're dealing with promises for these ones.

**Result and observation**

Everything should be green and on `popin-end`, we should subtract the stars to the current best score.

- [ ] **Breaking changes ?**
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing
