### PR TITLE
Remove useless border

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/hero/style.css
+++ b/packages/@coorpacademy-components/src/molecule/hero/style.css
@@ -17,7 +17,6 @@
   display: inline-block;
   box-sizing: border-box;
   vertical-align: top;
-  border: solid 1px light;
   background-color: white;
   overflow: hidden;
   height: 100%;


### PR DESCRIPTION
Removes Border from hero

# Before 

<img width="1639" alt="Capture d’écran 2019-10-31 à 10 34 19" src="https://user-images.githubusercontent.com/23306911/67935484-3274ed00-fbca-11e9-9e04-4b04c8a60b4f.png">

# After

<img width="1648" alt="Capture d’écran 2019-10-31 à 10 35 21" src="https://user-images.githubusercontent.com/23306911/67935502-3c96eb80-fbca-11e9-8d09-0eac4ed2ccf9.png">

