### PR TITLE
Resumes progression on extraLife endpoint

### DIFF
--- a/packages/@coorpacademy-player-store/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/answers.js
@@ -6,6 +6,7 @@ import {
   getAnswerValues,
   getCurrentProgressionId,
   getCurrentSlide,
+  getPrevAnswer,
   getQuestionType,
   hasSeenLesson
 } from '../../utils/state-extract';
@@ -150,5 +151,6 @@ export const validateAnswer = (partialPayload: PostAnswerPartialPayload) => asyn
   }
 
   await dispatch(progressionUpdated(progressionId, PROGRESSION_UPDATED_ON_MOVE));
-  return dispatch(fetchAnswer(progressionId, slideId, answer));
+  const prevAnswer = getPrevAnswer(state);
+  return dispatch(fetchAnswer(progressionId, slideId, prevAnswer));
 };

--- a/packages/@coorpacademy-player-store/src/actions/ui/progressions.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/progressions.js
@@ -12,12 +12,13 @@ import {fetchNext} from '../api/next-content';
 
 import {fetchAnswer} from '../api/answers';
 import {
-  getEngine,
-  getProgressionContent,
   getCurrentProgressionId,
-  getStepContent,
+  getEngine,
+  getPrevAnswer,
   getPrevStepContent,
-  getSlide
+  getProgressionContent,
+  getSlide,
+  getStepContent
 } from '../../utils/state-extract';
 import type {Action, DispatchedAction, GetState, Options} from '../../definitions/redux';
 import type {ExitNodeRef} from '../../definitions/models';
@@ -156,10 +157,12 @@ export const selectProgression = (id: ProgressionId) => async (
             });
           }
 
+          const prevAnswer = getPrevAnswer(getState());
+
           return Promise.all([
             fetchData(engine, progressionId, progressionContent)(dispatch),
             dispatch(fetchContent(prevContent.type, prevContent.ref)),
-            dispatch(fetchAnswer(progressionId, get('ref', prevContent), []))
+            dispatch(fetchAnswer(progressionId, get('ref', prevContent), prevAnswer))
           ]).then(last);
         }
       }

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-success.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-success.js
@@ -12,11 +12,30 @@ import {ANSWER_FETCH_REQUEST, ANSWER_FETCH_SUCCESS} from '../../../api/answers';
 import {CONTENT_FETCH_REQUEST, CONTENT_FETCH_SUCCESS} from '../../../api/contents';
 import {accordionIsOpenAt, progressionUpdated} from './helpers/shared';
 
