### PR TITLE
Autocomplete component

### DIFF
--- a/packages/@coorpacademy-components/package.json
+++ b/packages/@coorpacademy-components/package.json
@@ -59,6 +59,7 @@
     "postcss-modules-values-replace": "^3.1.0",
     "qs": "6.9.4",
     "react": "~16.13.1",
+    "react-autosuggest": "^10.0.2",
     "react-dropzone": "^9.0.0",
     "react-jw-player": "1.19.1",
     "react-tooltip": "^4.2.6"

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -61,6 +61,7 @@ const Autocomplete = props => {
 };
 
 Autocomplete.propTypes = {
+  title: PropTypes.string,
   placeholder: PropTypes.string,
   value: PropTypes.string,
   description: PropTypes.string,

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -21,12 +21,14 @@ const Autocomplete = props => {
     onChange = noop,
     onFetch = noop,
     onClear = noop,
+    onBlur = noop,
     onSuggestionSelected = noop
   } = props;
 
   const title = `${props.title}${required ? '*' : ''}`;
   const className = getClassState(style.default, style.modified, style.error, modified, error);
   const handleChange = e => onChange(e);
+  const handleBlur = (e, selectedSuggestion) => onBlur(e, selectedSuggestion);
   const handleSuggestionsFetchRequested = e => onFetch(e);
   const handleSuggestionsClearRequested = e => onClear(e);
   const handleSuggestionsSelected = (e, data) => onSuggestionSelected(data);
@@ -34,7 +36,8 @@ const Autocomplete = props => {
   const inputProps = {
     placeholder,
     value,
-    onChange: handleChange
+    onChange: handleChange,
+    onBlur: handleBlur
   };
 
   return (
@@ -77,6 +80,7 @@ Autocomplete.propTypes = {
   onChange: PropTypes.func,
   onFetch: PropTypes.func,
   onClear: PropTypes.func,
+  onBlur: PropTypes.func,
   onSuggestionSelected: PropTypes.func
 };
 

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -16,7 +16,7 @@ const Autocomplete = props => {
     description,
     required,
     modified = false,
-    error,
+    error = false,
     suggestions = [],
     onChange = noop,
     onFetch = noop,
@@ -27,6 +27,11 @@ const Autocomplete = props => {
 
   const title = `${props.title}${required ? '*' : ''}`;
   const className = getClassState(style.default, style.modified, style.error, modified, error);
+
+  console.log('modified', modified)
+  console.log('error', error)
+  console.log('className', className)
+
   const handleChange = e => onChange(e);
   const handleBlur = (e, selectedSuggestion) => onBlur(e, selectedSuggestion);
   const handleSuggestionsFetchRequested = e => onFetch(e);

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Autosuggest from 'react-autosuggest';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {noop, isNil} from 'lodash/fp';
 import getClassState from '../../util/get-class-state';
@@ -57,6 +58,25 @@ const Autocomplete = props => {
       <div className={style.description}>{description}</div>
     </div>
   );
+};
+
+Autocomplete.propTypes = {
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  description: PropTypes.string,
+  required: PropTypes.bool,
+  modified: PropTypes.bool,
+  error: PropTypes.bool,
+  suggestions: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      value: PropTypes.string
+    })
+  ),
+  onChange: PropTypes.func,
+  onFetch: PropTypes.func,
+  onClear: PropTypes.func,
+  onSuggestionSelected: PropTypes.func
 };
 
 export default Autocomplete;

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -70,7 +70,7 @@ Autocomplete.propTypes = {
   suggestions: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,
-      value: PropTypes.string
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     })
   ),
   onChange: PropTypes.func,

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -28,10 +28,6 @@ const Autocomplete = props => {
   const title = `${props.title}${required ? '*' : ''}`;
   const className = getClassState(style.default, style.modified, style.error, modified, error);
 
-  console.log('modified', modified)
-  console.log('error', error)
-  console.log('className', className)
-
   const handleChange = e => onChange(e);
   const handleBlur = (e, selectedSuggestion) => onBlur(e, selectedSuggestion);
   const handleSuggestionsFetchRequested = e => onFetch(e);

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import Autosuggest from 'react-autosuggest';
+import classnames from 'classnames';
+import {noop, isNil} from 'lodash/fp';
+import getClassState from '../../util/get-class-state';
+// eslint-disable-next-line css-modules/no-unused-class
+import style from './style.css';
+
+const renderSuggestion = suggestion => <span>{suggestion.name}</span>;
+
+const Autocomplete = props => {
+  const {
+    placeholder = '',
+    value,
+    description,
+    required,
+    modified = false,
+    error,
+    suggestions = [],
+    onChange = noop,
+    onFetch = noop,
+    onClear = noop,
+    onSuggestionSelected = noop
+  } = props;
+
+  const title = `${props.title}${required ? '*' : ''}`;
+  const className = getClassState(style.default, style.modified, style.error, modified, error);
+  const handleChange = e => onChange(e);
+  const handleSuggestionsFetchRequested = e => onFetch(e);
+  const handleSuggestionsClearRequested = e => onClear(e);
+  const handleSuggestionsSelected = (e, data) => onSuggestionSelected(data);
+
+  const inputProps = {
+    placeholder,
+    value,
+    onChange: handleChange
+  };
+
+  return (
+    <div className={classnames(className, isNil(title) && style.isNoTitle)}>
+      <label>
+        <span className={style.title}>{title}</span>
+        <div>
+          <Autosuggest
+            theme={style}
+            suggestions={suggestions}
+            onSuggestionsFetchRequested={handleSuggestionsFetchRequested}
+            onSuggestionsClearRequested={handleSuggestionsClearRequested}
+            getSuggestionValue={noop}
+            renderSuggestion={renderSuggestion}
+            inputProps={inputProps}
+            focusInputOnSuggestionClick={false}
+            onSuggestionSelected={handleSuggestionsSelected}
+          />
+        </div>
+      </label>
+      <div className={style.description}>{description}</div>
+    </div>
+  );
+};
+
+export default Autocomplete;

--- a/packages/@coorpacademy-components/src/atom/autocomplete/style.css
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/style.css
@@ -84,6 +84,14 @@
     width: 230px;
 }
 
