### PR TITLE
merge EngineConfig and EngineOptions

### DIFF
--- a/packages/@coorpacademy-player-store/src/test/index.js
+++ b/packages/@coorpacademy-player-store/src/test/index.js
@@ -50,6 +50,7 @@ test('it should expose all api', t => {
       'hasViewedAResourceAtThisStep',
       'getEngine',
       'getEngineConfig',
+      'getOriginalEngineConfig',
       'getPreviousSlide',
       'getExitNode',
       'getCurrentExitNode',

--- a/packages/@coorpacademy-player-store/src/utils/state-extract.js
+++ b/packages/@coorpacademy-player-store/src/utils/state-extract.js
@@ -8,6 +8,7 @@ import {
   any,
   find,
   includes,
+  extend,
   isEmpty,
   update,
   shuffle,
@@ -296,7 +297,7 @@ export const getEngine = (state: State): Engine | void => {
   return progression.engine;
 };
 
-export const getEngineConfig = (state: State): EngineConfig | void => {
+export const getOriginalEngineConfig = (state: State): EngineConfig | void => {
   const engine = getEngine(state);
 
   if (!engine) {
@@ -307,8 +308,17 @@ export const getEngineConfig = (state: State): EngineConfig | void => {
   return state.data.configs && state.data.configs.entities && state.data.configs.entities[config];
 };
 
+export const getEngineConfig = (state: State): EngineConfig | void => {
+  const originalEngineConfig = getOriginalEngineConfig(state);
+  const progression = getCurrentProgression(state);
+  const engineOptions = progression ? get('engineOptions', progression) : null;
+  if (!engineOptions && !originalEngineConfig) return;
+  return extend(originalEngineConfig, engineOptions);
+};
+
 const isEnableShuffleChoices = (state: State): boolean => {
   const engineConfig = getEngineConfig(state);
+
   if (!engineConfig || !engineConfig.shuffleChoices) return false;
   return engineConfig.shuffleChoices;
 };


### PR DESCRIPTION
`getEngineConfig` retournait la config original. La surcharge d'engineOptions de la progression n'était pas appliqué.

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
