### PR TITLE
[COMP] Add InputDoublestep to SetupSlide 

### DIFF
--- a/packages/@coorpacademy-components/src/atom/input-doublestep/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-doublestep/index.js
@@ -40,7 +40,11 @@ const ConfirmationForm = props => {
 
   const form = (
     <div className={style.confirmForm}>
-      {textValidation ? <ConfirmationInput onChange={onChange} placeholder={placeholder} /> : null}
+      {textValidation ? (
+        <ConfirmationInput onChange={onChange} placeholder={placeholder} />
+      ) : (
+        <div className={style.confirmEmptySpace} />
+      )}
       <span onClick={onHandleClose} className={style.cancel}>
         {cancelValue}
       </span>

--- a/packages/@coorpacademy-components/src/atom/input-doublestep/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-doublestep/style.css
@@ -32,7 +32,6 @@
 }
 
 .confirmEmptySpace {
-  /*position: relative;*/
   min-height: 63px;
 }
 

--- a/packages/@coorpacademy-components/src/atom/input-doublestep/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-doublestep/style.css
@@ -31,6 +31,11 @@
   min-height: 126px;
 }
 
+.confirmEmptySpace {
+  /*position: relative;*/
+  min-height: 63px;
+}
+
 .toggle {
   height: 52px;
   padding: 0 40px;

--- a/packages/@coorpacademy-components/src/molecule/setup-slide/index.js
+++ b/packages/@coorpacademy-components/src/molecule/setup-slide/index.js
@@ -5,6 +5,7 @@ import Select from '../../atom/select';
 import InputReadonly from '../../atom/input-readonly';
 import InputText from '../../atom/input-text';
 import InputCheckbox from '../../atom/input-checkbox';
+import InputDoublestep from '../../atom/input-doublestep';
 import InputSwitch from '../../atom/input-switch';
 import ImageUpload from '../../atom/image-upload';
 import SetupCohortItem from '../setup-cohort-item';
@@ -30,6 +31,8 @@ const SetupSlide = props => {
         return <MessagePopin header={field.title} content={field.subtitle} />;
       case 'readonly':
         return <InputReadonly {...field} />;
+      case 'doublestep':
+        return <InputDoublestep {...field} />;
       default:
         return <InputText {...field} />;
     }
@@ -75,6 +78,10 @@ SetupSlide.propTypes = {
       PropTypes.shape({
         type: PropTypes.oneOf(['readonly']),
         ...InputReadonly.propTypes
+      }),
+      PropTypes.shape({
+        type: PropTypes.oneOf(['doublestep']),
+        ...InputDoublestep.propTypes
       }),
       PropTypes.shape({
         type: PropTypes.oneOf(['splitForm']),

--- a/packages/@coorpacademy-components/src/molecule/setup-slide/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/setup-slide/test/fixtures/default.js
@@ -36,6 +36,11 @@ export default {
         onChange: () => true
       },
       {
+        type: 'readonly',
+        title: 'Informative input',
+        value: 'Some data displayed to the user'
+      },
+      {
         type: 'doublestep',
         toggleValue: 'Delete',
         confirmValue: 'Confirm',

--- a/packages/@coorpacademy-components/src/molecule/setup-slide/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/setup-slide/test/fixtures/default.js
@@ -43,7 +43,8 @@ export default {
         cancelValue: 'Cancel',
         description: "You are about to delete some important data. Click 'Confirm' to proceed.",
         textValidation: false,
-        isPending: false
+        isPending: false,
+        onClick: () => true
       }
     ]
   }

--- a/packages/@coorpacademy-components/src/molecule/setup-slide/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/setup-slide/test/fixtures/default.js
@@ -36,9 +36,14 @@ export default {
         onChange: () => true
       },
       {
-        type: 'readonly',
-        title: 'Informative input',
-        value: 'Some data displayed to the user'
+        type: 'doublestep',
+        toggleValue: 'Delete',
+        confirmValue: 'Confirm',
+        confirmDisabled: false,
+        cancelValue: 'Cancel',
+        description: "You are about to delete some important data. Click 'Confirm' to proceed.",
+        textValidation: false,
+        isPending: false
       }
     ]
   }


### PR DESCRIPTION
https://trello.com/c/nAMeCHrf/782-lms-setup-suppression-dune-configuration

**Detailed purpose of the PR**
- The component InputDoublestep has been added to the possible components that SetupSlide can contain. Needed for https://github.com/CoorpAcademy/app-backoffice/pull/505.
- Fixes a spacing issue when no text validation is required.
- Add a fixture for InputReadonly in SetupSlide, as well.

**Result and observation**
![setupslide-input-doublestep](https://user-images.githubusercontent.com/592800/83772604-d86a6780-a683-11ea-9575-cafdece683af.gif)

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [x] Unit testing