+.error .input {
+    border-color: negative;
+}
+
+.modified .input {
+    border-color: orange;
+}
+
 .suggestionsContainer {
     display: none;
 }

--- a/packages/@coorpacademy-components/src/atom/autocomplete/style.css
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/style.css
@@ -1,0 +1,118 @@
+@value colors: "../../variables/colors.css";
+@value orange from colors;
+@value negative from colors;
+@value light from colors;
+@value dark from colors;
+@value medium from colors;
+
+.default {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    align-content: center;
+}
+
+.default label {
+    display: flex;
+    align-items: center;
+    height: 50px;
+    position: relative;
+    flex-grow: 0;
+    margin-right: 20px;
+}
+
+.error {
+    composes: default;
+}
+
+.modified {
+    composes: default;
+}
+
+.title {
+    font-family: "Open Sans";
+    font-size: 15px;
+    text-transform: none;
+    color: dark;
+    width: 180px;
+}
+
+.description {
+    margin-top: 1px;
+    font-size: 20px;
+}
+
+.isNoTitle input {
+    margin-left: 0;
+}
+
+.isNoTitle .title {
+    display: none;
+}
+
+.isNoTitle .description {
+    margin-left: 8px;
+}
+
+.description {
+    font-family: 'Open Sans';
+    font-weight: 500;
+    font-size: 12px;
+    color: medium;
+    font-style: italic;
+}
+
+/*  classes for Autosuggest, do not change them nor use this names
+    see here https://github.com/moroshko/react-autosuggest#theme-optional
+ */
+
+.container {
+    position: relative;
+}
+
+.input {
+    font-family: "Open Sans";
+    text-transform: none;
+    padding: 0 15px;
+    border: solid 1px light;
+    height: 50px;
+    border-radius: 2px;
+    font-size: 14px;
+    color: dark;
+    margin-left: 20px;
+    width: 230px;
+}
+
+.suggestionsContainer {
+    display: none;
+}
+
+.suggestionsContainerOpen {
+    display: block;
+    position: absolute;
+    top: 52px;
+    border: solid 1px light;
+    font-family: "Open Sans";
+    font-size: 14px;
+    color: dark;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    margin-left: 20px;
+    width: 260px;
+    z-index: 2;
+}
+
+.suggestionsList {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+}
+
+.suggestion {
+    cursor: pointer;
+    padding: 10px 20px;
+}
+
+.suggestionHighlighted {
+    background-color: #ddd;
+}

--- a/packages/@coorpacademy-components/src/atom/autocomplete/style.css
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/style.css
@@ -4,6 +4,7 @@
 @value light from colors;
 @value dark from colors;
 @value medium from colors;
