### PR TITLE
(feat)(components) Add InputReadonly as a possible field in SetupSlide

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/setup-slide/index.js
+++ b/packages/@coorpacademy-components/src/molecule/setup-slide/index.js
@@ -55,9 +55,40 @@ SetupSlide.defaultProps = {
 
 SetupSlide.propTypes = {
   fields: PropTypes.arrayOf(
-    PropTypes.shape({
-      type: PropTypes.string.isRequired
-    })
+    PropTypes.oneOfType([
+      PropTypes.shape({
+        type: PropTypes.string.isRequired
+      }),
+      PropTypes.shape({
+        type: PropTypes.oneOf(['switch']),
+        ...InputSwitch.propTypes
+      }),
+      PropTypes.shape({
+        type: PropTypes.oneOf(['select']),
+        ...Select.propTypes
+      }),
+      PropTypes.shape({
+        type: PropTypes.oneOf(['checkbox']),
+        ...InputCheckbox.propTypes
+      }),
+      PropTypes.shape({
+        type: PropTypes.oneOf(['image']),
+        ...ImageUpload.propTypes
+      }),
+      PropTypes.shape({
+        type: PropTypes.oneOf(['readonly']),
+        ...InputReadonly.propTypes
+      }),
+      PropTypes.shape({
+        type: PropTypes.oneOf(['splitForm']),
+        ...SetupCohortItem.propTypes
+      }),
+      PropTypes.shape({
+        type: PropTypes.oneOf(['alert']),
+        ...MessagePopin.propTypes
+      }),
+      PropTypes.shape(InputText.propTypes)
+    ])
   )
 };
 export default SetupSlide;

--- a/packages/@coorpacademy-components/src/molecule/setup-slide/index.js
+++ b/packages/@coorpacademy-components/src/molecule/setup-slide/index.js
@@ -57,9 +57,6 @@ SetupSlide.propTypes = {
   fields: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.shape({
-        type: PropTypes.string.isRequired
-      }),
-      PropTypes.shape({
         type: PropTypes.oneOf(['switch']),
         ...InputSwitch.propTypes
       }),

--- a/packages/@coorpacademy-components/src/molecule/setup-slide/index.js
+++ b/packages/@coorpacademy-components/src/molecule/setup-slide/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {map} from 'lodash/fp';
 import Select from '../../atom/select';
+import InputReadonly from '../../atom/input-readonly';
 import InputText from '../../atom/input-text';
 import InputCheckbox from '../../atom/input-checkbox';
 import InputSwitch from '../../atom/input-switch';
@@ -27,6 +28,8 @@ const SetupSlide = props => {
         return <SetupCohortItem field={field} />;
       case 'alert':
         return <MessagePopin header={field.title} content={field.subtitle} />;
+      case 'readonly':
+        return <InputReadonly {...field} />;
       default:
         return <InputText {...field} />;
     }

--- a/packages/@coorpacademy-components/src/molecule/setup-slide/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/setup-slide/test/fixtures/default.js
@@ -34,6 +34,11 @@ export default {
         uploadLabel: 'Upload',
         previewLabel: 'Preview',
         onChange: () => true
+      },
+      {
+        type: 'readonly',
+        title: 'Informative input',
+        value: 'Some data displayed to the user'
       }
     ]
   }


### PR DESCRIPTION
https://trello.com/c/xeru4iXn/776-lms-setup-lecture-et-mise-%C3%A0-jour-dune-configuration

**Detailed purpose of the PR**
Added the an InputReadonly component as a possible field in SetupSlide.
This is needed in the new LMS configuration form in **SETUP**.

**Result and observation**
<img width="470" alt="Screenshot 2020-05-28 at 15 29 34" src="https://user-images.githubusercontent.com/592800/83147574-2c130900-a0f8-11ea-8be4-e8caaafe6460.png">

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [x] Unit testing
