### PR TITLE
Add ability to force best score refresh

### DIFF
--- a/packages/@coorpacademy-player-store/src/actions/api/progressions.js
+++ b/packages/@coorpacademy-player-store/src/actions/api/progressions.js
@@ -262,7 +262,8 @@ export const PROGRESSION_FETCH_BESTOF_FAILURE: string = '@@progression/FETCH_BES
 
 export const fetchBestProgression = (
   progressionContent: Content,
-  progressionId: string
+  progressionId: string,
+  force?: boolean
 ): ThunkAction => (
   dispatch: Function,
   getState: GetState,
@@ -287,10 +288,12 @@ DispatchedAction => {
       PROGRESSION_FETCH_BESTOF_FAILURE
     ],
     task: () => Progressions.findBestOf(engine.ref, type, ref, progressionId),
-    bailout: pipe(
-      getBestScore,
-      score => score !== undefined && score >= 0
-    ),
+    bailout: force
+      ? undefined
+      : pipe(
+          getBestScore,
+          score => score !== undefined && score >= 0
+        ),
     meta: {type, ref}
   });
 

--- a/packages/@coorpacademy-player-store/src/actions/api/test/progressions.fetch-bestof.js
+++ b/packages/@coorpacademy-player-store/src/actions/api/test/progressions.fetch-bestof.js
@@ -92,6 +92,40 @@ test(
 );
 
 test(
+  'should force request if bestScore should be refreshed',
+  macro,
+  pipe(
+    set('ui.current.progressionId', 'foo'),
+    set('data.progressions.entities.foo', {engine, content: {type: 'chapter', ref: 'plop'}}),
+    set('data.contents.chapter.entities.plop.bestScore', 0)
+  )({}),
+  t => ({
+    Progressions: {
+      findBestOf: (engineRef, contentType, contentRef, id) => {
+        t.is(engineRef, 'microlearning');
+        t.is(contentRef, 'bar');
+        t.is(contentType, 'foo');
+        t.is(id, 'foo');
+        return 'baz';
+      }
+    }
+  }),
+  fetchBestProgression(progressionContent, 'foo', true),
+  [
+    {
+      type: PROGRESSION_FETCH_BESTOF_REQUEST,
+      meta: progressionContent
+    },
+    {
+      type: PROGRESSION_FETCH_BESTOF_SUCCESS,
+      meta: progressionContent,
+      payload: 'baz'
+    }
+  ],
+  4
+);
+
+test(
   'should return error if request failed',
   macro,
   state,


### PR DESCRIPTION

**Detailed purpose of the PR**

This PR adds ability to force best score fetch to refresh it on mobile.

**Result and observation**

You should be able to refresh the best score even it's already fetched. It's useful if you have a store persisted between your app screens and needs to refresh this value to take in consideration local progressions or best score change on API.

- [ ] **Breaking changes ?** 
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing
