### PR TITLE
Instant feedback after an submit answer

### DIFF
--- a/packages/@coorpacademy-player-store/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/answers.js
@@ -119,9 +119,11 @@ export const validateAnswer = (partialPayload: PostAnswerPartialPayload) => asyn
   const progressionId = getCurrentProgressionId(initialState);
   const answer = getAnswerValues(slide, initialState);
 
-  const createAnswerResponse = await dispatch(createAnswer(progressionId, answer, partialPayload));
-  if (createAnswerResponse.error) return createAnswerResponse;
-  await dispatch(selectRoute('correction'));
+  const [createAnswerResponse] = await Promise.all([
+    dispatch(createAnswer(progressionId, answer, partialPayload)),
+    dispatch(selectRoute('correction'))
+  ]);
+  if (createAnswerResponse.error) return dispatch(selectRoute('answer'));
 
   const payload = createAnswerResponse.payload;
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-accordion.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-accordion.js
@@ -132,6 +132,13 @@ const answer = result => [
     }
   },
   {
+    type: UI_SELECT_ROUTE,
+    payload: 'correction',
+    meta: {
+      progressionId: 'foo'
+    }
+  },
+  {
     type: PROGRESSION_CREATE_ANSWER_SUCCESS,
     meta: {
       progressionId: 'foo',
@@ -142,13 +149,6 @@ const answer = result => [
       }
     },
     payload: result
-  },
-  {
-    type: UI_SELECT_ROUTE,
-    payload: 'correction',
-    meta: {
-      progressionId: 'foo'
-    }
   }
 ];
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-exit-node.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-exit-node.js
@@ -70,6 +70,13 @@ test(
       }
     },
     {
+      type: UI_SELECT_ROUTE,
+      payload: 'correction',
+      meta: {
+        progressionId: 'foo'
+      }
+    },
+    {
       type: PROGRESSION_CREATE_ANSWER_SUCCESS,
       meta: {
         progressionId: 'foo',
@@ -83,13 +90,6 @@ test(
         set('state.content.ref', 'slideRef'),
         set('state.nextContent', {type: 'success', ref: 'successExitNode'})
       )({})
-    },
-    {
-      type: UI_SELECT_ROUTE,
-      payload: 'correction',
-      meta: {
-        progressionId: 'foo'
-      }
     },
     accordionIsOpenAt(0),
     progressionUpdated,

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-failure.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-failure.js
@@ -80,6 +80,13 @@ test(
       }
     },
     {
+      type: UI_SELECT_ROUTE,
+      payload: 'correction',
+      meta: {
+        progressionId: 'foo'
+      }
+    },
+    {
       type: PROGRESSION_CREATE_ANSWER_FAILURE,
       meta: {
         progressionId: 'foo',
@@ -91,6 +98,13 @@ test(
       },
       error: true,
       payload: new Error('some error')
+    },
+    {
+      type: UI_SELECT_ROUTE,
+      payload: 'answer',
+      meta: {
+        progressionId: 'foo'
+      }
     }
   ],
   3
@@ -171,6 +185,13 @@ test(
       }
     },
     {
+      type: UI_SELECT_ROUTE,
+      payload: 'correction',
+      meta: {
+        progressionId: 'foo'
+      }
+    },
+    {
       type: PROGRESSION_CREATE_ANSWER_SUCCESS,
       meta: {
         progressionId: 'foo',
@@ -186,13 +207,6 @@ test(
         set('state.isCorrect', false),
         set('state.viewedResources', [])
       )({})
-    },
-    {
-      type: UI_SELECT_ROUTE,
-      payload: 'correction',
-      meta: {
-        progressionId: 'foo'
-      }
     },
     {
       type: UI_TOGGLE_ACCORDION,

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-success.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-success.js
@@ -76,32 +76,6 @@ const successfullyFetchAnswer = [
   }
 ];
 
-const createCorrectAnswer = [
-  {
-    type: PROGRESSION_CREATE_ANSWER_REQUEST,
-    meta: {
-      progressionId: 'foo',
-      answer: ['bar'],
-      content: {
-        ref: 'baz',
-        type: 'slide'
-      }
-    }
-  },
-  {
-    type: PROGRESSION_CREATE_ANSWER_SUCCESS,
-    meta: {
-      progressionId: 'foo',
-      answer: ['bar'],
-      content: {
-        ref: 'baz',
-        type: 'slide'
-      }
-    },
-    payload: postAnswerPayload
-  }
-];
-
 test(
   'should submit answer with the current content and refresh progression state',
   macro,
@@ -156,13 +130,35 @@ test(
   }),
   validateAnswer(),
   flatten([
-    createCorrectAnswer,
+    {
+      type: PROGRESSION_CREATE_ANSWER_REQUEST,
+      meta: {
+        progressionId: 'foo',
+        answer: ['bar'],
+        content: {
+          ref: 'baz',
+          type: 'slide'
+        }
+      }
+    },
     {
       type: UI_SELECT_ROUTE,
       payload: 'correction',
       meta: {
         progressionId: 'foo'
       }
+    },
+    {
+      type: PROGRESSION_CREATE_ANSWER_SUCCESS,
+      meta: {
+        progressionId: 'foo',
+        answer: ['bar'],
+        content: {
+          ref: 'baz',
+          type: 'slide'
+        }
+      },
+      payload: postAnswerPayload
     },
     contentFetchActions,
     accordionIsOpenAt(2),


### PR DESCRIPTION
Lors du clic sur `valider`, le feedback UI est direct, on attend plus le retour du serveur avant de passer en écran de correction.