### PR TITLE
extralife overlay = no autoplay

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/resource-player/index.js
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/index.js
@@ -34,7 +34,7 @@ const imgPropType = PropTypes.shape({
 });
 
 const ResourceElement = props => {
-  const {resource, autoplay = false, autostart} = props;
+  const {resource, autoplay = false, disableAutostart} = props;
   const {type, videoId, ...childProps} = omit('id', resource);
   const {url} = childProps;
 
@@ -47,7 +47,7 @@ const ResourceElement = props => {
       return (
         <VideoPlayer
           autoplay={autoplay}
-          autostart={autostart}
+          disableAutostart={disableAutostart}
           id={videoId}
           height="100%"
           width="100%"
@@ -59,7 +59,8 @@ const ResourceElement = props => {
 
 ResourceElement.propTypes = {
   resource: PropTypes.oneOfType([videoPropType, pdfPropType, imgPropType]),
-  autoplay: PropTypes.bool
+  autoplay: PropTypes.bool,
+  disableAutostart: PropTypes.bool
 };
 
 const OverlayElement = (props = {}, context = undefined) => {
@@ -138,7 +139,7 @@ class ResourcePlayer extends React.Component {
         {overlayView}
         <ResourceElement
           {...this.props}
-          autostart={!this.props.overlay}
+          disableAutostart={!!this.props.overlay}
           autoplay={this.state.autoplay}
         />
       </div>

--- a/packages/@coorpacademy-components/src/molecule/resource-player/index.js
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/index.js
@@ -34,7 +34,7 @@ const imgPropType = PropTypes.shape({
 });
 
 const ResourceElement = props => {
-  const {resource, autoplay = false, overlay} = props;
+  const {resource, autoplay = false, autostart} = props;
   const {type, videoId, ...childProps} = omit('id', resource);
   const {url} = childProps;
 
@@ -47,7 +47,7 @@ const ResourceElement = props => {
       return (
         <VideoPlayer
           autoplay={autoplay}
-          autostart={!overlay}
+          autostart={autostart}
           id={videoId}
           height="100%"
           width="100%"
@@ -136,7 +136,11 @@ class ResourcePlayer extends React.Component {
     return (
       <div data-name={type} className={className}>
         {overlayView}
-        <ResourceElement {...this.props} autoplay={this.state.autoplay} />
+        <ResourceElement
+          {...this.props}
+          autostart={!this.props.overlay}
+          autoplay={this.state.autoplay}
+        />
       </div>
     );
   }

--- a/packages/@coorpacademy-components/src/molecule/resource-player/index.js
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/index.js
@@ -34,7 +34,7 @@ const imgPropType = PropTypes.shape({
 });
 
 const ResourceElement = props => {
-  const {resource, autoplay = false} = props;
+  const {resource, autoplay = false, overlay} = props;
   const {type, videoId, ...childProps} = omit('id', resource);
   const {url} = childProps;
 
@@ -47,6 +47,7 @@ const ResourceElement = props => {
       return (
         <VideoPlayer
           autoplay={autoplay}
+          autostart={!overlay}
           id={videoId}
           height="100%"
           width="100%"

--- a/packages/@coorpacademy-components/src/molecule/resource-player/test/fixtures/jwplayer-with-overlay.js
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/test/fixtures/jwplayer-with-overlay.js
@@ -12,7 +12,7 @@ export default {
         playerScript: JWPLAYER_SCRIPT_URL,
         licenseKey: 'QDh3Fb2afiIAFI+XwlncwQDhNEwkXetm1y8tzWn3km8=',
         customProps: {
-          autostart: false,
+          autostart: 'viewable',
           width: '100%',
           height: '100%',
           skin: {

--- a/packages/@coorpacademy-components/src/molecule/resource-player/test/overlay.js
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/test/overlay.js
@@ -23,7 +23,7 @@ test('should call jwplayer.onPlay when overlay is clicked', t => {
         playerScript: JWPLAYER_SCRIPT_URL,
         licenseKey: 'QDh3Fb2afiIAFI+XwlncwQDhNEwkXetm1y8tzWn3km8=',
         customProps: {
-          autostart: false,
+          autostart: 'viewable',
           width: '100%',
           height: '100%',
           skin: {

--- a/packages/@coorpacademy-components/src/molecule/video-player/index.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/index.js
@@ -62,8 +62,20 @@ class VideoPlayer extends React.Component {
         );
       case 'application/kontiki':
       case 'application/jwplayer':
-      case 'video/mp4':
-        return <JWPlayer {...this.props} onPlay={this.handleOnPlay} key={id} />;
+      case 'video/mp4': {
+        const {autostart, jwpOptions, ...otherProps} = this.props;
+        const _jwpOptions = {
+          ...jwpOptions,
+          customProps: {
+            ...jwpOptions.customProps,
+            autostart: autostart && jwpOptions.customProps.autostart
+          }
+        };
+
+        return (
+          <JWPlayer jwpOptions={_jwpOptions} {...otherProps} onPlay={this.handleOnPlay} key={id} />
+        );
+      }
     }
   };
 
@@ -87,6 +99,7 @@ VideoPlayer.propTypes = {
   onEnded: PropTypes.func,
   onError: PropTypes.func,
   autoplay: PropTypes.bool,
+  autostart: PropTypes.bool,
   jwpOptions: JWPlayer.propTypes.jwpOptions,
   mimeType: PropTypes.oneOf([
     'application/kontiki',

--- a/packages/@coorpacademy-components/src/molecule/video-player/index.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {isEqual} from 'lodash/fp';
+import {get, isEqual} from 'lodash/fp';
 import {SrcPropType} from '../../util/proptypes';
 import VideoIframe from '../video-iframe';
 import JWPlayer from './jwplayer';
@@ -67,8 +67,8 @@ class VideoPlayer extends React.Component {
         const _jwpOptions = {
           ...jwpOptions,
           customProps: {
-            ...jwpOptions.customProps,
-            autostart: autostart && jwpOptions.customProps.autostart
+            ...get('customProps', jwpOptions),
+            autostart: autostart && get('customProps.autostart', jwpOptions)
           }
         };
 

--- a/packages/@coorpacademy-components/src/molecule/video-player/index.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {get, isEqual} from 'lodash/fp';
+import {isEqual} from 'lodash/fp';
 import {SrcPropType} from '../../util/proptypes';
 import VideoIframe from '../video-iframe';
 import JWPlayer from './jwplayer';
@@ -64,16 +64,15 @@ class VideoPlayer extends React.Component {
       case 'application/jwplayer':
       case 'video/mp4': {
         const {autostart, jwpOptions, ...otherProps} = this.props;
-        const _jwpOptions = {
-          ...jwpOptions,
-          customProps: {
-            ...get('customProps', jwpOptions),
-            autostart: autostart && get('customProps.autostart', jwpOptions)
-          }
-        };
 
         return (
-          <JWPlayer jwpOptions={_jwpOptions} {...otherProps} onPlay={this.handleOnPlay} key={id} />
+          <JWPlayer
+            autostart={autostart}
+            jwpOptions={jwpOptions}
+            {...otherProps}
+            onPlay={this.handleOnPlay}
+            key={id}
+          />
         );
       }
     }

--- a/packages/@coorpacademy-components/src/molecule/video-player/index.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/index.js
@@ -63,11 +63,11 @@ class VideoPlayer extends React.Component {
       case 'application/kontiki':
       case 'application/jwplayer':
       case 'video/mp4': {
-        const {autostart, jwpOptions, ...otherProps} = this.props;
+        const {disableAutostart, jwpOptions, ...otherProps} = this.props;
 
         return (
           <JWPlayer
-            autostart={autostart}
+            disableAutostart={disableAutostart}
             jwpOptions={jwpOptions}
             {...otherProps}
             onPlay={this.handleOnPlay}
@@ -98,7 +98,7 @@ VideoPlayer.propTypes = {
   onEnded: PropTypes.func,
   onError: PropTypes.func,
   autoplay: PropTypes.bool,
-  autostart: PropTypes.bool,
+  disableAutostart: PropTypes.bool,
   jwpOptions: JWPlayer.propTypes.jwpOptions,
   mimeType: PropTypes.oneOf([
     'application/kontiki',

--- a/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactJWPlayer from 'react-jw-player';
-import {includes, isFunction, keys} from 'lodash/fp';
+import {get, includes, isFunction, keys} from 'lodash/fp';
 import {SrcPropType} from '../../util/proptypes';
 import style from './jwplayer.css';
 
@@ -117,13 +117,21 @@ class JWPlayer extends React.Component {
   }
 
   render() {
+    const _jwpOptions = {
+      ...this.props.jwpOptions,
+      customProps: {
+        ...get('customProps', this.props.jwpOptions),
+        autostart: this.props.autostart && get('customProps.autostart', this.props.jwpOptions)
+      }
+    };
+
     return (
       <>
         {this.state.scriptFailedLoading && (
           <p className={style.errorMessage}>{this.props.scriptErrorMessage}</p>
         )}
         <ReactJWPlayer
-          {...this.props.jwpOptions}
+          {..._jwpOptions}
           className={style.wrapper}
           onPlay={this.handlePlay}
           onResume={this.handleResume}
@@ -142,6 +150,7 @@ class JWPlayer extends React.Component {
 }
 
 JWPlayer.propTypes = {
+  autostart: PropTypes.bool,
   // https://developer.jwplayer.com/jwplayer/docs/jw8-player-configuration-reference
   jwpOptions: PropTypes.shape({
     file: SrcPropType,

--- a/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
@@ -117,11 +117,12 @@ class JWPlayer extends React.Component {
   }
 
   render() {
+    const {jwpOptions, disableAutostart} = this.props;
     const _jwpOptions = {
-      ...this.props.jwpOptions,
+      ...jwpOptions,
       customProps: {
-        ...get('customProps', this.props.jwpOptions),
-        autostart: this.props.autostart && get('customProps.autostart', this.props.jwpOptions)
+        ...get('customProps', jwpOptions),
+        autostart: !disableAutostart && get('customProps.autostart', jwpOptions)
       }
     };
 
@@ -150,7 +151,7 @@ class JWPlayer extends React.Component {
 }
 
 JWPlayer.propTypes = {
-  autostart: PropTypes.bool,
+  disableAutostart: PropTypes.bool,
   // https://developer.jwplayer.com/jwplayer/docs/jw8-player-configuration-reference
   jwpOptions: PropTypes.shape({
     file: SrcPropType,

--- a/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
@@ -142,6 +142,7 @@ class JWPlayer extends React.Component {
 }
 
 JWPlayer.propTypes = {
+  // https://developer.jwplayer.com/jwplayer/docs/jw8-player-configuration-reference
   jwpOptions: PropTypes.shape({
     file: SrcPropType,
     customProps: PropTypes.shape({
@@ -154,6 +155,7 @@ JWPlayer.propTypes = {
           default: PropTypes.boolean
         })
       ),
+      autostart: PropTypes.oneOf(['viewable', 'false']),
       width: PropTypes.string,
       skin: PropTypes.shape({
         name: PropTypes.string

--- a/packages/@coorpacademy-components/src/molecule/video-player/test/fixtures/jwplayer-with-subtitles.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/test/fixtures/jwplayer-with-subtitles.js
@@ -17,7 +17,7 @@ export default {
             default: true
           }
         ],
-        autostart: false,
+        autostart: 'viewable',
         width: '100%',
         height: '100%'
       }

--- a/packages/@coorpacademy-components/src/molecule/video-player/test/fixtures/jwplayer.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/test/fixtures/jwplayer.js
@@ -9,7 +9,7 @@ export default {
       playerScript: JWPLAYER_SCRIPT_URL,
       licenseKey: 'QDh3Fb2afiIAFI+XwlncwQDhNEwkXetm1y8tzWn3km8=',
       customProps: {
-        autostart: false,
+        autostart: 'viewable',
         width: '100%',
         height: '100%'
       }

--- a/packages/@coorpacademy-components/src/molecule/video-player/test/fixtures/kontiki.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/test/fixtures/kontiki.js
@@ -9,7 +9,7 @@ export default {
       playerScript: JWPLAYER_SCRIPT_URL,
       licenseKey: 'QDh3Fb2afiIAFI+XwlncwQDhNEwkXetm1y8tzWn3km8=',
       customProps: {
-        autostart: false,
+        autostart: 'viewable',
         width: '100%',
         height: '100%'
       }

--- a/packages/@coorpacademy-components/src/molecule/video-player/test/fixtures/mp4.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/test/fixtures/mp4.js
@@ -9,7 +9,7 @@ export default {
       playerScript: JWPLAYER_SCRIPT_URL,
       licenseKey: 'QDh3Fb2afiIAFI+XwlncwQDhNEwkXetm1y8tzWn3km8=',
       customProps: {
-        autostart: false,
+        autostart: 'viewable',
         width: '100%',
         height: '100%',
         skin: {

--- a/packages/@coorpacademy-components/src/molecule/video-player/test/index.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/test/index.js
@@ -17,7 +17,11 @@ test('should emit play only one', t => {
     onPause: () => t.is('Pause', events.shift()),
     onPlay: () => t.is('Play', events.shift()),
     onResume: () => t.is('Resume', events.shift()),
-    onEnd: () => t.is('End', events.shift())
+    onEnd: () => t.is('End', events.shift()),
+    jwpOptions: {
+      licenseKey: '12345',
+      playerScript: '/path/to/jwplayer.js'
+    }
   };
 
   const component = <Player {...props} />;

--- a/packages/@coorpacademy-components/src/molecule/video-player/test/jwplayer.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/test/jwplayer.js
@@ -70,7 +70,7 @@ test('should call handlers within props, then add autoplay props', t => {
       licenseKey: 'QDh3Fb2afiIAFI+XwlncwQDhNEwkXetm1y8tzWn3km8=',
       customProps: {
         aspectratio: '16:9',
-        autostart: false,
+        autostart: 'viewable',
         width: '100%',
         skin: {
           name: 'bekle'


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

User must click on overlay to activate video + extralife
==> overriding `customProps.autostart` video option if there is an overlay

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [x] Unit testing
