### PR TITLE
Use parseInt from lodash instead of Number (not supported by IE)

### DIFF
--- a/packages/@coorpacademy-player-web/src/map-state-to-props/answer.js
+++ b/packages/@coorpacademy-player-web/src/map-state-to-props/answer.js
@@ -1,6 +1,7 @@
 import {
   pipe,
   includes,
+  parseInt,
   head,
   map,
   get,
@@ -197,7 +198,7 @@ const sliderProps = (options, store) => {
     );
 
     const stateValue = pipe(getAnswerValues, head)(slide, state);
-    const currentValue = Number.parseInt(stateValue);
+    const currentValue = parseInt(10, stateValue);
 
     const indexValue = indexOf(currentValue, values);
     const handleChange = editAnswerAction_(state, slide);

--- a/packages/@coorpacademy-player-web/src/map-state-to-props/answer.js
+++ b/packages/@coorpacademy-player-web/src/map-state-to-props/answer.js
@@ -1,7 +1,7 @@
 import {
   pipe,
   includes,
-  parseInt,
+  toInteger,
   head,
   map,
   get,
@@ -198,7 +198,7 @@ const sliderProps = (options, store) => {
     );
 
     const stateValue = pipe(getAnswerValues, head)(slide, state);
-    const currentValue = parseInt(10, stateValue);
+    const currentValue = toInteger(stateValue);
 
     const indexValue = indexOf(currentValue, values);
     const handleChange = editAnswerAction_(state, slide);


### PR DESCRIPTION
**Detailed purpose of the PR**

Fixes [error](https://app.datadoghq.eu/logs?cols=core_host%2Ccore_service&event&from_ts=1595408760000&index=&live=false&messageDisplay=inline&query=service%3Amooc+%40platform%3Aproduction+status%3Aerror++%22%27parseInt%27%22+%40syslog.appname%3Abrowser&stream_sort=desc&to_ts=1595494800000&type=logs)

```
TypeError: Object doesn't support property or method 'parseInt'
   at Anonymous function (https://faurecia.coorpacademy.com/js/app-player.min.84f35bce6df.js:1:129698)
   at Anonymous function (https://faurecia.coorpacademy.com/js/app-player.min.84f35bce6df.js:1:130225)
   at Anonymous function (https://faurecia.coorpacademy.com/js/app-player.min.84f35bce6df.js:1:130674)
   at Anonymous function (https://faurecia.coorpacademy.com/js/app-player.min.84f35bce6df.js:1:132498)
   at Anonymous function (https://faurecia.coorpacademy.com/js/core.min.b01af7de1fd.js:1:1010676)
   at Anonymous function (https://faurecia.coorpacademy.com/js/app-player.min.84f35bce6df.js:1:31070)
   at Anonymous function (https://faurecia.coorpacademy.com/js/core.min.b01af7de1fd.js:1:1166137)
   at e.exports (https://faurecia.coorpacademy.com/js/core.min.b01af7de1fd.js:1:962012)
   at e.exports (https://faurecia.coorpacademy.com/js/app-player.min.84f35bce6df.js:1:31034)
   at e (https://faurecia.coorpacademy.com/js/core.min.b01af7de1fd.js:1:972800)
```
on IE, where this method is not supported
