### PR TITLE
[componenets] Replace native findIndex with  lodash findIndex

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
@@ -192,7 +192,7 @@ class CardsList extends React.Component {
       head
     )(cardWidths);
 
-    const skip = possiblePositions.findIndex(position => position >= wrapperScrollLeft);
+    const skip = findIndex(position => position >= wrapperScrollLeft, possiblePositions);
     const actualPage = possiblePages[skip + 1];
 
     this.setState({


### PR DESCRIPTION
Replace native findIndex with  lodash findIndex
PS : findIndex is not supported in IE
- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