+@value white from colors;
 
 .default {
     display: flex;
@@ -106,6 +107,7 @@
     margin: 0;
     padding: 0;
     list-style-type: none;
+    background-color: white;
 }
 
 .suggestion {

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/default.js
@@ -1,0 +1,17 @@
+export default {
+  props: {
+    title: 'Population',
+    placeholder: "Type 'c'",
+    value: '',
+    suggestions: [],
+    onChange: value => {
+      console.log(`onChange ${value}`);
+    },
+    onFetch: ({value}) => {
+      console.log(`onFetch ${value}`);
+    },
+    onClear: () => {
+      console.log('onClear');
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/default.js
@@ -6,7 +6,7 @@ export default {
     description: '',
     required: false,
     modified: false,
-    error: true,
+    error: false,
     suggestions: [],
     onChange: value => {
       console.log(`onChange ${value}`);

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/default.js
@@ -3,6 +3,10 @@ export default {
     title: 'Population',
     placeholder: "Type 'c'",
     value: '',
+    description: '',
+    required: false,
+    modified: false,
+    error: true,
     suggestions: [],
     onChange: value => {
       console.log(`onChange ${value}`);
@@ -12,6 +16,9 @@ export default {
     },
     onClear: () => {
       console.log('onClear');
+    },
+    onSuggestionSelected: data => {
+      console.log('onSuggestionSelected', data);
     }
   }
 };

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/error.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/error.js
@@ -1,0 +1,10 @@
+import Filled from './filled';
+
+const {props} = Filled;
+
+export default {
+  props: {
+    ...props,
+    error: true
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/filled.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/filled.js
@@ -24,6 +24,23 @@ export default {
         name: 'Clojure',
         value: 2007
       }
-    ]
+    ],
+    onChange: e => {
+      const value = e.target.value;
+      console.log(`onChange ${value}`, e);
+    },
+    onFetch: e => {
+      const {value} = e;
+      console.log(`onFetch ${value}`);
+    },
+    onClear: e => {
+      console.log('onClear', e);
+    },
+    onSuggestionSelected: data => {
+      console.log('onSuggestionSelected', data);
+    },
+    onBlur: (e, selectedSuggestion) => {
+      console.log('onBlur > selected', selectedSuggestion);
+    }
   }
 };

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/filled.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/filled.js
@@ -1,0 +1,40 @@
+const suggestions = [
+  {
+    name: 'C',
+    year: 1972
+  },
+  {
+    name: 'C#',
+    year: 2000
+  },
+  {
+    name: 'C++',
+    year: 1983
+  },
+  {
+    name: 'Clojure',
+    year: 2007
+  }
+];
+
+export default {
+  props: {
+    title: 'Population',
+    value: 'c',
+    suggestions,
+    onChange: e => {
+      const value = e.target.value;
+      console.log(`onChange ${value}`, e);
+    },
+    onFetch: e => {
+      const {value} = e;
+      console.log(`onFetch ${value}`);
+    },
+    onClear: e => {
+      console.log('onClear', e);
+    },
+    onSuggestionSelected: data => {
+      console.log('onSuggestionSelected', data);
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/filled.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/filled.js
@@ -1,19 +1,19 @@
 const suggestions = [
   {
     name: 'C',
-    year: 1972
+    value: 1972
   },
   {
     name: 'C#',
-    year: 2000
+    value: 2000
   },
   {
     name: 'C++',
-    year: 1983
+    value: 1983
   },
   {
     name: 'Clojure',
-    year: 2007
+    value: 2007
   }
 ];
 

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/filled.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/filled.js
@@ -1,40 +1,29 @@
-const suggestions = [
-  {
-    name: 'C',
-    value: 1972
-  },
-  {
-    name: 'C#',
-    value: 2000
-  },
-  {
-    name: 'C++',
-    value: 1983
-  },
-  {
-    name: 'Clojure',
-    value: 2007
-  }
-];
+import Default from './default';
+
+const {props} = Default;
 
 export default {
   props: {
+    ...props,
     title: 'Population',
     value: 'c',
-    suggestions,
-    onChange: e => {
-      const value = e.target.value;
-      console.log(`onChange ${value}`, e);
-    },
-    onFetch: e => {
-      const {value} = e;
-      console.log(`onFetch ${value}`);
-    },
-    onClear: e => {
-      console.log('onClear', e);
-    },
-    onSuggestionSelected: data => {
-      console.log('onSuggestionSelected', data);
-    }
+    suggestions: [
+      {
+        name: 'C',
+        value: 1972
+      },
+      {
+        name: 'C#',
+        value: 2000
+      },
+      {
+        name: 'C++',
+        value: 1983
+      },
+      {
+        name: 'Clojure',
+        value: 2007
+      }
+    ]
   }
 };

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/modified.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/modified.js
@@ -1,0 +1,10 @@
+import Filled from './filled';
+
+const {props} = Filled;
+
+export default {
+  props: {
+    ...props,
+    modified: true
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/select/index.js
+++ b/packages/@coorpacademy-components/src/atom/select/index.js
@@ -107,7 +107,7 @@ const Select = (props, context) => {
 
 export const SelectOptionPropTypes = {
   name: PropTypes.string.isRequired,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   selected: PropTypes.bool
 };
 

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import {map, snakeCase} from 'lodash/fp';
 import Autocomplete from '../../atom/autocomplete';
@@ -66,12 +65,9 @@ const buildInput = field => {
 
 const buildField = (field, index) => {
   const input = buildInput(field);
-  const className = classnames(style.field, {
-    [style.withMultipleSelect]: field.type === 'selectMultiple'
-  });
 
   return (
-    <div className={className} key={index}>
+    <div className={style.field} key={index}>
       {input}
     </div>
   );

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
@@ -99,6 +99,10 @@ BrandFormGroup.propTypes = {
   fields: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.shape({
+        type: PropTypes.oneOf(['autoComplete']),
+        ...Autocomplete.propTypes
+      }),
+      PropTypes.shape({
         type: PropTypes.oneOf(['color']),
         ...InputColor.propTypes
       }),

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import {map, snakeCase} from 'lodash/fp';
+import Autosuggest from 'react-autosuggest';
 import Select from '../../atom/select';
 import SelectMultiple from '../select-multiple';
 import InputText from '../../atom/input-text';
@@ -24,6 +25,8 @@ const buildInput = field => {
   const {type} = field;
 
   switch (type) {
+    case 'autoComplete':
+      return <Autosuggest />;
     case 'color':
       return <InputColor {...field} />;
     case 'readonly':

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import {map, snakeCase} from 'lodash/fp';
-import Autosuggest from 'react-autosuggest';
+import Autocomplete from '../../atom/autocomplete';
 import Select from '../../atom/select';
 import SelectMultiple from '../select-multiple';
 import InputText from '../../atom/input-text';
@@ -26,7 +26,7 @@ const buildInput = field => {
 
   switch (type) {
     case 'autoComplete':
-      return <Autosuggest />;
+      return <Autocomplete {...field} />;
     case 'color':
       return <InputColor {...field} />;
     case 'readonly':

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/style.css
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/style.css
@@ -41,9 +41,6 @@
   margin-bottom: 20px;
 }
 
-.field.withMultipleSelect {
-  max-width: 430px;
-}
 
 .field:last-child {
   margin-bottom: 0;

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/animations.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/animations.js
@@ -1,0 +1,78 @@
+export default {
+  props: {
+    title: 'Massive Battle',
+    fields: [
+      {
+        title: 'User',
+        value: 'autoComplete',
+        description: 'Lorem ipsum dolor sit amet.'
+      },
+      {
+        title: 'Population',
+        type: 'selectMultiple',
+        key: 'payload.language.supported',
+        description: '',
+        options: [
+          {
+            value: 'pop-1',
+            name: 'Population 1',
+            selected: false
+          },
+          {
+            value: 'pop-2',
+            name: 'Population 2',
+            selected: true
+          },
+          {
+            value: 'pop-3',
+            name: 'Population 2',
+            selected: false
+          },
+          {
+            value: 'pop-4',
+            name: 'Population 4',
+            selected: false
+          },
+          {
+            value: 'pop-5',
+            name: 'Population 5',
+            selected: false
+          }
+        ],
+        multiple: true,
+        value: ['pop-1', 'pop-2'],
+        theme: 'setup',
+        modified: false
+      },
+      {
+        title: 'Course',
+        value: 'autoComplete',
+        description: 'Content used on the battle.'
+      },
+      {
+        title: 'Difficulty level',
+        type: 'select',
+        key: 'payload.sector',
+        value: 'none',
+        options: [
+          {
+            value: 0.2,
+            name: 'Easy',
+            selected: true
+          },
+          {
+            value: 0.5,
+            name: 'Average',
+            selected: false
+          },
+          {
+            value: 0.8,
+            name: 'Hard',
+            selected: false
+          }
+        ],
+        modified: false
+      }
+    ]
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/animations.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/animations.js
@@ -1,11 +1,13 @@
+import Autocomplete from '../../../../atom/autocomplete/test/fixtures/filled';
+
 export default {
   props: {
     title: 'Massive Battle',
     fields: [
       {
-        title: 'User',
-        value: 'autoComplete',
-        description: 'Lorem ipsum dolor sit amet.'
+        type: 'autoComplete',
+        ...Autocomplete.props,
+        title: 'Users'
       },
       {
         title: 'Population',
@@ -45,9 +47,9 @@ export default {
         modified: false
       },
       {
-        title: 'Course',
-        value: 'autoComplete',
-        description: 'Content used on the battle.'
+        type: 'autoComplete',
+        ...Autocomplete.props,
+        title: 'Cours'
       },
       {
         title: 'Difficulty level',

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/animations.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/animations.js
@@ -12,8 +12,6 @@ export default {
       {
         title: 'Population',
         type: 'selectMultiple',
-        key: 'payload.language.supported',
-        description: '',
         options: [
           {
             value: 'pop-1',
@@ -42,7 +40,6 @@ export default {
           }
         ],
         multiple: true,
-        value: ['pop-1', 'pop-2'],
         theme: 'setup',
         modified: false
       },
@@ -54,8 +51,6 @@ export default {
       {
         title: 'Difficulty level',
         type: 'select',
-        key: 'payload.sector',
-        value: 'none',
         options: [
           {
             value: 0.2,

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
@@ -123,6 +123,8 @@ SelectMultiple.contextTypes = {
 SelectMultiple.propTypes = {
   title: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.shape(SelectOptionPropTypes)),
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  multiple: PropTypes.bool,
+  theme: PropTypes.string
 };
 export default SelectMultiple;

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
@@ -5,11 +5,13 @@ import {map, pipe, join, filter, get, set} from 'lodash/fp';
 import {NovaCompositionNavigationArrowDown as ArrowDown} from '@coorpacademy/nova-icons';
 import TitledCheckbox from '../titled-checkbox';
 import Provider from '../../atom/provider';
+import getClassState from '../../util/get-class-state';
 import style from './style.css';
 
 const themeStyle = {
   setup: style.setup,
-  cockpit: style.cockpit
+  cockpit: style.cockpit,
+  sidebar: style.sidebar
 };
 
 class SelectMultiple extends React.Component {
@@ -71,7 +73,7 @@ class SelectMultiple extends React.Component {
     const {skin} = this.context;
     const defaultColor = get('common.primary', skin);
     const black = get('common.black', skin);
-    const {title, options, theme, placeholder} = this.props;
+    const {title, options, theme, placeholder, description, modified = false} = this.props;
 
     this._choices = options;
 
@@ -93,18 +95,29 @@ class SelectMultiple extends React.Component {
     )(options);
     const titleView = title && <span className={style.title}>{title}</span>;
     const isActive = this.state.opened === true;
-    const mainClass = classnames(theme ? themeStyle[theme] : style.default);
+    const mainClass = theme ? themeStyle[theme] : style.default;
+    const behaviourClassName = getClassState(style.default, style.modified, style.error, modified);
 
     return (
-      <div className={mainClass} ref={node => (this.node = node)}>
-        {titleView}
-        <div className={style.select} title={selection || placeholder} onClick={this.handleOnClick}>
-          {selection || placeholder}
-          <ArrowDown color={black} className={classnames(style.arrow, {[style.down]: isActive})} />
-        </div>
-        <div className={isActive ? style.activeChoices : style.choices}>
-          <ul className={style.list}>{lines}</ul>
-        </div>
+      <div className={classnames(mainClass, behaviourClassName)} ref={node => (this.node = node)}>
+        <label>
+          {titleView}
+          <div
+            className={style.select}
+            title={selection || placeholder}
+            onClick={this.handleOnClick}
+          >
+            {selection || placeholder}
+            <ArrowDown
+              color={black}
+              className={classnames(style.arrow, {[style.down]: isActive})}
+            />
+          </div>
+          <div className={isActive ? style.activeChoices : style.choices}>
+            <ul className={style.list}>{lines}</ul>
+          </div>
+        </label>
+        <div className={style.description}>{description}</div>
       </div>
     );
   }
@@ -122,9 +135,11 @@ SelectMultiple.contextTypes = {
 
 SelectMultiple.propTypes = {
   title: PropTypes.string,
+  description: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.shape(SelectOptionPropTypes)),
   onChange: PropTypes.func,
   multiple: PropTypes.bool,
-  theme: PropTypes.string
+  theme: PropTypes.string,
+  modified: PropTypes.bool
 };
 export default SelectMultiple;

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/style.css
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/style.css
@@ -1,6 +1,7 @@
 @value colors: "../../variables/colors.css";
 @value dark from colors;
 @value black from colors;
+@value white from colors;
 @value light from colors;
 @value lightGrey from colors;
 @value xtraLightGrey from colors;
@@ -38,9 +39,11 @@
 }
 
 .title {
+  font-family: "Open Sans";
   font-size: 15px;
+  text-transform: none;
   color: dark;
-  margin-bottom: 10px;
+  width: 180px;
 }
 
 .choices {
@@ -105,7 +108,6 @@
   composes: default;
   display: flex;
   align-items: center;
-  margin-left: 20px;
   height: 50px;
   flex-grow: 0;
 }
@@ -114,11 +116,11 @@
   padding-top: 15px;
   line-height: 16px;
   height: 50px;
-  margin-left: 32px;
+  margin-left: 20px;
   width: 230px;
   font-weight: normal;
-  background-color: lightGrey;
-  border: solid 2px light;
+  background-color: white;
+  border: solid 1px light;
 }
 
 .setup .title {
@@ -129,6 +131,7 @@
   width: 230px;
   left: 180px;
   border-top: none;
+  margin-left: 20px;
 }
 
 /*

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/style.css
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/style.css
@@ -5,6 +5,7 @@
 @value light from colors;
 @value lightGrey from colors;
 @value xtraLightGrey from colors;
+@value medium from colors;
 @value defaultText from "../../variables/fonts.css";
 
 /*
@@ -15,6 +16,14 @@
   position: relative;
   user-select: none;
   composes: defaultText;
+}
+
+.error {
+  composes: default;
+}
+
+.modified {
+  composes: default;
 }
 
 .select {
@@ -100,7 +109,20 @@
   margin: 0;
   padding: 0;
 }
-
+.description {
+  font-family: 'Open Sans';
+  font-weight: 500;
+  font-size: 12px;
+  color: medium;
+  font-style: italic;
+  margin: auto 0;
+}
+/*
+  setup sidebar
+*/
+.sidebar {
+  width: 150px;
+}
 /*
   setup theme
 */
@@ -120,11 +142,13 @@
   width: 230px;
   font-weight: normal;
   background-color: white;
-  border: solid 1px light;
+  border: solid 2px light;
+  margin-right: 20px;
 }
 
 .setup .title {
   white-space: nowrap;
+  width: 180px;
 }
 
 .setup .activeChoices {
@@ -134,6 +158,14 @@
   margin-left: 20px;
 }
 
+.setup.modified .select {
+  border: solid 2px orange;
+}
+
+.setup label {
+  display: inline-flex;
+  align-items: center;
+}
 /*
   cockpit theme
 */

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/test/fixtures/setup-theme.js
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/test/fixtures/setup-theme.js
@@ -1,0 +1,82 @@
+export default {
+  props: {
+    title: 'Populations',
+    type: 'selectMultiple',
+    description: 'The cohorte which will receive the battle',
+    options: [
+      {
+        value: 'connect',
+        name: 'Connect users',
+        selected: false
+      },
+      {
+        value: 'coorpacademy',
+        name: 'Coorpacademy users',
+        selected: false
+      },
+      {
+        value: 'fr',
+        name: 'country-fr',
+        selected: false
+      },
+      {
+        value: 'ekino',
+        name: 'Ekino users',
+        selected: false
+      },
+      {
+        value: 'user',
+        name: 'Simple users',
+        selected: false
+      },
+      {
+        value: 'default-digital',
+        name: 'Default for digital',
+        selected: false
+      },
+      {
+        value: 'chanel',
+        name: 'Chanel users',
+        selected: false
+      },
+      {
+        value: 'adaptive-pop',
+        name: 'adaptive-pop',
+        selected: false
+      },
+      {
+        value: 'co',
+        name: 'provider-co',
+        selected: false
+      },
+      {
+        value: 'latin',
+        name: 'latin',
+        selected: false
+      },
+      {
+        value: 'organization_A',
+        name: 'organization_A',
+        selected: false
+      },
+      {
+        value: 'organization_B',
+        name: 'organization_B',
+        selected: false
+      },
+      {
+        value: 'organization_C',
+        name: 'organization_C',
+        selected: false
+      },
+      {
+        value: 'ALL',
+        name: 'ALL',
+        selected: false
+      }
+    ],
+    multiple: true,
+    theme: 'setup',
+    modified: true
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/test/index.js
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/test/index.js
@@ -1,29 +1,13 @@
 import browserEnv from 'browser-env';
 import test from 'ava';
 import React from 'react';
-import {mount, shallow, configure} from 'enzyme';
+import {mount, configure} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import defaultFixture from './fixtures/checked';
 import SelectMultiple from '..';
 
 browserEnv();
 configure({adapter: new Adapter()});
-
-test('should shallow render with default props', t => {
-  const props = {...defaultFixture.props};
-  const wrapper = shallow(<SelectMultiple {...props} />);
-
-  t.snapshot(wrapper);
-});
-
-test('should shallow render when select is opened', t => {
-  const props = {...defaultFixture.props};
-  const wrapper = shallow(<SelectMultiple {...props} />);
-
-  wrapper.setState({opened: true});
-
-  t.snapshot(wrapper);
-});
 
 test('should open and close list', t => {
   t.plan(8);

--- a/packages/@coorpacademy-components/src/organism/sidebar/index.js
+++ b/packages/@coorpacademy-components/src/organism/sidebar/index.js
@@ -47,7 +47,7 @@ export const MultiSelectItem = props => {
   return (
     <li data-name={props.name || `select-item-${props.index}`} className={style.selectItem}>
       <span className={style.sidebarTitle}>{props.title}</span>
-      <SelectMultiple onChange={props.onChange} options={props.options} />
+      <SelectMultiple theme="sidebar" onChange={props.onChange} options={props.options} />
     </li>
   );
 };

--- a/packages/@coorpacademy-components/src/organism/sidebar/style.css
+++ b/packages/@coorpacademy-components/src/organism/sidebar/style.css
@@ -23,9 +23,7 @@
   margin-bottom: 20px;
   background-color: white;
 }
-.selectMultiple {
-  width: 150px;
-}
+
 .sidebarTitle {
   text-transform: uppercase;
 }

--- a/packages/@coorpacademy-components/src/organism/sidebar/style.css
+++ b/packages/@coorpacademy-components/src/organism/sidebar/style.css
@@ -23,7 +23,9 @@
   margin-bottom: 20px;
   background-color: white;
 }
-
+.selectMultiple {
+  width: 150px;
+}
 .sidebarTitle {
   text-transform: uppercase;
 }

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -325,6 +325,7 @@ import MoleculeBrandDownloadBoxFixtureDefault from '../src/molecule/brand-downlo
 import MoleculeBrandDownloadBoxFixtureDownloadOneLoginTokens from '../src/molecule/brand-download-box/test/fixtures/download-one-login-tokens';
 import MoleculeBrandDownloadBoxFixtureSso from '../src/molecule/brand-download-box/test/fixtures/sso';
 import MoleculeBrandFormGroupFixtureAnalytics from '../src/molecule/brand-form-group/test/fixtures/analytics';
+import MoleculeBrandFormGroupFixtureAnimations from '../src/molecule/brand-form-group/test/fixtures/animations';
 import MoleculeBrandFormGroupFixtureCohort from '../src/molecule/brand-form-group/test/fixtures/cohort';
 import MoleculeBrandFormGroupFixtureDashboard from '../src/molecule/brand-form-group/test/fixtures/dashboard';
 import MoleculeBrandFormGroupFixtureDefault from '../src/molecule/brand-form-group/test/fixtures/default';
@@ -1251,6 +1252,7 @@ export const fixtures = {
     },
     MoleculeBrandFormGroup: {
       Analytics: MoleculeBrandFormGroupFixtureAnalytics,
+      Animations: MoleculeBrandFormGroupFixtureAnimations,
       Cohort: MoleculeBrandFormGroupFixtureCohort,
       Dashboard: MoleculeBrandFormGroupFixtureDashboard,
       Default: MoleculeBrandFormGroupFixtureDefault,

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -502,6 +502,7 @@ import MoleculeSelectMultipleFixtureCheckedCockpitTheme from '../src/molecule/se
 import MoleculeSelectMultipleFixtureCheckedSetupTheme from '../src/molecule/select-multiple/test/fixtures/checked-setup-theme';
 import MoleculeSelectMultipleFixtureChecked from '../src/molecule/select-multiple/test/fixtures/checked';
 import MoleculeSelectMultipleFixtureDefault from '../src/molecule/select-multiple/test/fixtures/default';
+import MoleculeSelectMultipleFixtureSetupTheme from '../src/molecule/select-multiple/test/fixtures/setup-theme';
 import MoleculeSetupCohortItemFixtureCreateNewValid from '../src/molecule/setup-cohort-item/test/fixtures/create-new-valid';
 import MoleculeSetupCohortItemFixtureCreateNew from '../src/molecule/setup-cohort-item/test/fixtures/create-new';
 import MoleculeSetupCohortItemFixtureDefault from '../src/molecule/setup-cohort-item/test/fixtures/default';
@@ -1459,7 +1460,8 @@ export const fixtures = {
       CheckedCockpitTheme: MoleculeSelectMultipleFixtureCheckedCockpitTheme,
       CheckedSetupTheme: MoleculeSelectMultipleFixtureCheckedSetupTheme,
       Checked: MoleculeSelectMultipleFixtureChecked,
-      Default: MoleculeSelectMultipleFixtureDefault
+      Default: MoleculeSelectMultipleFixtureDefault,
+      SetupTheme: MoleculeSelectMultipleFixtureSetupTheme
     },
     MoleculeSetupCohortItem: {
       CreateNewValid: MoleculeSetupCohortItemFixtureCreateNewValid,

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -156,7 +156,9 @@ import TemplateCommonDiscipline from './../src/template/common/discipline';
 import TemplateCommonSearchPage from './../src/template/common/search-page';
 import TemplateExternalCourse from './../src/template/external-course';
 import AtomAutocompleteFixtureDefault from '../src/atom/autocomplete/test/fixtures/default';
+import AtomAutocompleteFixtureError from '../src/atom/autocomplete/test/fixtures/error';
 import AtomAutocompleteFixtureFilled from '../src/atom/autocomplete/test/fixtures/filled';
+import AtomAutocompleteFixtureModified from '../src/atom/autocomplete/test/fixtures/modified';
 import AtomAvatarFixtureDefault from '../src/atom/avatar/test/fixtures/default';
 import AtomButtonFixtureA from '../src/atom/button/test/fixtures/a';
 import AtomButtonFixtureClassName from '../src/atom/button/test/fixtures/class-name';
@@ -987,7 +989,9 @@ export const fixtures = {
   Atom: {
     AtomAutocomplete: {
       Default: AtomAutocompleteFixtureDefault,
-      Filled: AtomAutocompleteFixtureFilled
+      Error: AtomAutocompleteFixtureError,
+      Filled: AtomAutocompleteFixtureFilled,
+      Modified: AtomAutocompleteFixtureModified
     },
     AtomAvatar: {
       Default: AtomAvatarFixtureDefault

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 
+import AtomAutocomplete from './../src/atom/autocomplete';
 import AtomAvatar from './../src/atom/avatar';
 import AtomButton from './../src/atom/button';
 import AtomCatalogSection from './../src/atom/catalog-section';
@@ -154,6 +155,8 @@ import TemplateCommonDashboard from './../src/template/common/dashboard';
 import TemplateCommonDiscipline from './../src/template/common/discipline';
 import TemplateCommonSearchPage from './../src/template/common/search-page';
 import TemplateExternalCourse from './../src/template/external-course';
+import AtomAutocompleteFixtureDefault from '../src/atom/autocomplete/test/fixtures/default';
+import AtomAutocompleteFixtureFilled from '../src/atom/autocomplete/test/fixtures/filled';
 import AtomAvatarFixtureDefault from '../src/atom/avatar/test/fixtures/default';
 import AtomButtonFixtureA from '../src/atom/button/test/fixtures/a';
 import AtomButtonFixtureClassName from '../src/atom/button/test/fixtures/class-name';
@@ -791,6 +794,7 @@ import TemplateExternalCourseFixtureVideo from '../src/template/external-course/
 
 export const components = {
   Atom: {
+    AtomAutocomplete,
     AtomAvatar,
     AtomButton,
     AtomCatalogSection,
@@ -980,6 +984,10 @@ export const components = {
 
 export const fixtures = {
   Atom: {
+    AtomAutocomplete: {
+      Default: AtomAutocompleteFixtureDefault,
+      Filled: AtomAutocompleteFixtureFilled
+    },
     AtomAvatar: {
       Default: AtomAvatarFixtureDefault
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8046,7 +8046,7 @@ es6-error@^4.0.1:
   resolved "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-es6-promise@^4.0.3:
+es6-promise@^4.0.3, es6-promise@^4.2.8:
   version "4.2.8"
   resolved "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
@@ -12786,6 +12786,11 @@ oauth-sign@~0.9.0:
   resolved "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+  integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
+
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -14299,6 +14304,27 @@ rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-autosuggest@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-10.0.2.tgz#c45cd73a7307026c932cb6a3e19c2fe35bfb6ec4"
+  integrity sha512-ouI0RJDSgM1FBfK0ZmLC3qUqithIwPVTpnC4JQW4DeId3mH2JnZmkNNDKImhcMrxLbSQRpV/DfTLn0uCs4b27w==
+  dependencies:
+    es6-promise "^4.2.8"
+    prop-types "^15.7.2"
+    react-autowhatever "^10.2.1"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+    shallow-equal "^1.2.1"
+
+react-autowhatever@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.npmjs.org/react-autowhatever/-/react-autowhatever-10.2.1.tgz#a6d421dc6135173efedc249ab7216e4f5b691bcc"
+  integrity sha512-5gQyoETyBH6GmuW1N1J81CuoAV+Djeg66DEo03xiZOl3WOwJHBP5LisKUvCGOakjrXU4M3hcIvCIqMBYGUmqOA==
+  dependencies:
+    prop-types "^15.5.8"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+
 react-clientside-effect@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
@@ -14555,6 +14581,13 @@ react-textarea-autosize@^7.1.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
+
+react-themeable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
+  integrity sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=
+  dependencies:
+    object-assign "^3.0.0"
 
 react-tooltip@^4.2.6:
   version "4.2.6"
@@ -15469,6 +15502,11 @@ schema-utils@^2.4.1:
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
 
+section-iterator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
+  integrity sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=
+
 seekout@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/seekout/-/seekout-1.0.2.tgz#09ba9f1bd5b46fbb134718eb19a68382cbb1b9c9"
@@ -15653,6 +15691,11 @@ shallow-equal@^1.1.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.0.tgz#fd828d2029ff4e19569db7e19e535e94e2d1f5cc"
   integrity sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA==
+
+shallow-equal@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
+  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 shallowequal@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR add a new component `autocomplete` as an atom and includes it as a possible input that can be used on `brand-form-group` molecule.

It also fixes a visual problem on with `select-multiple` molecule (background color and label not aligned)
<img width="567" alt="Capture d’écran 2020-06-03 à 14 29 12" src="https://user-images.githubusercontent.com/7602475/83636704-b18a3380-a5a6-11ea-985c-298dfa334da5.png">


**Result and observation**

## Atom autocomplete
<img width="556" alt="Capture d’écran 2020-06-03 à 14 26 08" src="https://user-images.githubusercontent.com/7602475/83636701-b18a3380-a5a6-11ea-8ab4-dc25a1c9bcdf.png">

## Visual fix of form having select and multiselect + autocomplete behavior
![massive-battle-with-autocomplete](https://user-images.githubusercontent.com/7602475/83636918-075edb80-a5a7-11ea-8522-6c19b69a65a0.gif)

- **Extra lib ?**
      react-autosuggest(https://github.com/moroshko/react-autosuggest)

**Testing Strategy**

- Already covered by tests
- Manual testing
- Unit testing
