### PR TITLE
Fix e2e window.jwplayer error

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactJWPlayer from 'react-jw-player';
 import includes from 'lodash/fp/includes';
+import isFunction from 'lodash/fp/isFunction';
 import keys from 'lodash/fp/keys';
 import {SrcPropType} from '../../util/proptypes';
 import style from './jwplayer.css';
@@ -36,7 +37,7 @@ class JWPlayer extends React.Component {
     const changes = keys(this.props).filter(_name => this.props[_name] !== prevProps[_name]);
     const shouldStart = includes('autoplay', changes);
     if (shouldStart) {
-      if (window.jwplayer) {
+      if (isFunction(window.jwplayer)) {
         window.jwplayer().play();
       }
     }


### PR DESCRIPTION
This PR aims to fix this ` unknown error: window.jwplayer is not a function` error when running e2e tests on the MOOC.

