### PR TITLE
Add missing type to fetchTracksById

### DIFF
--- a/packages/@coorpacademy-player-store/src/actions/api/test/videos.js
+++ b/packages/@coorpacademy-player-store/src/actions/api/test/videos.js
@@ -11,7 +11,7 @@ import {
   FETCH_VIDEOS_TRACKS_SUCCESS,
   FETCH_VIDEOS_TRACKS_FAILURE
 } from '../videos';
-
+import {VIDEO_TRACK_TYPE} from '../../../definitions/models';
 import tracks from '../../../fixtures/tracks';
 
 test(
@@ -94,11 +94,39 @@ test(
   [
     {
       type: FETCH_VIDEOS_TRACKS_REQUEST,
-      meta: {id: '1234'}
+      meta: {id: '1234', type: VIDEO_TRACK_TYPE.SRT}
     },
     {
       type: FETCH_VIDEOS_TRACKS_SUCCESS,
-      meta: {id: '1234'},
+      meta: {id: '1234', type: VIDEO_TRACK_TYPE.SRT},
+      payload: tracks
+    }
+  ],
+  1
+);
+
+test(
+  'should fetch a subtitle (vtt)',
+  macro,
+  {},
+  t => ({
+    Videos: {
+      findTracksById: id => {
+        t.is(id, '1234');
+
+        return tracks;
+      }
+    }
+  }),
+  fetchVideoTracks('1234', VIDEO_TRACK_TYPE.VTT),
+  [
+    {
+      type: FETCH_VIDEOS_TRACKS_REQUEST,
+      meta: {id: '1234', type: VIDEO_TRACK_TYPE.VTT}
+    },
+    {
+      type: FETCH_VIDEOS_TRACKS_SUCCESS,
+      meta: {id: '1234', type: VIDEO_TRACK_TYPE.VTT},
       payload: tracks
     }
   ],
@@ -127,11 +155,11 @@ test(
   [
     {
       type: FETCH_VIDEOS_TRACKS_REQUEST,
-      meta: {id: '456'}
+      meta: {id: '456', type: VIDEO_TRACK_TYPE.SRT}
     },
     {
       type: FETCH_VIDEOS_TRACKS_FAILURE,
-      meta: {id: '456'},
+      meta: {id: '456', type: VIDEO_TRACK_TYPE.SRT},
       error: true,
       payload: new Error('some error')
     }

--- a/packages/@coorpacademy-player-store/src/actions/api/videos.js
+++ b/packages/@coorpacademy-player-store/src/actions/api/videos.js
@@ -4,7 +4,8 @@ import buildTask from '@coorpacademy/redux-task';
 
 import {getVideoUri, getVideoTracks} from '../../utils/state-extract';
 import type {Services} from '../../definitions/services';
-import type {VideoProvider} from '../../definitions/models';
+import type {VideoProvider, VideoTrackType} from '../../definitions/models';
+import {VIDEO_TRACK_TYPE} from '../../definitions/models';
 import type {
   Action,
   Dispatch,
@@ -39,7 +40,10 @@ DispatchedAction => {
   return dispatch(action);
 };
 
-export const fetchVideoTracks = (id: string): ThunkAction => (
+export const fetchVideoTracks = (
+  id: string,
+  type?: VideoTrackType = VIDEO_TRACK_TYPE.SRT
+): ThunkAction => (
   dispatch: Dispatch,
   getState: GetState,
   {services}: {services: Services}
@@ -49,8 +53,8 @@ DispatchedAction => {
 
   const action: Action = buildTask({
     types: [FETCH_VIDEOS_TRACKS_REQUEST, FETCH_VIDEOS_TRACKS_SUCCESS, FETCH_VIDEOS_TRACKS_FAILURE],
-    task: () => VideosService.findTracksById(id),
-    meta: {id},
+    task: () => VideosService.findTracksById(id, type),
+    meta: {id, type},
     bailout: getVideoTracks(id)
   });
 


### PR DESCRIPTION
**Detailed purpose of the PR**

This PR fixes missing type argument on `fetchTracksById` redux action, so the value is always `srt` in videos service and can't be customized (for the mobile)

**Result and observation**

Nothing special

- [ ] **Breaking changes ?**
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing
