### PR TITLE
Add context media state extract

### DIFF
--- a/packages/@coorpacademy-player-store/src/test/index.js
+++ b/packages/@coorpacademy-player-store/src/test/index.js
@@ -63,6 +63,7 @@ test('it should expose all api', t => {
     'getEndRank',
     'getBestScore',
     'getQuestionMedia',
+    'getContextMedia',
     'getResourceToPlay',
     'getLives',
     'getCoaches',

--- a/packages/@coorpacademy-player-store/src/utils/state-extract.js
+++ b/packages/@coorpacademy-player-store/src/utils/state-extract.js
@@ -435,17 +435,7 @@ export const getBestScore = (state: State): number | void => {
   }
 };
 
-export const getQuestionMedia = (state: State): void | Media => {
-  const slide = getCurrentSlide(state);
-
-  if (!slide) {
-    return;
-  }
-
-  const media: Media = get('question.medias.0', slide);
-  if (!media) {
-    return;
-  }
+const getMedia = (media: Media): Media | void => {
   const {type} = media;
   const resource = get('src.0', media);
   switch (type) {
@@ -461,6 +451,36 @@ export const getQuestionMedia = (state: State): void | Media => {
         type
       };
   }
+};
+
+export const getQuestionMedia = (state: State): void | Media => {
+  const slide = getCurrentSlide(state);
+
+  if (!slide) {
+    return;
+  }
+
+  const media: Media = get('question.medias.0', slide);
+  if (!media) {
+    return;
+  }
+
+  return getMedia(media);
+};
+
+export const getContextMedia = (state: State): void | Media => {
+  const slide = getCurrentSlide(state);
+
+  if (!slide) {
+    return;
+  }
+
+  const media: Media = get('context.media', slide);
+  if (!media) {
+    return;
+  }
+
+  return getMedia(media);
 };
 
 export const getResourceToPlay: State => string = get('ui.corrections.playResource');

--- a/packages/@coorpacademy-player-store/src/utils/test/state-extract.js
+++ b/packages/@coorpacademy-player-store/src/utils/test/state-extract.js
@@ -41,6 +41,7 @@ import {
   hasViewedAResourceAtThisStep,
   hasSeenLesson,
   getQuestionMedia,
+  getContextMedia,
   isContentAdaptive,
   getVideoTracks,
   getPrevAnswer
@@ -828,6 +829,84 @@ test('getQuestionMedia should return video media from state', t => {
   )({});
 
   t.deepEqual(getQuestionMedia(state), {
+    type: 'video',
+    mimeType: 'application/vimeo',
+    videoId: '231095700'
+  });
+});
+
+test('getContextMedia should return undefined if no slide is found', t => {
+  const progression = {state: {nextContent: {ref: '0'}}};
+  const state = pipe(
+    set('ui.current.progressionId', '0'),
+    set('data.progressions.entities', {'0': progression})
+  )({});
+
+  t.is(getContextMedia(state), undefined);
+});
+
+test('getContextMedia should return nothing if media is not provided', t => {
+  const slide = {
+    _id: '0',
+    context: {}
+  };
+  const progression = {state: {nextContent: {ref: '0'}}};
+  const state = pipe(
+    set('ui.current.progressionId', '0'),
+    set('data.progressions.entities', {'0': progression}),
+    set('data.contents.slide.entities', {'0': slide})
+  )({});
+
+  t.is(getContextMedia(state), undefined);
+});
+
+test('getContextMedia should return image media from state', t => {
+  const slide = {
+    _id: '0',
+    context: {
+      media: {
+        type: 'img',
+        src: [
+          {
+            url: 'http://monimage.jpg'
+          }
+        ]
+      }
+    }
+  };
+  const progression = {state: {nextContent: {ref: '0'}}};
+  const state = pipe(
+    set('ui.current.progressionId', '0'),
+    set('data.progressions.entities', {'0': progression}),
+    set('data.contents.slide.entities', {'0': slide})
+  )({});
+
+  t.deepEqual(getContextMedia(state), {type: 'img', url: 'http://monimage.jpg'});
+});
+
+test('getContextMedia should return video media from state', t => {
+  const slide = {
+    _id: '0',
+    context: {
+      media: {
+        type: 'video',
+        src: [
+          {
+            mimeType: 'application/vimeo',
+            videoId: '231095700'
+          }
+        ]
+      }
+    }
+  };
+  const progression = {state: {nextContent: {ref: '0'}}};
+  const state = pipe(
+    set('ui.current.progressionId', '0'),
+    set('data.progressions.entities', {'0': progression}),
+    set('data.contents.slide.entities', {'0': slide})
+  )({});
+
+  t.deepEqual(getContextMedia(state), {
     type: 'video',
     mimeType: 'application/vimeo',
     videoId: '231095700'


### PR DESCRIPTION
**Detailed purpose of the PR**

This PR adds context media extractor to avoid [this](https://github.com/CoorpAcademy/mobile/blob/master/src/screens/context.js#L82) instead of [this](https://github.com/CoorpAcademy/mobile/blob/master/src/screens/question.js#L187)

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
