### PR TITLE
Use green as progression bar color instead of brands primary color

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/card-content/index.js
+++ b/packages/@coorpacademy-components/src/molecule/card-content/index.js
@@ -48,10 +48,10 @@ const ContentInfo = (
   context
 ) => {
   const {skin} = context;
-  const primaryColor = get('common.primary', skin);
   const whiteColor = get('common.white', skin);
+  const progressBarColor = '#3EC483';
   const inlineProgressValueStyle = {
-    backgroundColor: primaryColor,
+    backgroundColor: progressBarColor,
     width: `${progress * 100}%`
   };
 


### PR DESCRIPTION
https://trello.com/c/0Hnopfbd/1601-ux-end-of-primary-color-on-progression-card