-const postAnswerPayload = pipe(
-  set('state.content.ref', 'baz'),
-  set('state.nextContent', {type: 'slide', ref: 'slideRef'}),
-  set('state.isCorrect', true)
-)({});
+const postAnswerPayload = {
+  engine: {
+    ref: 'learner',
+    version: '1'
+  },
+  state: {
+    content: {
+      type: 'slide',
+      ref: 'sli_1'
+    },
+    nextContent: {
+      type: 'slide',
+      ref: 'slideRef'
+    },
+    isCorrect: true,
+    allAnswers: [
+      {
+        slideRef: 'sli_1',
+        isCorrect: true,
+        answer: ['bar']
+      }
+    ]
+  }
+};
 
 const contentFetchActions = [
   {
@@ -60,14 +79,14 @@ const successfullyFetchAnswer = [
     type: ANSWER_FETCH_REQUEST,
     meta: {
       progressionId: 'foo',
-      slideId: 'baz'
+      slideId: 'sli_1'
     }
   },
   {
     type: ANSWER_FETCH_SUCCESS,
     meta: {
       progressionId: 'foo',
-      slideId: 'baz'
+      slideId: 'sli_1'
     },
     payload: {
       correctAnswer: ['Bonne réponse'],
@@ -82,18 +101,26 @@ test(
   pipe(
     set('ui.answers.foo.value', ['bar']),
     set('ui.current.progressionId', 'foo'),
-    set('data.progressions.entities.foo.engine', {
-      ref: 'learner',
-      version: '1'
+    set('data.progressions.entities.foo', {
+      engine: {
+        ref: 'learner',
+        version: '1'
+      },
+      content: {
+        type: 'chapter',
+        ref: 'chapId'
+      },
+      state: {
+        nextContent: {
+          type: 'slide',
+          ref: 'sli_1'
+        }
+      }
     }),
     set('data.configs.entities.learner@1', {
       version: '1'
     }),
-    set('data.progressions.entities.foo.state.nextContent', {
-      type: 'slide',
-      ref: 'baz'
-    }),
-    set('data.contents.slide.entities.baz', {})
+    set('data.contents.slide.entities.sli_1', {})
   )({}),
   t => ({
     Content: mockContentService(t),
@@ -101,7 +128,7 @@ test(
       postAnswer: (id, payload) => {
         t.is(id, 'foo');
         t.deepEqual(payload, {
-          content: {type: 'slide', ref: 'baz'},
+          content: {type: 'slide', ref: 'sli_1'},
           answer: ['bar']
         });
         return postAnswerPayload;
@@ -114,6 +141,7 @@ test(
     Answers: {
       findById: (id, slideId, givenAnswer) => {
         t.is(id, 'foo');
+        t.deepEqual(givenAnswer, ['bar']);
         return {
           correctAnswer: ['Bonne réponse'],
           corrections: givenAnswer.map(answer => ({answer, isCorrect: false}))
@@ -136,7 +164,7 @@ test(
         progressionId: 'foo',
         answer: ['bar'],
         content: {
-          ref: 'baz',
+          ref: 'sli_1',
           type: 'slide'
         }
       }
@@ -154,7 +182,7 @@ test(
         progressionId: 'foo',
         answer: ['bar'],
         content: {
-          ref: 'baz',
+          ref: 'sli_1',
           type: 'slide'
         }
       },
@@ -165,5 +193,5 @@ test(
     progressionUpdated,
     successfullyFetchAnswer
   ]),
-  7
+  8
 );

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/progressions.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/progressions.js
@@ -819,7 +819,7 @@ test(
       findById: (progressionId, slideId, givenAnswers) => {
         t.is(slideId, slide._id);
         t.is(progressionId, 'xtralife');
-        t.deepEqual(givenAnswers, []);
+        t.deepEqual(givenAnswers, ['qux']);
         return ['a', 'n', 's', 'w', 'e', 'r', 's'];
       }
     },
@@ -830,7 +830,14 @@ test(
           _id: 'xtralife',
           state: {
             content: {type: 'slide', ref: 'bar'},
-            nextContent: {type: 'node', ref: 'extraLife'}
+            nextContent: {type: 'node', ref: 'extraLife'},
+            allAnswers: [
+              {
+                slideRef: 'bar',
+                isCorrect: true,
+                answer: ['qux']
+              }
+            ]
           },
           content: {type: 'chapter', ref: 'baz'},
           engine: {ref: 'qux', version: 'quux'}
@@ -881,7 +888,14 @@ test(
         _id: 'xtralife',
         state: {
           content: {type: 'slide', ref: 'bar'},
-          nextContent: {type: 'node', ref: 'extraLife'}
+          nextContent: {type: 'node', ref: 'extraLife'},
+          allAnswers: [
+            {
+              slideRef: 'bar',
+              isCorrect: true,
+              answer: ['qux']
+            }
+          ]
         },
         content: {type: 'chapter', ref: 'baz'},
         engine: {ref: 'qux', version: 'quux'}

--- a/packages/@coorpacademy-player-store/src/test/index.js
+++ b/packages/@coorpacademy-player-store/src/test/index.js
@@ -69,6 +69,7 @@ test('it should expose all api', t => {
     'hasSeenLesson',
     'getVideoUri',
     'getVideoTracks',
+    'getPrevAnswer',
     'MEDIA_VIEWED_ANALYTICS_REQUEST',
     'MEDIA_VIEWED_ANALYTICS_SUCCESS',
     'MEDIA_VIEWED_ANALYTICS_FAILURE',

--- a/packages/@coorpacademy-player-store/src/utils/state-extract.js
+++ b/packages/@coorpacademy-player-store/src/utils/state-extract.js
@@ -517,3 +517,13 @@ export const getVideoUri = (id: string) => (state: State): string | void =>
 
 export const getVideoTracks = (id: string) => (state: State): Array<VideoTrack> | void =>
   get(['data', 'videos', 'entities', id, 'tracks'], state);
+
+export const getPrevAnswer = (state: State): Answer => {
+  const progression = getCurrentProgression(state);
+
+  return pipe(
+    get('state.allAnswers'),
+    last,
+    getOr([], 'answer')
+  )(progression);
+};

--- a/packages/@coorpacademy-player-store/src/utils/test/state-extract.js
+++ b/packages/@coorpacademy-player-store/src/utils/test/state-extract.js
@@ -42,7 +42,8 @@ import {
   hasSeenLesson,
   getQuestionMedia,
   isContentAdaptive,
-  getVideoTracks
+  getVideoTracks,
+  getPrevAnswer
 } from '../state-extract';
 
 import tracksFixture from '../../fixtures/tracks';
@@ -1086,4 +1087,57 @@ test('should return true if slide is at previous step and at least one lesson ha
   );
 
   return t.is(result, true);
+});
+
+test('getPrevAnswer should return the given answer of the last answered slide', t => {
+  const state = pipe(
+    set('ui.current.progressionId', '0'),
+    set('data.progressions.entities', {
+      '0': {
+        state: {
+          content: {
+            ref: 'sli_1',
+            type: 'slide'
+          },
+          allAnswers: [
+            {
+              slideRef: 'sli_1',
+              answer: ['bar', 'foo'],
+              isCorrect: false
+            },
+            {
+              slideRef: 'sli_1',
+              answer: ['foo', 'bar'],
+              isCorrect: true
+            }
+          ]
+        }
+      }
+    })
+  )({});
+
+  const result = getPrevAnswer(state);
+
+  return t.deepEqual(result, ['foo', 'bar']);
+});
+
+test('getPrevAnswer should return empty answer if there are not an previous slide', t => {
+  const state = pipe(
+    set('ui.current.progressionId', '0'),
+    set('data.progressions.entities', {
+      '0': {
+        state: {
+          nextContent: {
+            ref: 'sli_1',
+            type: 'slide'
+          },
+          allAnswers: []
+        }
+      }
+    })
+  )({});
+
+  const result = getPrevAnswer(state);
+
+  return t.deepEqual(result, []);
 });

--- a/packages/@coorpacademy-player-web/sandbox/fixtures/data/progressions.json
+++ b/packages/@coorpacademy-player-web/sandbox/fixtures/data/progressions.json
@@ -543,5 +543,217 @@
         }
       }
     ]
+  },
+  "extralife": {
+    "_id": "extralife",
+    "engine": {
+      "ref": "learner",
+      "version": "2"
+    },
+    "engineOptions": {
+      "livesDisabled": false
+    },
+    "content": {
+      "ref": "mod_E15Bh1hDM",
+      "type": "level",
+      "version": "2"
+    },
+    "actions": [
+      {
+        "payload": {
+          "instructions": null,
+          "nextContent": {
+            "type": "slide",
+            "ref": "sli_4JGaactjS"
+          }
+        },
+        "type": "move"
+      },
+      {
+        "payload": {
+          "answer": [
+            "It comes in different forms",
+            "It is expensive to store"
+          ],
+          "instructions": null,
+          "content": {
+            "ref": "sli_4JGaactjS",
+            "type": "slide"
+          },
+          "nextContent": {
+            "ref": "sli_N1sSU2Kjr",
+            "type": "slide"
+          },
+          "isCorrect": false,
+          "godMode": false
+        },
+        "type": "answer"
+      },
+      {
+        "type": "resource",
+        "payload": {
+          "resource": {
+            "ref": "les_V1RNjcOAS",
+            "type": "video",
+            "version": "1"
+          },
+          "content": {
+            "type": "chapter",
+            "ref": "cha_VJ9Gx~EqS"
+          }
+        }
+      },
+      {
+        "payload": {
+          "answer": [
+            "A sense of diplomacy and a certain political acumen"
+          ],
+          "instructions": null,
+          "content": {
+            "ref": "sli_N1sSU2Kjr",
+            "type": "slide"
+          },
+          "nextContent": {
+            "ref": "sli_NJtyhcYiS",
+            "type": "slide"
+          },
+          "isCorrect": false,
+          "godMode": false
+        },
+        "type": "answer"
+      },
+      {
+        "payload": {
+          "answer": [
+            "decreases"
+          ],
+          "instructions": null,
+          "content": {
+            "ref": "sli_NJtyhcYiS",
+            "type": "slide"
+          },
+          "nextContent": {
+            "ref": "sli_Vk3JSnKiB",
+            "type": "slide"
+          },
+          "isCorrect": true,
+          "godMode": false
+        },
+        "type": "answer"
+      },
+      {
+        "payload": {
+          "answer": [
+            "relevant"
+          ],
+          "instructions": null,
+          "content": {
+            "ref": "sli_Vk3JSnKiB",
+            "type": "slide"
+          },
+          "nextContent": {
+            "ref": "sli_NJxCH5jjS",
+            "type": "slide"
+          },
+          "isCorrect": true,
+          "godMode": false
+        },
+        "type": "answer"
+      },
+      {
+        "payload": {
+          "answer": [
+            "easy to use"
+          ],
+          "instructions": null,
+          "content": {
+            "ref": "sli_NJxCH5jjS",
+            "type": "slide"
+          },
+          "nextContent": {
+            "ref": "sli_VJLDzciiB",
+            "type": "slide"
+          },
+          "isCorrect": true,
+          "godMode": false
+        },
+        "type": "answer"
+      },
+      {
+        "payload": {
+          "answer": [
+            "Focus on their core business",
+            "Quickly acquire users",
+            "Reduce costs",
+            "Profit from their innovations",
+            "Develop goodwill with third parties"
+          ],
+          "instructions": null,
+          "content": {
+            "ref": "sli_VJLDzciiB",
+            "type": "slide"
+          },
+          "nextContent": {
+            "ref": "sli_VJ0nnKjsr",
+            "type": "slide"
+          },
+          "isCorrect": false,
+          "godMode": false
+        },
+        "type": "answer"
+      },
+      {
+        "type": "resource",
+        "payload": {
+          "resource": {
+            "ref": "les_N1mDoc-CB",
+            "type": "video",
+            "version": "1"
+          },
+          "content": {
+            "type": "chapter",
+            "ref": "cha_VyIVx~N9S"
+          }
+        }
+      },
+      {
+        "payload": {
+          "answer": [
+            "They enable a company’s applications to communicate with each another internally"
+          ],
+          "instructions": null,
+          "content": {
+            "ref": "sli_VJ0nnKjsr",
+            "type": "slide"
+          },
+          "nextContent": {
+            "type": "slide",
+            "ref": "sli_NJenMOm2f"
+          },
+          "isCorrect": true,
+          "godMode": false
+        },
+        "type": "answer"
+      },
+      {
+        "payload": {
+          "answer": [
+            "12"
+          ],
+          "instructions": null,
+          "content": {
+            "type": "slide",
+            "ref": "sli_NJenMOm2f"
+          },
+          "nextContent": {
+            "ref": "extraLife",
+            "type": "node"
+          },
+          "isCorrect": false,
+          "godMode": false
+        },
+        "type": "answer"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Pour récupérer la correction sur l'écran d'inter-question, on utilisait la réponse stocker dans `ui.anwsers`. Lors d'un rafraîchissement d'une progression en extraLide, `ui.answers` est vide et l'écran d'inter-question reste bloqué en loading tant qu'il n'a pas de correction.

Maintenant, on récupère la réponse stockée dans le state de la progression `state.allAnswers`. On utilise la dernière occurrence à la dernière slide (`state.content`).