### PR TITLE
(feat) Add LMS to brand update template

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/brand-tabs/test/fixtures/lms.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-tabs/test/fixtures/lms.js
@@ -1,0 +1,46 @@
+export default {
+  props: {
+    tabs: [
+      {
+        title: 'General Settings',
+        href: '#brand/samsung/settings',
+        selected: false
+      },
+      {
+        title: 'Look & Feel',
+        href: '#brand/samsung/lookandfeel',
+        selected: false
+      },
+      {
+        title: 'SSO',
+        href: '#brand/samsung/sso',
+        selected: false
+      },
+      {
+        title: 'Manage users',
+        href: '#brand/samsung/users',
+        selected: false
+      },
+      {
+        title: 'Upload users',
+        href: '#brand/samsung/import',
+        selected: false
+      },
+      {
+        title: 'Analytics',
+        href: '#brand/samsung/analytics',
+        selected: false
+      },
+      {
+        title: 'Cohort',
+        href: '#brand/samsung/cohort',
+        selected: false
+      },
+      {
+        title: 'LMS',
+        href: '#brand/samsung/lms',
+        selected: true
+      }
+    ]
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/brand-form/test/fixtures/lms.js
+++ b/packages/@coorpacademy-components/src/organism/brand-form/test/fixtures/lms.js
@@ -1,204 +1,211 @@
 export default {
   props: {
-    groups: [{
-      title: 'LMS configuration',
-      subtitle: 'Configure the coorpacademy integration to LMS',
-      fields: [
-        {
-          type: 'slider',
-          tabProps: [
-            {
-              title: 'CSOD'
-            },
-            {
-              title: 'SAP'
-            },
-            {
-              title: 'XAPI'
-            }
-          ],
-          slides: [{
-            fields: [
+    groups: [
+      {
+        title: 'LMS configuration',
+        subtitle: 'Configure the coorpacademy integration to LMS',
+        fields: [
+          {
+            type: 'slider',
+            tabProps: [
               {
-                type: 'switch',
-                title: 'Enabled',
-                value: true,
-                onChange: () => console.log('dispatch Enabled')
+                title: 'CSOD'
               },
               {
-                type: 'text',
-                title: 'URL',
-                placeholder: 'https://some.fake.csod.hostname',
-                // description: 'This should explain',
-                required: true,
-                value: 'https://partner0125.csod.com',
-                onChange: () => console.log('dispatch URL')
+                title: 'SAP'
               },
               {
-                type: 'text',
-                title: 'Client ID',
-                // description: 'This should explain',
-                required: true,
-                value: 'Some-client-id',
-                onChange: () => console.log('dispatch Client ID')
+                title: 'XAPI'
+              }
+            ],
+            slides: [
+              {
+                fields: [
+                  {
+                    type: 'switch',
+                    title: 'Enabled',
+                    value: true,
+                    onChange: () => console.log('dispatch Enabled')
+                  },
+                  {
+                    type: 'text',
+                    title: 'URL',
+                    placeholder: 'https://some.fake.csod.hostname',
+                    // description: 'This should explain',
+                    required: true,
+                    value: 'https://partner0125.csod.com',
+                    onChange: () => console.log('dispatch URL')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Client ID',
+                    // description: 'This should explain',
+                    required: true,
+                    value: 'Some-client-id',
+                    onChange: () => console.log('dispatch Client ID')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Client Secret',
+                    // description: 'This should explain',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch Client Secret')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Provider',
+                    description: 'This is the name you gave to Coorpacademy in CSOD.',
+                    required: true,
+                    value: 'COORPACADEMY',
+                    onChange: () => console.log('dispatch Provider')
+                  },
+                  {
+                    type: 'switch',
+                    title: 'Course',
+                    value: true,
+                    onChange: () => console.log('dispatch Course')
+                  },
+                  {
+                    type: 'switch',
+                    title: 'Level',
+                    value: true,
+                    onChange: () => console.log('dispatch Level')
+                  },
+                  {
+                    type: 'switch',
+                    title: 'Chapter',
+                    value: false,
+                    onChange: () => console.log('dispatch Chapter')
+                  }
+                ]
               },
               {
-                type: 'text',
-                title: 'Client Secret',
-                // description: 'This should explain',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch Client Secret')
+                fields: [
+                  {
+                    type: 'switch',
+                    title: 'Enabled',
+                    value: false,
+                    onChange: () => console.log('dispatch Enabled')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Contact email address',
+                    placeholder: '',
+                    description:
+                      'The email address we should notify when new content has been exported.',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch Email address')
+                  },
+                  {
+                    type: 'text',
+                    title: 'URL',
+                    placeholder: 'https://some.fake.sap.hostname',
+                    // description: 'This should explain',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch URL')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Client ID',
+                    // description: 'This should explain',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch Client ID')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Client Secret',
+                    // description: 'This should explain',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch ClientSecret')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Scope User ID',
+                    // description: 'This should explain',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch Scope user ID')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Scope Company ID',
+                    // description: 'This should explain',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch Scope Company ID')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Provider',
+                    description: 'This is the name you gave to Coorpacademy in CSOD.',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch Provider')
+                  },
+                  {
+                    type: 'switch',
+                    title: 'Course',
+                    value: false,
+                    onChange: () => console.log('dispatch Course')
+                  },
+                  {
+                    type: 'switch',
+                    title: 'Level',
+                    value: false,
+                    onChange: () => console.log('dispatch Level')
+                  },
+                  {
+                    type: 'switch',
+                    title: 'Chapter',
+                    value: false,
+                    onChange: () => console.log('dispatch Chapter')
+                  }
+                ]
               },
               {
-                type: 'text',
-                title: 'Provider',
-                description: 'This is the name you gave to Coorpacademy in CSOD.',
-                required: true,
-                value: 'COORPACADEMY',
-                onChange: () => console.log('dispatch Provider')
-              },
-              {
-                type: 'switch',
-                title: 'Course',
-                value: true,
-                onChange: () => console.log('dispatch Course')
-              },
-              {
-                type: 'switch',
-                title: 'Level',
-                value: true,
-                onChange: () => console.log('dispatch Level')
-              },
-              {
-                type: 'switch',
-                title: 'Chapter',
-                value: false,
-                onChange: () => console.log('dispatch Chapter')
-              },
-            ]
-          }, {
-            fields: [
-              {
-                type: 'switch',
-                title: 'Enabled',
-                value: false,
-                onChange: () => console.log('dispatch Enabled')
-              },
-              {
-                type: 'text',
-                title: 'Contact email address',
-                placeholder: '',
-                description: 'The email address we should notify when new content has been exported.',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch Email address')
-              },
-              {
-                type: 'text',
-                title: 'URL',
-                placeholder: 'https://some.fake.sap.hostname',
-                // description: 'This should explain',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch URL')
-              },
-              {
-                type: 'text',
-                title: 'Client ID',
-                // description: 'This should explain',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch Client ID')
-              },
-              {
-                type: 'text',
-                title: 'Client Secret',
-                // description: 'This should explain',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch ClientSecret')
-              },
-              {
-                type: 'text',
-                title: 'Scope User ID',
-                // description: 'This should explain',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch Scope user ID')
-              },
-              {
-                type: 'text',
-                title: 'Scope Company ID',
-                // description: 'This should explain',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch Scope Company ID')
-              },
-              {
-                type: 'text',
-                title: 'Provider',
-                description: 'This is the name you gave to Coorpacademy in CSOD.',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch Provider')
-              },
-              {
-                type: 'switch',
-                title: 'Course',
-                value: false,
-                onChange: () => console.log('dispatch Course')
-              },
-              {
-                type: 'switch',
-                title: 'Level',
-                value: false,
-                onChange: () => console.log('dispatch Level')
-              },
-              {
-                type: 'switch',
-                title: 'Chapter',
-                value: false,
-                onChange: () => console.log('dispatch Chapter')
+                fields: [
+                  {
+                    type: 'switch',
+                    title: 'Enabled',
+                    value: false,
+                    onChange: () => console.log('dispatch Enabled')
+                  },
+                  {
+                    type: 'text',
+                    title: 'URL',
+                    placeholder: 'https://some.fake.csod.hostname',
+                    // description: 'This should explain',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch URL')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Username',
+                    // description: 'This should explain',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch Username')
+                  },
+                  {
+                    type: 'text',
+                    title: 'Password',
+                    description: 'this should be an input type password',
+                    required: true,
+                    value: '',
+                    onChange: () => console.log('dispatch Password')
+                  }
+                ]
               }
             ]
-          }, {
-            fields: [
-              {
-                type: 'switch',
-                title: 'Enabled',
-                value: false,
-                onChange: () => console.log('dispatch Enabled')
-              },
-              {
-                type: 'text',
-                title: 'URL',
-                placeholder: 'https://some.fake.csod.hostname',
-                // description: 'This should explain',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch URL')
-              },
-              {
-                type: 'text',
-                title: 'Username',
-                // description: 'This should explain',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch Username')
-              },
-              {
-                type: 'text',
-                title: 'Password',
-                description: 'this should be an input type password',
-                required: true,
-                value: '',
-                onChange: () => console.log('dispatch Password')
-              }
-            ]
-          }]
-        }
-      ]
-    }]
+          }
+        ]
+      }
+    ]
   }
 };

--- a/packages/@coorpacademy-components/src/organism/brand-form/test/fixtures/lms.js
+++ b/packages/@coorpacademy-components/src/organism/brand-form/test/fixtures/lms.js
@@ -1,0 +1,204 @@
+export default {
+  props: {
+    groups: [{
+      title: 'LMS configuration',
+      subtitle: 'Configure the coorpacademy integration to LMS',
+      fields: [
+        {
+          type: 'slider',
+          tabProps: [
+            {
+              title: 'CSOD'
+            },
+            {
+              title: 'SAP'
+            },
+            {
+              title: 'XAPI'
+            }
+          ],
+          slides: [{
+            fields: [
+              {
+                type: 'switch',
+                title: 'Enabled',
+                value: true,
+                onChange: () => console.log('dispatch Enabled')
+              },
+              {
+                type: 'text',
+                title: 'URL',
+                placeholder: 'https://some.fake.csod.hostname',
+                // description: 'This should explain',
+                required: true,
+                value: 'https://partner0125.csod.com',
+                onChange: () => console.log('dispatch URL')
+              },
+              {
+                type: 'text',
+                title: 'Client ID',
+                // description: 'This should explain',
+                required: true,
+                value: 'Some-client-id',
+                onChange: () => console.log('dispatch Client ID')
+              },
+              {
+                type: 'text',
+                title: 'Client Secret',
+                // description: 'This should explain',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch Client Secret')
+              },
+              {
+                type: 'text',
+                title: 'Provider',
+                description: 'This is the name you gave to Coorpacademy in CSOD.',
+                required: true,
+                value: 'COORPACADEMY',
+                onChange: () => console.log('dispatch Provider')
+              },
+              {
+                type: 'switch',
+                title: 'Course',
+                value: true,
+                onChange: () => console.log('dispatch Course')
+              },
+              {
+                type: 'switch',
+                title: 'Level',
+                value: true,
+                onChange: () => console.log('dispatch Level')
+              },
+              {
+                type: 'switch',
+                title: 'Chapter',
+                value: false,
+                onChange: () => console.log('dispatch Chapter')
+              },
+            ]
+          }, {
+            fields: [
+              {
+                type: 'switch',
+                title: 'Enabled',
+                value: false,
+                onChange: () => console.log('dispatch Enabled')
+              },
+              {
+                type: 'text',
+                title: 'Contact email address',
+                placeholder: '',
+                description: 'The email address we should notify when new content has been exported.',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch Email address')
+              },
+              {
+                type: 'text',
+                title: 'URL',
+                placeholder: 'https://some.fake.sap.hostname',
+                // description: 'This should explain',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch URL')
+              },
+              {
+                type: 'text',
+                title: 'Client ID',
+                // description: 'This should explain',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch Client ID')
+              },
+              {
+                type: 'text',
+                title: 'Client Secret',
+                // description: 'This should explain',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch ClientSecret')
+              },
+              {
+                type: 'text',
+                title: 'Scope User ID',
+                // description: 'This should explain',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch Scope user ID')
+              },
+              {
+                type: 'text',
+                title: 'Scope Company ID',
+                // description: 'This should explain',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch Scope Company ID')
+              },
+              {
+                type: 'text',
+                title: 'Provider',
+                description: 'This is the name you gave to Coorpacademy in CSOD.',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch Provider')
+              },
+              {
+                type: 'switch',
+                title: 'Course',
+                value: false,
+                onChange: () => console.log('dispatch Course')
+              },
+              {
+                type: 'switch',
+                title: 'Level',
+                value: false,
+                onChange: () => console.log('dispatch Level')
+              },
+              {
+                type: 'switch',
+                title: 'Chapter',
+                value: false,
+                onChange: () => console.log('dispatch Chapter')
+              }
+            ]
+          }, {
+            fields: [
+              {
+                type: 'switch',
+                title: 'Enabled',
+                value: false,
+                onChange: () => console.log('dispatch Enabled')
+              },
+              {
+                type: 'text',
+                title: 'URL',
+                placeholder: 'https://some.fake.csod.hostname',
+                // description: 'This should explain',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch URL')
+              },
+              {
+                type: 'text',
+                title: 'Username',
+                // description: 'This should explain',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch Username')
+              },
+              {
+                type: 'text',
+                title: 'Password',
+                description: 'this should be an input type password',
+                required: true,
+                value: '',
+                onChange: () => console.log('dispatch Password')
+              }
+            ]
+          }]
+        }
+      ]
+    }]
+  }
+};

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-error.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-error.js
@@ -9,9 +9,9 @@ const {props} = Default;
 const {groups} = Lms.props;
 const {tabs} = BrandTabs.props;
 
-const errorGroups = cloneDeep(groups)
-errorGroups[0].fields[0].slides[0].fields[3].error = 'Client Secret is required'
-errorGroups[0].fields[0].tabProps[0].isOpen = true
+const errorGroups = cloneDeep(groups);
+errorGroups[0].fields[0].slides[0].fields[3].error = 'Client Secret is required';
+errorGroups[0].fields[0].tabProps[0].isOpen = true;
 
 export default {
   props: defaultsDeep(props, {
@@ -22,12 +22,15 @@ export default {
         onClose: noop
       }
     ],
+
     tabs,
     content: {
       type: 'form',
       groups: errorGroups,
       isModified: true,
-      onReset: () => {console.log('Reset modified values')},
+      onReset: () => {
+        console.log('Reset modified values');
+      },
       onSubmit: noop,
       resetValue: 'Reset changes',
       submitValue: 'Save changes'

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-error.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-error.js
@@ -1,0 +1,36 @@
+import cloneDeep from 'lodash/fp/cloneDeep';
+import defaultsDeep from 'lodash/fp/defaultsDeep';
+import noop from 'lodash/fp/noop';
+import BrandTabs from '../../../../../molecule/brand-tabs/test/fixtures/lms';
+import Lms from '../../../../../organism/brand-form/test/fixtures/lms';
+import Default from './default';
+
+const {props} = Default;
+const {groups} = Lms.props;
+const {tabs} = BrandTabs.props;
+
+const errorGroups = cloneDeep(groups)
+errorGroups[0].fields[0].slides[0].fields[3].error = 'Client Secret is required'
+errorGroups[0].fields[0].tabProps[0].isOpen = true
+
+export default {
+  props: defaultsDeep(props, {
+    notifications: [
+      {
+        type: 'error',
+        message: errorGroups[0].fields[0].slides[0].fields[3].error,
+        onClose: noop
+      }
+    ],
+    tabs,
+    content: {
+      type: 'form',
+      groups: errorGroups,
+      isModified: true,
+      onReset: () => {console.log('Reset modified values')},
+      onSubmit: noop,
+      resetValue: 'Reset changes',
+      submitValue: 'Save changes'
+    }
+  })
+};

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-modified.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-modified.js
@@ -1,0 +1,28 @@
+import cloneDeep from 'lodash/fp/cloneDeep';
+import defaultsDeep from 'lodash/fp/defaultsDeep';
+import BrandTabs from '../../../../../molecule/brand-tabs/test/fixtures/lms';
+import Lms from '../../../../../organism/brand-form/test/fixtures/lms';
+import Default from './default';
+
+const {props} = Default;
+const {groups} = Lms.props;
+const {tabs} = BrandTabs.props;
+
+const modifiedGroups = cloneDeep(groups)
+modifiedGroups[0].fields[0].slides[0].fields[0].modified = true
+modifiedGroups[0].fields[0].tabProps[0].isOpen = true
+
+export default {
+  props: defaultsDeep(props, {
+    tabs,
+    content: {
+      type: 'form',
+      groups: modifiedGroups,
+      isModified: true,
+      onReset: () => {console.log('Reset modified values')},
+      onSubmit: () => {console.log('Submit form')},
+      resetValue: 'Reset changes',
+      submitValue: 'Save changes'
+    }
+  })
+};

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-modified.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-modified.js
@@ -8,9 +8,9 @@ const {props} = Default;
 const {groups} = Lms.props;
 const {tabs} = BrandTabs.props;
 
-const modifiedGroups = cloneDeep(groups)
-modifiedGroups[0].fields[0].slides[0].fields[0].modified = true
-modifiedGroups[0].fields[0].tabProps[0].isOpen = true
+const modifiedGroups = cloneDeep(groups);
+modifiedGroups[0].fields[0].slides[0].fields[0].modified = true;
+modifiedGroups[0].fields[0].tabProps[0].isOpen = true;
 
 export default {
   props: defaultsDeep(props, {
@@ -19,8 +19,12 @@ export default {
       type: 'form',
       groups: modifiedGroups,
       isModified: true,
-      onReset: () => {console.log('Reset modified values')},
-      onSubmit: () => {console.log('Submit form')},
+      onReset: () => {
+        console.log('Reset modified values');
+      },
+      onSubmit: () => {
+        console.log('Submit form');
+      },
       resetValue: 'Reset changes',
       submitValue: 'Save changes'
     }

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-success.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-success.js
@@ -1,4 +1,4 @@
-import cloneDeep from "lodash/fp/cloneDeep";
+import cloneDeep from 'lodash/fp/cloneDeep';
 import defaultsDeep from 'lodash/fp/defaultsDeep';
 import noop from 'lodash/fp/noop';
 import BrandTabs from '../../../../../molecule/brand-tabs/test/fixtures/lms';
@@ -9,9 +9,9 @@ const {props} = Default;
 const {groups} = Lms.props;
 const {tabs} = BrandTabs.props;
 
-const successGroups = cloneDeep(groups)
-successGroups[0].fields[0].slides[0].fields[3].value = 'jlJkklJbhgTYvghytfgvf(7H77ggbV4T'
-successGroups[0].fields[0].tabProps[0].isOpen = true
+const successGroups = cloneDeep(groups);
+successGroups[0].fields[0].slides[0].fields[3].value = 'jlJkklJbhgTYvghytfgvf(7H77ggbV4T';
+successGroups[0].fields[0].tabProps[0].isOpen = true;
 
 export default {
   props: defaultsDeep(props, {

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-success.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms-success.js
@@ -1,0 +1,35 @@
+import cloneDeep from "lodash/fp/cloneDeep";
+import defaultsDeep from 'lodash/fp/defaultsDeep';
+import noop from 'lodash/fp/noop';
+import BrandTabs from '../../../../../molecule/brand-tabs/test/fixtures/lms';
+import Lms from '../../../../../organism/brand-form/test/fixtures/lms';
+import Default from './default';
+
+const {props} = Default;
+const {groups} = Lms.props;
+const {tabs} = BrandTabs.props;
+
+const successGroups = cloneDeep(groups)
+successGroups[0].fields[0].slides[0].fields[3].value = 'jlJkklJbhgTYvghytfgvf(7H77ggbV4T'
+successGroups[0].fields[0].tabProps[0].isOpen = true
+
+export default {
+  props: defaultsDeep(props, {
+    notifications: [
+      {
+        type: 'success',
+        message: 'Your changes have been saved.',
+        onClose: noop
+      }
+    ],
+    tabs,
+    content: {
+      type: 'form',
+      groups: successGroups,
+      onReset: noop,
+      onSubmit: noop,
+      resetValue: 'Reset changes',
+      submitValue: 'Save changes'
+    }
+  })
+};

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms.js
@@ -1,0 +1,23 @@
+import defaultsDeep from 'lodash/fp/defaultsDeep';
+import noop from 'lodash/fp/noop';
+import BrandTabs from '../../../../../molecule/brand-tabs/test/fixtures/lms';
+import Lms from '../../../../../organism/brand-form/test/fixtures/lms';
+import Default from './default';
+
+const {props} = Default;
+const {groups} = Lms.props;
+const {tabs} = BrandTabs.props;
+
+export default {
+  props: defaultsDeep(props, {
+    tabs,
+    content: {
+      type: 'form',
+      groups: groups,
+      onReset: noop,
+      onSubmit: noop,
+      resetValue: 'Reset changes',
+      submitValue: 'Save changes'
+    }
+  })
+};

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/lms.js
@@ -13,7 +13,7 @@ export default {
     tabs,
     content: {
       type: 'form',
-      groups: groups,
+      groups,
       onReset: noop,
       onSubmit: noop,
       resetValue: 'Reset changes',

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -338,6 +338,7 @@ import MoleculeBrandTabsFixtureAnalytics from '../src/molecule/brand-tabs/test/f
 import MoleculeBrandTabsFixtureCohort from '../src/molecule/brand-tabs/test/fixtures/cohort';
 import MoleculeBrandTabsFixtureDefault from '../src/molecule/brand-tabs/test/fixtures/default';
 import MoleculeBrandTabsFixtureImportusers from '../src/molecule/brand-tabs/test/fixtures/importusers';
+import MoleculeBrandTabsFixtureLms from '../src/molecule/brand-tabs/test/fixtures/lms';
 import MoleculeBrandTabsFixtureLookandfeel from '../src/molecule/brand-tabs/test/fixtures/lookandfeel';
 import MoleculeBrandTabsFixtureManageusers from '../src/molecule/brand-tabs/test/fixtures/manageusers';
 import MoleculeBrandTabsFixtureSso from '../src/molecule/brand-tabs/test/fixtures/sso';
@@ -734,6 +735,10 @@ import TemplateBackOfficeBrandUpdateFixtureDashboard from '../src/template/back-
 import TemplateBackOfficeBrandUpdateFixtureDefault from '../src/template/back-office/brand-update/test/fixtures/default';
 import TemplateBackOfficeBrandUpdateFixtureGeneralSettingsSuccess from '../src/template/back-office/brand-update/test/fixtures/general-settings-success';
 import TemplateBackOfficeBrandUpdateFixtureGeneralSettings from '../src/template/back-office/brand-update/test/fixtures/general-settings';
+import TemplateBackOfficeBrandUpdateFixtureLms from '../src/template/back-office/brand-update/test/fixtures/lms';
+import TemplateBackOfficeBrandUpdateFixtureLmsModified from '../src/template/back-office/brand-update/test/fixtures/lms-modified';
+import TemplateBackOfficeBrandUpdateFixtureLmsError from '../src/template/back-office/brand-update/test/fixtures/lms-error';
+import TemplateBackOfficeBrandUpdateFixtureLmsSuccess from '../src/template/back-office/brand-update/test/fixtures/lms-success';
 import TemplateBackOfficeBrandUpdateFixtureLoader from '../src/template/back-office/brand-update/test/fixtures/loader';
 import TemplateBackOfficeBrandUpdateFixtureLookandfeelError from '../src/template/back-office/brand-update/test/fixtures/lookandfeel-error';
 import TemplateBackOfficeBrandUpdateFixtureLookandfeelModified from '../src/template/back-office/brand-update/test/fixtures/lookandfeel-modified';
@@ -1257,6 +1262,7 @@ export const fixtures = {
       Cohort: MoleculeBrandTabsFixtureCohort,
       Default: MoleculeBrandTabsFixtureDefault,
       Importusers: MoleculeBrandTabsFixtureImportusers,
+      Lms: MoleculeBrandTabsFixtureLms,
       Lookandfeel: MoleculeBrandTabsFixtureLookandfeel,
       Manageusers: MoleculeBrandTabsFixtureManageusers,
       Sso: MoleculeBrandTabsFixtureSso
@@ -1873,6 +1879,10 @@ export const fixtures = {
       Default: TemplateBackOfficeBrandUpdateFixtureDefault,
       GeneralSettingsSuccess: TemplateBackOfficeBrandUpdateFixtureGeneralSettingsSuccess,
       GeneralSettings: TemplateBackOfficeBrandUpdateFixtureGeneralSettings,
+      Lms: TemplateBackOfficeBrandUpdateFixtureLms,
+      LmsModified: TemplateBackOfficeBrandUpdateFixtureLmsModified,
+      LmsError: TemplateBackOfficeBrandUpdateFixtureLmsError,
+      LmsSuccess: TemplateBackOfficeBrandUpdateFixtureLmsSuccess,
       Loader: TemplateBackOfficeBrandUpdateFixtureLoader,
       LookandfeelError: TemplateBackOfficeBrandUpdateFixtureLookandfeelError,
       LookandfeelModified: TemplateBackOfficeBrandUpdateFixtureLookandfeelModified,

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -564,6 +564,7 @@ import OrganismBrandFormFixtureCohort from '../src/organism/brand-form/test/fixt
 import OrganismBrandFormFixtureDashboard from '../src/organism/brand-form/test/fixtures/dashboard';
 import OrganismBrandFormFixtureDefault from '../src/organism/brand-form/test/fixtures/default';
 import OrganismBrandFormFixtureGeneralSettings from '../src/organism/brand-form/test/fixtures/general-settings';
+import OrganismBrandFormFixtureLms from '../src/organism/brand-form/test/fixtures/lms';
 import OrganismBrandFormFixtureLookandfeel from '../src/organism/brand-form/test/fixtures/lookandfeel';
 import OrganismBrandFormFixtureManageusersEdit from '../src/organism/brand-form/test/fixtures/manageusers-edit';
 import OrganismBrandFormFixtureSso from '../src/organism/brand-form/test/fixtures/sso';
@@ -735,10 +736,10 @@ import TemplateBackOfficeBrandUpdateFixtureDashboard from '../src/template/back-
 import TemplateBackOfficeBrandUpdateFixtureDefault from '../src/template/back-office/brand-update/test/fixtures/default';
 import TemplateBackOfficeBrandUpdateFixtureGeneralSettingsSuccess from '../src/template/back-office/brand-update/test/fixtures/general-settings-success';
 import TemplateBackOfficeBrandUpdateFixtureGeneralSettings from '../src/template/back-office/brand-update/test/fixtures/general-settings';
-import TemplateBackOfficeBrandUpdateFixtureLms from '../src/template/back-office/brand-update/test/fixtures/lms';
-import TemplateBackOfficeBrandUpdateFixtureLmsModified from '../src/template/back-office/brand-update/test/fixtures/lms-modified';
 import TemplateBackOfficeBrandUpdateFixtureLmsError from '../src/template/back-office/brand-update/test/fixtures/lms-error';
+import TemplateBackOfficeBrandUpdateFixtureLmsModified from '../src/template/back-office/brand-update/test/fixtures/lms-modified';
 import TemplateBackOfficeBrandUpdateFixtureLmsSuccess from '../src/template/back-office/brand-update/test/fixtures/lms-success';
+import TemplateBackOfficeBrandUpdateFixtureLms from '../src/template/back-office/brand-update/test/fixtures/lms';
 import TemplateBackOfficeBrandUpdateFixtureLoader from '../src/template/back-office/brand-update/test/fixtures/loader';
 import TemplateBackOfficeBrandUpdateFixtureLookandfeelError from '../src/template/back-office/brand-update/test/fixtures/lookandfeel-error';
 import TemplateBackOfficeBrandUpdateFixtureLookandfeelModified from '../src/template/back-office/brand-update/test/fixtures/lookandfeel-modified';
@@ -1628,6 +1629,7 @@ export const fixtures = {
       Dashboard: OrganismBrandFormFixtureDashboard,
       Default: OrganismBrandFormFixtureDefault,
       GeneralSettings: OrganismBrandFormFixtureGeneralSettings,
+      Lms: OrganismBrandFormFixtureLms,
       Lookandfeel: OrganismBrandFormFixtureLookandfeel,
       ManageusersEdit: OrganismBrandFormFixtureManageusersEdit,
       Sso: OrganismBrandFormFixtureSso
@@ -1879,10 +1881,10 @@ export const fixtures = {
       Default: TemplateBackOfficeBrandUpdateFixtureDefault,
       GeneralSettingsSuccess: TemplateBackOfficeBrandUpdateFixtureGeneralSettingsSuccess,
       GeneralSettings: TemplateBackOfficeBrandUpdateFixtureGeneralSettings,
-      Lms: TemplateBackOfficeBrandUpdateFixtureLms,
-      LmsModified: TemplateBackOfficeBrandUpdateFixtureLmsModified,
       LmsError: TemplateBackOfficeBrandUpdateFixtureLmsError,
+      LmsModified: TemplateBackOfficeBrandUpdateFixtureLmsModified,
       LmsSuccess: TemplateBackOfficeBrandUpdateFixtureLmsSuccess,
+      Lms: TemplateBackOfficeBrandUpdateFixtureLms,
       Loader: TemplateBackOfficeBrandUpdateFixtureLoader,
       LookandfeelError: TemplateBackOfficeBrandUpdateFixtureLookandfeelError,
       LookandfeelModified: TemplateBackOfficeBrandUpdateFixtureLookandfeelModified,


### PR DESCRIPTION
**Detailed purpose of the PR**
Add LMS configuration to the Brand Update Template

**Result and observation**
It adds a new LMT Tab.
It adds three new forms for CSOD, SAP and XAPI LMS under the shape of an accordion.

<img width="1402" alt="Screenshot 2020-05-05 at 16 08 50" src="https://user-images.githubusercontent.com/592800/81210419-2717d980-8fd2-11ea-8628-bea0092a4d0d.png">
<img width="943" alt="Screenshot 2020-05-06 at 19 44 56" src="https://user-images.githubusercontent.com/592800/81210427-297a3380-8fd2-11ea-92ef-395f937b5739.png">

- [ ] **Breaking changes ?**  
- [ ] **Extra lib ?**

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [x] Unit testing
