### PR TITLE
[Dashboard, CardsList] Add paging & change design

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
@@ -168,7 +168,7 @@ class CardsList extends React.Component {
       const rightBound = this.rightBound();
 
       const skip = this.getPossiblePositions().filter((el, index) => {
-        return el + getOr(0, [index, 'scrollWidth'], this.cards) <= leftBound;
+        return el + this.getScrollWidth(this.cards[index]) <= leftBound;
       }).length;
       const limit = this.getPossiblePositions().filter((el, index) => {
         return el + this.getScrollWidth(this.cards[index]) > leftBound && el < rightBound;
@@ -202,12 +202,21 @@ class CardsList extends React.Component {
 
   updatePages(event_) {
     const isResize = typeof event_ === 'object' && event_.type === 'resize';
-    if (isResize) this.forceUpdate();
-
     const {actualPage} = this.state;
-    const nextState = {
-      actualPage: typeof event_ === 'number' ? event_ : actualPage || 1
-    };
+    let nextState;
+    if (isResize) {
+      const leftBound = this.leftBound();
+      const skip = this.getPossiblePositions().filter(el => {
+        return el <= leftBound;
+      }).length;
+      nextState = {
+        actualPage: this.getPossiblePages()[skip + 1]
+      };
+    } else {
+      nextState = {
+        actualPage: typeof event_ === 'number' ? event_ : actualPage || 1
+      };
+    }
     if (!isEqual(this.state, nextState)) this.setState(nextState);
   }
 
@@ -219,7 +228,6 @@ class CardsList extends React.Component {
     const {title, showMore, cards, onShowMore, dataName, contentType} = this.props;
     const {skin} = this.context;
     const {actualPage} = this.state;
-
     const dark = getOr('#90A4AE', 'common.dark', skin);
     const titleStyle = onShowMore ? style.titleLink : style.title;
     const cardsView = map.convert({cap: false})((card, key) => {

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
@@ -141,27 +141,23 @@ class CardsList extends React.Component {
     return getOr(0, 'offsetWidth', this.cardsWrapper);
   }
 
-  getPossiblePositions() {
-    return this.cards.map((card, index, arr) => {
-      return arr.slice(0, index).reduce((a, b) => {
-        return a + getOr(0, 'scrollWidth', b);
-      }, 0);
-    });
-  }
-
   // eslint-disable-next-line class-methods-use-this
   getScrollWidth(b) {
     return getOr(0, 'scrollWidth', b);
   }
 
+  getPossiblePositions() {
+    return this.cards.map((card, index, arr) => {
+      return arr.slice(0, index).reduce((a, b) => {
+        return a + this.getScrollWidth(b);
+      }, 0);
+    });
+  }
+
   getPossiblePages() {
-    return this.cards
-      .map((card, index, arr) => {
-        return arr.slice(0, index).reduce((a, b) => {
-          return a + this.getScrollWidth(b);
-        }, 0);
-      })
-      .map(el => Math.floor(el / this.wrapperWidth() + 1));
+    return this.getPossiblePositions().map((el, index) =>
+      Math.floor((el + this.getScrollWidth(this.cards[index])) / this.wrapperWidth() + 1)
+    );
   }
 
   handleScroll(scrollEvent) {
@@ -203,9 +199,12 @@ class CardsList extends React.Component {
     this.updatePages(page);
   }
 
-  updatePages(page) {
+  updatePages(event_) {
+    const isResize = typeof event_ === 'object' && event_.type === 'resize';
+    if (isResize) this.forceUpdate();
+
     const nextState = {
-      actualPage: page ? page : this.state.actualPage || 1
+      actualPage: typeof event_ === 'number' ? event_ : this.state.actualPage || 1
     };
     if (!isEqual(this.state, nextState)) this.setState(nextState);
   }

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
@@ -80,7 +80,9 @@ class CardsList extends React.Component {
     super(props);
     this.cards = [];
 
-    this.state = {};
+    this.state = {
+      actualPage: null
+    };
 
     this.leftBound = this.leftBound.bind(this);
     this.rightBound = this.rightBound.bind(this);

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
@@ -12,9 +12,9 @@ import Card from '../../card';
 import style from './style.css';
 
 const ShowMoreLink = props => {
-  const {onShowMore, showMore} = props;
+  const {onShowMore, showMore, className} = props;
   return (
-    <div className={style.showMore} onClick={onShowMore}>
+    <div className={className} onClick={onShowMore}>
       {showMore}
     </div>
   );
@@ -26,7 +26,8 @@ ShowMoreLink.contextTypes = {
 
 ShowMoreLink.propTypes = {
   onShowMore: PropTypes.func,
-  showMore: PropTypes.string
+  showMore: PropTypes.string,
+  className: PropTypes.string
 };
 
 const IconView = (props, context) => {
@@ -156,7 +157,7 @@ class CardsList extends React.Component {
 
   getPossiblePages() {
     return this.getPossiblePositions().map((el, index) =>
-      Math.floor((el + this.getScrollWidth(this.cards[index])) / this.wrapperWidth() + 1)
+      Math.ceil((el + this.getScrollWidth(this.cards[index])) / this.wrapperWidth())
     );
   }
 
@@ -177,7 +178,7 @@ class CardsList extends React.Component {
   }
 
   handleOnLeft() {
-    const actualPage = this.state.actualPage;
+    const {actualPage} = this.state;
     if (actualPage === 1) {
       return;
     }
@@ -185,7 +186,7 @@ class CardsList extends React.Component {
   }
 
   handleOnRight() {
-    const actualPage = this.state.actualPage;
+    const {actualPage} = this.state;
     if (actualPage === this.maxPages()) {
       return;
     }
@@ -203,8 +204,9 @@ class CardsList extends React.Component {
     const isResize = typeof event_ === 'object' && event_.type === 'resize';
     if (isResize) this.forceUpdate();
 
+    const {actualPage} = this.state;
     const nextState = {
-      actualPage: typeof event_ === 'number' ? event_ : this.state.actualPage || 1
+      actualPage: typeof event_ === 'number' ? event_ : actualPage || 1
     };
     if (!isEqual(this.state, nextState)) this.setState(nextState);
   }
@@ -216,6 +218,7 @@ class CardsList extends React.Component {
   render() {
     const {title, showMore, cards, onShowMore, dataName, contentType} = this.props;
     const {skin} = this.context;
+    const {actualPage} = this.state;
 
     const dark = getOr('#90A4AE', 'common.dark', skin);
     const titleStyle = onShowMore ? style.titleLink : style.title;
@@ -227,14 +230,13 @@ class CardsList extends React.Component {
       );
     }, cards);
 
-    const leftCircleStyle = this.state.actualPage === 1 ? style.disabledCircle : style.circle;
+    const leftCircleStyle = actualPage === 1 ? style.disabledCircle : style.circle;
     const leftArrowView = (
       <div className={leftCircleStyle} onClick={this.handleOnLeft}>
         <ArrowLeft color={dark} className={style.left} width={10} height={10} />
       </div>
     );
-    const rightCircleStyle =
-      this.state.actualPage === this.maxPages() ? style.disabledCircle : style.circle;
+    const rightCircleStyle = actualPage === this.maxPages() ? style.disabledCircle : style.circle;
     const rightArrowView = (
       <div className={rightCircleStyle} onClick={this.handleOnRight}>
         <ArrowRight color={dark} className={style.right} width={10} height={10} />
@@ -248,11 +250,18 @@ class CardsList extends React.Component {
       </span>
     );
 
+    const hasPages = this.maxPages() > 1;
     const showMoreView =
-      showMore && onShowMore ? <ShowMoreLink onShowMore={onShowMore} showMore={showMore} /> : null;
+      showMore && onShowMore ? (
+        <ShowMoreLink
+          className={hasPages ? style.showMoreBar : style.showMore}
+          onShowMore={onShowMore}
+          showMore={showMore}
+        />
+      ) : null;
 
     const maxPages = this.maxPages();
-    const restPages = this.state.actualPage || 0;
+    const restPages = actualPage || 0;
     const paging = `${restPages}/${maxPages}`;
 
     const pagingView = (
@@ -260,18 +269,23 @@ class CardsList extends React.Component {
         <span className={style.paging}>{paging}</span>
       </span>
     );
+    const switchPagesView = hasPages ? (
+      <div className={style.pagingWrapper}>
+        {showMoreView}
+        {pagingView}
+        {leftArrowView}
+        {rightArrowView}
+      </div>
+    ) : (
+      <div className={style.pagingWrapper}>{showMoreView}</div>
+    );
     return (
       <div className={style.wrapper} data-name="cardsList">
         <div className={style.list}>
           <div className={style.listWrapper}>
             <div data-name="header" className={style.header}>
               {titleView}
-              <div className={style.pagingWrapper}>
-                {showMoreView}
-                {pagingView}
-                {leftArrowView}
-                {rightArrowView}
-              </div>
+              {switchPagesView}
             </div>
             <div className={style.cards} ref={this.setCardsWrapper}>
               {cardsView}

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/style.css
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/style.css
@@ -4,6 +4,10 @@
 @value tablet from breakpoints;
 @value desktop from breakpoints;
 @value dark from colors;
+@value black from colors;
+@value lightMediumGray from colors;
+@value medium from colors;
+@value light from colors;
 
 .wrapper {
   padding: 16px 30px 8px;
@@ -33,7 +37,6 @@
 }
 
 .listWrapper {
-  overflow: hidden;
 }
 
 .title {
@@ -60,28 +63,38 @@
   font-family: 'Open Sans';
   font-size: 14px;
   line-height: 20px;
-  font-weight: 600;
+  font-weight: bold;
   cursor: pointer;
   display: flex;
   align-items: center;
   color: dark;
+  padding-right: 16px;
+  margin-right: 16px;
+  border-right: 1px solid color(dark a(70%));
+}
+
+.paging {
+  font-family: 'Open Sans';
+  font-size: 14px;
+  font-weight: normal;
+  letter-spacing: 4px;
+  color: dark;
+  margin-right: 10px;
+  line-height: 28px;
 }
 
 .showMore:hover {
   text-decoration: underline;
-}
-
-.showMoreIcon {
-  margin-left: 8px;
-  width: 8px;
-  height: 8px;
+  color: black;
 }
 
 .cards {
   display: flex;
   overflow: hidden;
   margin-left: -8px;
-  margin-right: -8px;
+  margin-right: 0px;
+  overflow: hidden;
+  scroll-behavior: smooth;
 }
 
 .card {
@@ -91,16 +104,39 @@
 }
 
 .arrow {
-  position: absolute;
-  width: 28px;
-  height: 28px;
-  margin-top: -8px;
-  top: 50%;
+  position: flex;
+  padding: 9px;
   cursor: pointer;
-  opacity: 0.5;
+  opacity: 1;
   user-select: none;
 }
 
+.circle:hover {
+  box-shadow: 0 0 10px 0  color(medium a(70%));
+}
+
+.circle {
+  box-shadow: 0 0px 4px 0 color(lightMediumGray a(70%));
+  border: solid 1px light;
+  border-radius: 50%;
+  cursor: pointer;
+  line-height: 0;
+  margin-left: 5px;
+}
+.pagingWrapper {
+  display: inline-flex;
+}
+.disabledCircle {
+  box-shadow: 0 0px 4px 0 color(lightMediumGray a(70%));
+  border: solid 1px light;
+  border-radius: 50%;
+  cursor: default;
+  pointer-events: none;
+  opacity: 0.5;
+  background: #CCC;
+  line-height: 0;
+  margin-left: 5px;
+}
 .arrow:hover {
   opacity: 1;
 }
@@ -117,16 +153,6 @@
   text-align: left;
 }
 
-@media desktop {
-  .left {
-    left: -25px;
-  }
-
-  .right {
-    right: -25px;
-  }
-}
-
 @media tablet {
   .cards {
     overflow-x: scroll;
@@ -134,7 +160,7 @@
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 
-  .arrow {
+  .pagingWrapper {
     display: none;
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/style.css
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/style.css
@@ -70,6 +70,9 @@
   color: dark;
   padding-right: 16px;
   margin-right: 16px;
+}
+.showMoreBar {
+  composes: showMore;
   border-right: 1px solid color(dark a(70%));
 }
 

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/fixtures/microlearning.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/fixtures/microlearning.js
@@ -1,3 +1,4 @@
+import {times} from 'lodash/fp';
 import Card from '../../../../card/test/fixtures/default';
 
 const {props} = Card;
@@ -7,11 +8,7 @@ export default {
   props: {
     title: 'Microlearning: Most popular',
     showMore: 'See all',
-    cards: [props, props, props, props, props, props, props, props, props, props, props, props].map(
-      (p, index) => {
-        return {...p, title: `${p.title}#${index}`};
-      }
-    ),
+    cards: times(() => props, 12).map((p, index) => ({...p, title: `${p.title}#${index}`})),
     onScroll: (skip, limit) => {
       console.log(skip, limit);
     },

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/fixtures/microlearning.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/fixtures/microlearning.js
@@ -7,7 +7,11 @@ export default {
   props: {
     title: 'Microlearning: Most popular',
     showMore: 'See all',
-    cards: [props, props, props, props, props, props, props, props, props, props],
+    cards: [props, props, props, props, props, props, props, props, props, props, props, props].map(
+      (p, index) => {
+        return {...p, title: `${p.title}#${index}`};
+      }
+    ),
     onScroll: (skip, limit) => {
       console.log(skip, limit);
     },

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
@@ -114,7 +114,7 @@ test('should return scrollWidth and call onScroll if exist', t => {
 test('should update componenet when resizing', t => {
   const {props} = Card;
   const props_ = {
-    cards: [props, props, props, props, props, props, props, props, props, props, props]
+    cards: [props, props, props]
   };
 
   const cardsList = mountCardsList(props_);
@@ -126,8 +126,12 @@ test('should update componenet when resizing', t => {
     state.isUpdated = true;
   };
   instance.forceUpdate = forceUpdate;
+  t.is(instance.maxPages(), 1);
+
+  instance.wrapperWidth = () => 600;
   instance.updatePages({type: 'resize'});
   t.is(state.isUpdated, true);
+  t.is(instance.maxPages(), 2);
 
   cardsList.unmount();
 });

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
@@ -100,13 +100,34 @@ test('should return scrollWidth and call onScroll if exist', t => {
 
   instance_.getScrollWidth = () => 272;
   instance_.handleScroll({});
-  t.is(scrollData.skip, 11);
-  t.is(scrollData.limit, 11);
+  t.is(scrollData.skip, 1);
+  t.is(scrollData.limit, 4);
 
   instance_.leftBound = () => 1088;
   instance_.handleScroll({});
-  t.is(scrollData.skip, 11);
-  t.is(scrollData.limit, 0);
+  t.is(scrollData.skip, 5);
+  t.is(scrollData.limit, 4);
+
+  cardsList.unmount();
+});
+
+test('should update componenet when resizing', t => {
+  const {props} = Card;
+  const props_ = {
+    cards: [props, props, props, props, props, props, props, props, props, props, props]
+  };
+
+  const cardsList = mountCardsList(props_);
+  const instance = cardsList.instance();
+  instance.getScrollWidth = () => 272;
+  instance.wrapperWidth = () => 1088;
+  const state = {isUpdated: false};
+  const forceUpdate = () => {
+    state.isUpdated = true;
+  };
+  instance.forceUpdate = forceUpdate;
+  instance.updatePages({type: 'resize'});
+  t.is(state.isUpdated, true);
 
   cardsList.unmount();
 });

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
@@ -3,6 +3,7 @@ import test from 'ava';
 import React from 'react';
 import {mount, configure} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import {times} from 'lodash/fp';
 import {wrappingComponent} from '../../../../test/helpers/render-component';
 import Card from '../../../card/test/fixtures/default';
 import CardsList from '..';
@@ -27,7 +28,7 @@ test('should call cardsWidth', t => {
 test('should move cards by pages', t => {
   const {props} = Card;
   const props_ = {
-    cards: [props, props, props, props, props, props, props, props, props, props, props]
+    cards: times(() => props, 11)
   };
 
   const cardsList = mountCardsList(props_);
@@ -78,7 +79,7 @@ test('should move cards by pages', t => {
 test('should return scrollWidth and call onScroll if exist', t => {
   const {props} = Card;
   const props_ = {
-    cards: [props, props, props, props, props, props, props, props, props, props, props]
+    cards: times(() => props, 11)
   };
 
   const cardsList = mountCardsList(props_);
@@ -114,7 +115,7 @@ test('should return scrollWidth and call onScroll if exist', t => {
 test('should update componenet when resizing', t => {
   const {props} = Card;
   const props_ = {
-    cards: [props, props, props]
+    cards: times(() => props, 3)
   };
 
   const cardsList = mountCardsList(props_);

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
@@ -100,12 +100,12 @@ test('should return scrollWidth and call onScroll if exist', t => {
 
   instance_.getScrollWidth = () => 272;
   instance_.handleScroll({});
-  t.is(scrollData.skip, 1);
+  t.is(scrollData.skip, 0);
   t.is(scrollData.limit, 4);
 
   instance_.leftBound = () => 1088;
   instance_.handleScroll({});
-  t.is(scrollData.skip, 5);
+  t.is(scrollData.skip, 4);
   t.is(scrollData.limit, 4);
 
   cardsList.unmount();
@@ -122,10 +122,10 @@ test('should update componenet when resizing', t => {
   instance.getScrollWidth = () => 272;
   instance.wrapperWidth = () => 1088;
   const state = {isUpdated: false};
-  const forceUpdate = () => {
+  const setState = () => {
     state.isUpdated = true;
   };
-  instance.forceUpdate = forceUpdate;
+  instance.setState = setState;
   t.is(instance.maxPages(), 1);
 
   instance.wrapperWidth = () => 600;

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
@@ -1,7 +1,6 @@
 import browserEnv from 'browser-env';
 import test from 'ava';
 import React from 'react';
-import {unset} from 'lodash/fp';
 import {mount, configure} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import {wrappingComponent} from '../../../../test/helpers/render-component';
@@ -18,10 +17,96 @@ const mountCardsList = props => {
 };
 
 test('should call cardsWidth', t => {
-  const card = unset('favorite', Card.props);
-  const props = {cards: [card, card, card]};
-  const cardsList = mountCardsList(props);
-  const width = cardsList.instance().cardsWidth();
+  const {props} = Card;
+  const props_ = {cards: [props, props, props]};
+  const cardsList = mountCardsList(props_);
+  const width = cardsList.instance().wrapperWidth();
   t.is(width, 0);
+});
+
+test('should move cards by pages', t => {
+  const {props} = Card;
+  const props_ = {
+    cards: [props, props, props, props, props, props, props, props, props, props, props]
+  };
+
+  const cardsList = mountCardsList(props_);
+  const instance = cardsList.instance();
+  instance.getScrollWidth = () => 272;
+  instance.wrapperWidth = () => 1088;
+  instance.updatePages();
+
+  t.is(instance.maxPages(), 3);
+  t.is(instance.state.actualPage, 1);
+
+  instance.handleOnLeft();
+  t.is(instance.maxPages(), 3);
+  t.is(instance.state.actualPage, 1);
+  instance.updatePages();
+
+  instance.handleOnRight();
+  t.is(instance.maxPages(), 3);
+  t.is(instance.state.actualPage, 2);
+
+  instance.handleOnLeft();
+  t.is(instance.maxPages(), 3);
+  t.is(instance.state.actualPage, 1);
+
+  instance.handleOnRight();
+  t.is(instance.maxPages(), 3);
+  t.is(instance.state.actualPage, 2);
+
+  instance.handleOnRight();
+  t.is(instance.maxPages(), 3);
+  t.is(instance.state.actualPage, 3);
+
+  instance.handleOnRight();
+  t.is(instance.maxPages(), 3);
+  t.is(instance.state.actualPage, 3);
+
+  instance.handleOnLeft();
+  t.is(instance.maxPages(), 3);
+  t.is(instance.state.actualPage, 2);
+
+  instance.handleOnLeft();
+  t.is(instance.maxPages(), 3);
+  t.is(instance.state.actualPage, 1);
+
+  cardsList.unmount();
+});
+
+test('should return scrollWidth and call onScroll if exist', t => {
+  const {props} = Card;
+  const props_ = {
+    cards: [props, props, props, props, props, props, props, props, props, props, props]
+  };
+
+  const cardsList = mountCardsList(props_);
+  const instance = cardsList.instance();
+  instance.handleScroll({});
+
+  const scrollData = {skip: 0, limit: 0};
+  const onScroll = (skip, limit) => {
+    scrollData.skip = skip;
+    scrollData.limit = limit;
+  };
+
+  const cardsList_ = mountCardsList({...props_, onScroll});
+  const instance_ = cardsList_.instance();
+  instance_.wrapperWidth = () => 1088;
+  instance_.updatePages();
+
+  t.is(instance_.getScrollWidth({scrollWidth: 272}), 272);
+
+  instance_.getScrollWidth = () => 272;
+  instance_.handleScroll({});
+  t.is(scrollData.skip, 11);
+  t.is(scrollData.limit, 11);
+
+  instance_.leftBound = () => 1088;
+  instance_.handleScroll({});
+  t.is(scrollData.skip, 11);
+  t.is(scrollData.limit, 0);
+
   cardsList.unmount();
 });


### PR DESCRIPTION
This pr
- Adds paging to the cards list , the cards will be move by page ( number of visible cards )
- Changes the showMore view and arrows Design 
<!--What existing problem does the PR solve?/
What is the current behavior? -->
Before

![Beforee](https://user-images.githubusercontent.com/58167920/86936770-be1e2080-c13e-11ea-8712-78346684e3f1.gif)
After
![After](https://user-images.githubusercontent.com/58167920/86936468-58ca2f80-c13e-11ea-92b1-88e8d4b560cf.gif)

Without **paging** & without **show more**
<img width="996" alt="Capture d’écran 2020-07-16 à 10 47 39" src="https://user-images.githubusercontent.com/58167920/87650365-d64efa80-c751-11ea-8944-9130b72a3d14.png">

I've changed the show more **hide/show** logic , now we handle it in componenet side 
we hide it when there is only one page and we show it when there is more than one page
**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [x] **Breaking changes ?**  
       If checked, what have you broken ?

- [x] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
