### PR TITLE
adding missing attributs for states (error, required) on select/mutiselect

### DIFF
--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -25,7 +25,7 @@ const Autocomplete = props => {
     onSuggestionSelected = noop
   } = props;
 
-  const title = `${props.title}${required ? '*' : ''}`;
+  const title = `${props.title}${required ? ' *' : ''}`;
   const className = getClassState(style.default, style.modified, style.error, modified, error);
 
   const handleChange = e => onChange(e);

--- a/packages/@coorpacademy-components/src/atom/select/index.js
+++ b/packages/@coorpacademy-components/src/atom/select/index.js
@@ -30,7 +30,8 @@ const Select = (props, context) => {
     required,
     description,
     theme,
-    modified = false
+    modified = false,
+    error = false
   } = props;
 
   const {skin} = context;
@@ -76,7 +77,13 @@ const Select = (props, context) => {
       className={style.arrow}
     />
   ) : null;
-  const behaviourClassName = getClassState(style.default, style.modified, style.error, modified);
+  const behaviourClassName = getClassState(
+    style.default,
+    style.modified,
+    style.error,
+    modified,
+    error
+  );
   const composedClassName = classnames(
     theme ? themeStyle[theme] : behaviourClassName,
     selected ? style.selected : style.unselected,
@@ -127,7 +134,8 @@ Select.propTypes = {
   onChange: PropTypes.func,
   theme: PropTypes.oneOf(keys(themeStyle)),
   options: PropTypes.arrayOf(PropTypes.shape(SelectOptionPropTypes)),
-  modified: PropTypes.bool
+  modified: PropTypes.bool,
+  error: PropTypes.bool
 };
 
 export default Select;

--- a/packages/@coorpacademy-components/src/atom/select/style.css
+++ b/packages/@coorpacademy-components/src/atom/select/style.css
@@ -2,6 +2,7 @@
 @value mobile from breakpoints;
 @value colors: "../../variables/colors.css";
 @value orange from colors;
+@value negative from colors;
 @value dark from colors;
 @value light from colors;
 @value medium from colors;
@@ -83,6 +84,10 @@
   outline: none;
   appearance: none;
   cursor: pointer;
+}
+
+.error select {
+  border: solid 2px negative;
 }
 
 .description {

--- a/packages/@coorpacademy-components/src/atom/select/test/fixtures/error.js
+++ b/packages/@coorpacademy-components/src/atom/select/test/fixtures/error.js
@@ -1,0 +1,24 @@
+export default {
+  props: {
+    title: 'Propriétés de la marque :',
+    error: true,
+    options: [
+      {
+        name: '',
+        value: '',
+        selected: true
+      },
+      {
+        name: 'Pouet',
+        value: 'Pouet',
+        selected: false
+      },
+      {
+        name: 'Pouet2',
+        value: 'Pouet2',
+        selected: false
+      }
+    ],
+    onChange: value => console.log(value)
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
@@ -73,7 +73,15 @@ class SelectMultiple extends React.Component {
     const {skin} = this.context;
     const defaultColor = get('common.primary', skin);
     const black = get('common.black', skin);
-    const {title, options, theme, placeholder, description, modified = false} = this.props;
+    const {
+      title,
+      options,
+      theme,
+      placeholder,
+      description,
+      modified = false,
+      required = false
+    } = this.props;
 
     this._choices = options;
 
@@ -93,7 +101,10 @@ class SelectMultiple extends React.Component {
       map('name'),
       join(', ')
     )(options);
-    const titleView = title && <span className={style.title}>{title}</span>;
+
+    const _title = title && `${title}${required ? ' *' : ''}`;
+
+    const titleView = title && <span className={style.title}>{_title}</span>;
     const isActive = this.state.opened === true;
     const mainClass = theme ? themeStyle[theme] : style.default;
     const behaviourClassName = getClassState(style.default, style.modified, style.error, modified);
@@ -140,6 +151,7 @@ SelectMultiple.propTypes = {
   onChange: PropTypes.func,
   multiple: PropTypes.bool,
   theme: PropTypes.string,
-  modified: PropTypes.bool
+  modified: PropTypes.bool,
+  required: PropTypes.bool
 };
 export default SelectMultiple;

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
@@ -80,7 +80,8 @@ class SelectMultiple extends React.Component {
       placeholder,
       description,
       modified = false,
-      required = false
+      required = false,
+      error = false
     } = this.props;
 
     this._choices = options;
@@ -107,7 +108,13 @@ class SelectMultiple extends React.Component {
     const titleView = title && <span className={style.title}>{_title}</span>;
     const isActive = this.state.opened === true;
     const mainClass = theme ? themeStyle[theme] : style.default;
-    const behaviourClassName = getClassState(style.default, style.modified, style.error, modified);
+    const behaviourClassName = getClassState(
+      style.default,
+      style.modified,
+      style.error,
+      modified,
+      error
+    );
 
     return (
       <div className={classnames(mainClass, behaviourClassName)} ref={node => (this.node = node)}>

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/style.css
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/style.css
@@ -4,6 +4,7 @@
 @value white from colors;
 @value light from colors;
 @value lightGrey from colors;
+@value negative from colors;
 @value xtraLightGrey from colors;
 @value medium from colors;
 @value defaultText from "../../variables/fonts.css";
@@ -160,6 +161,10 @@
 
 .setup.modified .select {
   border: solid 2px orange;
+}
+
+.setup.error .select {
+  border: solid 2px negative;
 }
 
 .setup label {

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/test/fixtures/setup-theme-error.js
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/test/fixtures/setup-theme-error.js
@@ -1,0 +1,83 @@
+export default {
+  props: {
+    title: 'Populations',
+    type: 'selectMultiple',
+    description: 'The cohorte which will receive the battle',
+    required: true,
+    options: [
+      {
+        value: 'connect',
+        name: 'Connect users',
+        selected: false
+      },
+      {
+        value: 'coorpacademy',
+        name: 'Coorpacademy users',
+        selected: false
+      },
+      {
+        value: 'fr',
+        name: 'country-fr',
+        selected: false
+      },
+      {
+        value: 'ekino',
+        name: 'Ekino users',
+        selected: false
+      },
+      {
+        value: 'user',
+        name: 'Simple users',
+        selected: false
+      },
+      {
+        value: 'default-digital',
+        name: 'Default for digital',
+        selected: false
+      },
+      {
+        value: 'chanel',
+        name: 'Chanel users',
+        selected: false
+      },
+      {
+        value: 'adaptive-pop',
+        name: 'adaptive-pop',
+        selected: false
+      },
+      {
+        value: 'co',
+        name: 'provider-co',
+        selected: false
+      },
+      {
+        value: 'latin',
+        name: 'latin',
+        selected: false
+      },
+      {
+        value: 'organization_A',
+        name: 'organization_A',
+        selected: false
+      },
+      {
+        value: 'organization_B',
+        name: 'organization_B',
+        selected: false
+      },
+      {
+        value: 'organization_C',
+        name: 'organization_C',
+        selected: false
+      },
+      {
+        value: 'ALL',
+        name: 'ALL',
+        selected: false
+      }
+    ],
+    multiple: true,
+    theme: 'setup',
+    error: true
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/test/fixtures/setup-theme.js
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/test/fixtures/setup-theme.js
@@ -3,6 +3,7 @@ export default {
     title: 'Populations',
     type: 'selectMultiple',
     description: 'The cohorte which will receive the battle',
+    required: true,
     options: [
       {
         value: 'connect',

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -273,6 +273,7 @@ import AtomResourceMiniatureFixtureSelectedVideo from '../src/atom/resource-mini
 import AtomResourceMiniatureFixtureVideo from '../src/atom/resource-miniature/test/fixtures/video';
 import AtomSelectFixtureDefault from '../src/atom/select/test/fixtures/default';
 import AtomSelectFixtureDisabled from '../src/atom/select/test/fixtures/disabled';
+import AtomSelectFixtureError from '../src/atom/select/test/fixtures/error';
 import AtomSelectFixtureFilter from '../src/atom/select/test/fixtures/filter';
 import AtomSelectFixtureInvalid from '../src/atom/select/test/fixtures/invalid';
 import AtomSelectFixtureModified from '../src/atom/select/test/fixtures/modified';
@@ -1169,6 +1170,7 @@ export const fixtures = {
     AtomSelect: {
       Default: AtomSelectFixtureDefault,
       Disabled: AtomSelectFixtureDisabled,
+      Error: AtomSelectFixtureError,
       Filter: AtomSelectFixtureFilter,
       Invalid: AtomSelectFixtureInvalid,
       Modified: AtomSelectFixtureModified,

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -505,6 +505,7 @@ import MoleculeSelectMultipleFixtureCheckedCockpitTheme from '../src/molecule/se
 import MoleculeSelectMultipleFixtureCheckedSetupTheme from '../src/molecule/select-multiple/test/fixtures/checked-setup-theme';
 import MoleculeSelectMultipleFixtureChecked from '../src/molecule/select-multiple/test/fixtures/checked';
 import MoleculeSelectMultipleFixtureDefault from '../src/molecule/select-multiple/test/fixtures/default';
+import MoleculeSelectMultipleFixtureSetupThemeError from '../src/molecule/select-multiple/test/fixtures/setup-theme-error';
 import MoleculeSelectMultipleFixtureSetupTheme from '../src/molecule/select-multiple/test/fixtures/setup-theme';
 import MoleculeSetupCohortItemFixtureCreateNewValid from '../src/molecule/setup-cohort-item/test/fixtures/create-new-valid';
 import MoleculeSetupCohortItemFixtureCreateNew from '../src/molecule/setup-cohort-item/test/fixtures/create-new';
@@ -1468,6 +1469,7 @@ export const fixtures = {
       CheckedSetupTheme: MoleculeSelectMultipleFixtureCheckedSetupTheme,
       Checked: MoleculeSelectMultipleFixtureChecked,
       Default: MoleculeSelectMultipleFixtureDefault,
+      SetupThemeError: MoleculeSelectMultipleFixtureSetupThemeError,
       SetupTheme: MoleculeSelectMultipleFixtureSetupTheme
     },
     MoleculeSetupCohortItem: {


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->
Multi-select has not required prop before
select has not error prop before

**Detailed purpose of the PR**

Adds this props

**Result and observation**
<img width="681" alt="Capture d’écran 2020-06-09 à 16 15 18" src="https://user-images.githubusercontent.com/7602475/84158730-7edfaf80-aa6c-11ea-9587-b379e22d8ebd.png">
<img width="502" alt="Capture d’écran 2020-06-09 à 16 15 44" src="https://user-images.githubusercontent.com/7602475/84158736-8010dc80-aa6c-11ea-875d-030f35ace0bd.png">

**Testing Strategy**

- Manual testing
- Unit testing (properties + fixtures)
