### PR TITLE
[FIX]Trigger on play even with auto start

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "flow": "lerna run flow",
     "codecov": "codecov",
     "publish:beta": "lerna publish --npm-tag beta --exact",
-    "publish:canary": "lerna publish --canary --exact patch --no-git-tag-version --no-push --npm-client npm",
+    "publish:canary": "lerna publish --canary --exact patch --no-git-tag-version --no-push",
     "publish:latest": "lerna publish --exact",
     "postinstall": "npm run preflow",
     "update": "update-node"

--- a/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/jwplayer.js
@@ -134,6 +134,7 @@ class JWPlayer extends React.Component {
         <ReactJWPlayer
           {..._jwpOptions}
           className={style.wrapper}
+          onAutoStart={this.handlePlay}
           onPlay={this.handlePlay}
           onResume={this.handleResume}
           onPause={this.handlePause}


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

Consider a resourced as viewed even after a video autostart.


<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

Before

![Kapture 2019-12-03 at 15 53 07](https://user-images.githubusercontent.com/15958334/70061958-743bed80-15e5-11ea-9be8-274af8c3dd67.gif)

After

![Kapture 2019-12-03 at 15 58 06](https://user-images.githubusercontent.com/15958334/70062234-edd3db80-15e5-11ea-8d33-17dec44d427b.gif)

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [X] Manual testing
- [ ] Unit testing
