### PR TITLE
add sticky block on discipline page

### DIFF
--- a/packages/@coorpacademy-components/src/template/common/discipline/index.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/index.js
@@ -27,17 +27,19 @@ const Discipline = (props, context) => {
       <div className={style.header}>
         <DisciplineHeader image={image} video={video} title={title} description={description} />
       </div>
-      <div className={style.cta}>
-        <DisciplineCTA
-          type={'discipline'}
-          start={start}
-          buy={buy}
-          startLabel={startLabel}
-          buyLabel={buyLabel}
-        />
-      </div>
-      <div className={style.partners}>
-        <DisciplinePartners authors={authors} />
+      <div className={style.sticky}>
+        <div className={style.cta}>
+          <DisciplineCTA
+            type={'discipline'}
+            start={start}
+            buy={buy}
+            startLabel={startLabel}
+            buyLabel={buyLabel}
+          />
+        </div>
+        <div className={style.partners}>
+          <DisciplinePartners authors={authors} />
+        </div>
       </div>
       <div className={style.content}>
         <DisciplineScope

--- a/packages/@coorpacademy-components/src/template/common/discipline/style.css
+++ b/packages/@coorpacademy-components/src/template/common/discipline/style.css
@@ -14,6 +14,14 @@
   margin-bottom: 30px;
 }
 
+.sticky {
+  position: fixed;
+  left: 50%;
+  margin-left: 330px;
+  top: 80px;
+  width: 280px;
+}
+
 .leftColumn {
   composes: column;
   float: left;
@@ -40,7 +48,14 @@
   .wrapper {
     display: flex;
   }
-
+  .sticky {
+    composes: wrapper from '../layout.css';
+    position: inherit;
+    display: flex;
+    flex-basis: 100%;
+    order: 2;
+    margin-left: 0px;
+  }
   .column {
     display: flex;
     flex-basis: 100%;
@@ -66,5 +81,8 @@
 @media mobile {
   .content {
     width: 100%;
+  }
+  .sticky {
+    padding: 0px;
   }
 }


### PR DESCRIPTION
### 1 -  desktop with sticky block
![desktop-discipline](https://user-images.githubusercontent.com/15608581/68948352-fcce2780-07b7-11ea-882b-ea908c496337.gif)
### 2 -  tablette without sticky block
![tablette-description](https://user-images.githubusercontent.com/15608581/68948354-fcce2780-07b7-11ea-8449-c14d68149399.gif)
### 3 -  mobile without sticky block
<img src="https://user-images.githubusercontent.com/15608581/68948353-fcce2780-07b7-11ea-803b-a8e8a37bbb3f.gif" width="300px"/>




**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
