### PR TITLE
Fix accordion

### DIFF
--- a/packages/@coorpacademy-components/package.json
+++ b/packages/@coorpacademy-components/package.json
@@ -30,6 +30,7 @@
     "static": "npm run storybook:export",
     "storybook:run": "cross-env BABEL_ENV=es start-storybook -p 3004 -c .storybook",
     "storybook:export": "cross-env BABEL_ENV=es build-storybook -c .storybook -o static",
+    "preava": "npm run generate:fixtures",
     "ava": "ava",
     "test:only": "nyc npm run ava",
     "test": " npm run lint && npm run test:only",

--- a/packages/@coorpacademy-components/src/organism/accordion/toggler/index.js
+++ b/packages/@coorpacademy-components/src/organism/accordion/toggler/index.js
@@ -1,30 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {map, pipe, set, get, getOr, identity, constant} from 'lodash/fp';
+import {map, pipe, set, get, getOr, identity, constant, zipWith} from 'lodash/fp';
 
 import Accordion from '../container';
 
-const mapi = map.convert({cap: false});
-const map2 = (iteratee, arr1, arr2) => {
-  return mapi((value1, index) => {
-    const value2 = get(index, arr2);
-    return iteratee(value1, value2);
-  }, arr1);
-};
-
 class AccordionToggler extends React.Component {
   static getDerivedStateFromProps(props, state) {
-    if (state.isOpen) return null;
+    if (state.isOpenValues) return null;
 
-    const isOpen = map(getOr(false, 'isOpen'), props.tabProps);
+    const isOpenValues = map(getOr(false, 'isOpen'), props.tabProps);
 
-    return {isOpen};
+    return {isOpenValues};
   }
 
   constructor(props) {
     super(props);
 
-    this.state = {isOpen: null};
+    this.state = {isOpenValues: null};
 
     this.handleOnClick = this.handleOnClick.bind(this);
   }
@@ -32,22 +24,22 @@ class AccordionToggler extends React.Component {
   handleOnClick(key) {
     this.setState(prevState => {
       return {
-        isOpen: pipe(
+        isOpenValues: pipe(
           this.props.oneTabOnly ? map(constant(false)) : identity,
-          set(key, !get(key, prevState.isOpen))
-        )(prevState.isOpen)
+          set(key, !get(key, prevState.isOpenValues))
+        )(prevState.isOpenValues)
       };
     });
   }
 
   mergePropsAndState() {
-    return map2(
+    return zipWith(
       (props, isOpen) => ({
         ...props,
         isOpen
       }),
       this.props.tabProps,
-      this.state.isOpen
+      this.state.isOpenValues
     );
   }
 

--- a/packages/@coorpacademy-components/src/organism/accordion/toggler/index.js
+++ b/packages/@coorpacademy-components/src/organism/accordion/toggler/index.js
@@ -1,44 +1,66 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {forEach} from 'lodash/fp';
+import {map, pipe, set, get, getOr, identity, constant} from 'lodash/fp';
+
 import Accordion from '../container';
 
+const mapi = map.convert({cap: false});
+const map2 = (iteratee, arr1, arr2) => {
+  return mapi((value1, index) => {
+    const value2 = get(index, arr2);
+    return iteratee(value1, value2);
+  }, arr1);
+};
+
 class AccordionToggler extends React.Component {
+  static getDerivedStateFromProps(props, state) {
+    if (state.isOpen) return null;
+
+    const isOpen = map(getOr(false, 'isOpen'), props.tabProps);
+
+    return {isOpen};
+  }
+
   constructor(props) {
     super(props);
-    this.state = {
-      tabProps: props.tabProps
-    };
+
+    this.state = {isOpen: null};
 
     this.handleOnClick = this.handleOnClick.bind(this);
-    this.newOpenState = this.newOpenState.bind(this);
   }
 
   handleOnClick(key) {
     this.setState(prevState => {
-      const newState = {...prevState};
-      forEach.convert({cap: false})((part, index) => {
-        part.isOpen = this.newOpenState(index === key, part.isOpen);
-      }, newState.tabProps);
-
-      return newState;
+      return {
+        isOpen: pipe(
+          this.props.oneTabOnly ? map(constant(false)) : identity,
+          set(key, !get(key, prevState.isOpen))
+        )(prevState.isOpen)
+      };
     });
   }
 
-  newOpenState(isSelectedTab, currentOpenState) {
-    const isOpenOtherTab = this.props.oneTabOnly ? false : currentOpenState;
-    return isSelectedTab ? !currentOpenState : isOpenOtherTab;
+  mergePropsAndState() {
+    return map2(
+      (props, isOpen) => ({
+        ...props,
+        isOpen
+      }),
+      this.props.tabProps,
+      this.state.isOpen
+    );
   }
 
   render() {
     const {children = [], theme} = this.props;
     return (
-      <Accordion tabProps={this.state.tabProps} onClick={this.handleOnClick} theme={theme}>
+      <Accordion tabProps={this.mergePropsAndState()} onClick={this.handleOnClick} theme={theme}>
         {children}
       </Accordion>
     );
   }
 }
+
 AccordionToggler.propTypes = {
   tabProps: PropTypes.arrayOf(PropTypes.shape(Accordion.PropTypes)),
   oneTabOnly: PropTypes.bool,

--- a/packages/@coorpacademy-components/src/organism/accordion/toggler/test/on-click.js
+++ b/packages/@coorpacademy-components/src/organism/accordion/toggler/test/on-click.js
@@ -14,47 +14,46 @@ test('should open/close accordion', t => {
   t.plan(11);
 
   const wrapper = mount(<Accordion {...fixture.props}>{fixture.children}</Accordion>);
-  t.is(wrapper.find('.part__header').exists(), true);
-
-  t.is(wrapper.find('.part__openHeader').exists(), true);
+  t.true(wrapper.find('.part__header').exists());
+  t.true(wrapper.find('.part__openHeader').exists());
   wrapper
     .find('.part__header')
     .at(1)
     .simulate('click');
-  t.is(wrapper.find(`.part__openHeader`).exists(), false);
+  t.false(wrapper.find(`.part__openHeader`).exists());
 
   wrapper
     .find('.part__header')
     .at(0)
     .simulate('click');
-  t.is(wrapper.find('.part__openHeader').exists(), true);
+  t.true(wrapper.find('.part__openHeader').exists());
   wrapper
     .find('.part__header')
     .at(0)
     .simulate('click');
-  t.is(wrapper.find('.part__openHeader').exists(), false);
+  t.false(wrapper.find('.part__openHeader').exists());
 
   wrapper
     .find('.part__header')
     .at(2)
     .simulate('click');
-  t.is(wrapper.find('.part__openHeader').exists(), true);
+  t.true(wrapper.find('.part__openHeader').exists());
   wrapper
     .find('.part__header')
     .at(2)
     .simulate('click');
-  t.is(wrapper.find('.part__openHeader').exists(), false);
+  t.false(wrapper.find('.part__openHeader').exists());
 
   wrapper
     .find('.part__header')
     .at(1)
     .simulate('click');
-  t.is(wrapper.find('.part__openHeader').exists(), true);
+  t.true(wrapper.find('.part__openHeader').exists());
   wrapper
     .find('.part__header')
     .at(1)
     .simulate('click');
-  t.is(wrapper.find('.part__openHeader').exists(), false);
+  t.false(wrapper.find('.part__openHeader').exists());
 
   wrapper
     .find('.part__header')
@@ -68,7 +67,7 @@ test('should open/close accordion', t => {
     .find('.part__header')
     .at(2)
     .simulate('click');
-  t.is(wrapper.find('.part__openHeader').exists(), true);
+  t.true(wrapper.find('.part__openHeader').exists());
   t.is(wrapper.find('.part__openHeader').length, 3);
 });
 
@@ -76,42 +75,42 @@ test('should open/close accordion - only one open', t => {
   t.plan(12);
 
   const wrapper = mount(<Accordion {...onlyOneFixture.props}>{onlyOneFixture.children}</Accordion>);
-  t.is(wrapper.find('.part__header').exists(), true);
+  t.true(wrapper.find('.part__header').exists());
 
-  t.is(wrapper.find('.part__openHeader').exists(), true);
+  t.true(wrapper.find('.part__openHeader').exists());
 
   wrapper
     .find('.part__header')
     .at(1)
     .simulate('click');
   t.is(wrapper.find('.part__openHeader').length, 0);
-  t.is(wrapper.find('.part__openHeader').exists(), false);
+  t.false(wrapper.find('.part__openHeader').exists());
 
   wrapper
     .find('.part__header')
     .at(0)
     .simulate('click');
   t.is(wrapper.find('.part__openHeader').length, 1);
-  t.is(wrapper.find('.part__openHeader').exists(), true);
+  t.true(wrapper.find('.part__openHeader').exists());
 
   wrapper
     .find('.part__header')
     .at(1)
     .simulate('click');
   t.is(wrapper.find('.part__openHeader').length, 1);
-  t.is(wrapper.find('.part__openHeader').exists(), true);
+  t.true(wrapper.find('.part__openHeader').exists());
 
   wrapper
     .find('.part__header')
     .at(2)
     .simulate('click');
   t.is(wrapper.find('.part__openHeader').length, 1);
-  t.is(wrapper.find('.part__openHeader').exists(), true);
+  t.true(wrapper.find('.part__openHeader').exists());
 
   wrapper
     .find('.part__header')
     .at(2)
     .simulate('click');
   t.is(wrapper.find('.part_openHeader').length, 0);
-  t.is(wrapper.find('.part_openHeader').exists(), false);
+  t.false(wrapper.find('.part_openHeader').exists());
 });

--- a/packages/@coorpacademy-components/src/organism/accordion/toggler/test/render.js
+++ b/packages/@coorpacademy-components/src/organism/accordion/toggler/test/render.js
@@ -1,0 +1,48 @@
+import browserEnv from 'browser-env';
+import test from 'ava';
+import React from 'react';
+import {take} from 'lodash/fp';
+import {mount, configure} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import onlyOneFixture from './fixtures/only-one';
+import Accordion from '..';
+
+browserEnv();
+configure({adapter: new Adapter()});
+
+const SINGLE_TAB_PROPS = {
+  ...onlyOneFixture.props,
+  tabProps: take(1, onlyOneFixture.props.tabProps),
+  children: take(1, onlyOneFixture.children)
+};
+
+test(`shouldn't props in state`, t => {
+  const multiPropsWrapper = mount(<Accordion />);
+  multiPropsWrapper.setProps(SINGLE_TAB_PROPS);
+
+  const singlePropsWrapper = mount(<Accordion {...SINGLE_TAB_PROPS} />);
+
+  t.is(multiPropsWrapper.html(), singlePropsWrapper.html());
+});
+
+test(`should keep isOpen in state`, t => {
+  const wrapper = mount(<Accordion {...SINGLE_TAB_PROPS} />);
+
+  t.true(wrapper.find('.part__header').exists());
+
+  t.false(wrapper.find('.part__openHeader').exists());
+
+  wrapper
+    .find('.part__header')
+    .at(0)
+    .simulate('click');
+
+  t.true(wrapper.find('.part__openHeader').exists());
+
+  wrapper.setProps({
+    ...onlyOneFixture.props,
+    children: onlyOneFixture.children
+  });
+
+  t.true(wrapper.find('.part__openHeader').exists());
+});

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
@@ -76,14 +76,17 @@ BrandUpdate.propTypes = {
   ).isRequired,
   content: PropTypes.oneOfType([
     PropTypes.shape({
+      key: PropTypes.string,
       type: PropTypes.oneOf(['form']),
       ...BrandForm.propTypes
     }),
     PropTypes.shape({
+      key: PropTypes.string,
       type: PropTypes.oneOf(['list']),
       ...BrandTable.propTypes
     }),
     PropTypes.shape({
+      key: PropTypes.string,
       type: PropTypes.oneOf(['upload']),
       ...BrandUpload.propTypes
     })


### PR DESCRIPTION
- les tests des fixtures n’étaient plus générés. `preava`
- mise en évidence du bug de synchronisation entre les props et le state.
- on ne stocke plus toutes les props dans le state, mais on n'y gère que le `isOpen`.
- ajout de la propriété `key` pour gérer les changements de page sur setup