### PR TITLE
center background image for external content

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/card/style.css
@@ -261,6 +261,7 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  background-position: 50%;
 }
 
 .course .externalContentHeader::after {

--- a/packages/@coorpacademy-components/src/molecule/card/test/fixtures/external-content.js
+++ b/packages/@coorpacademy-components/src/molecule/card/test/fixtures/external-content.js
@@ -12,6 +12,6 @@ export default {
       name: 'Decathlon creation'
     },
     image:
-      'https://api.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/CoorpAcademy/content-marmiton/cockpit-marmiton/cover/shutterstock_520965634-1491986518210.jpg&h=500&w=500&q=90'
+      'https://api.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/CoorpAcademy/content-marmiton/cockpit-marmiton/cover/shutterstock_520965634-1491986518210.jpg&h=260&w=260&q=90'
   })
 };

--- a/packages/@coorpacademy-components/src/molecule/card/test/fixtures/podcast.js
+++ b/packages/@coorpacademy-components/src/molecule/card/test/fixtures/podcast.js
@@ -7,7 +7,8 @@ export default {
   props: defaultsDeep(props, {
     disabled: false,
     type: 'podcast',
-    image: null,
+    image:
+      'https://api.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/partner-wedemain/fr/medias/img/cover/shutterstock_248741149-1470302136299.jpg&h=280&w=280&q=80&m=crop',
     progress: 0.1
   })
 };

--- a/packages/@coorpacademy-components/src/organism/cards-grid/test/fixtures/catalog.js
+++ b/packages/@coorpacademy-components/src/organism/cards-grid/test/fixtures/catalog.js
@@ -8,7 +8,7 @@ import card6 from '../../../../molecule/card/test/fixtures/freerun-and-disabled'
 import card7 from '../../../../molecule/card/test/fixtures/adaptiv-and-disabled';
 import card8 from '../../../../molecule/card/test/fixtures/favorite';
 import card9 from '../../../../molecule/card/test/fixtures/empty';
-import card10 from '../../../../molecule/card/test/fixtures/scorm';
+import card10 from '../../../../molecule/card/test/fixtures/external-content';
 import card11 from '../../../../molecule/card/test/fixtures/article';
 import card12 from '../../../../molecule/card/test/fixtures/video';
 import card13 from '../../../../molecule/card/test/fixtures/podcast';


### PR DESCRIPTION
Background image is currently shown from its top on the background of the external card.
This PR sets the background position to the middle

Before
<img width="265" alt="Capture d’écran 2020-08-13 à 15 20 32" src="https://user-images.githubusercontent.com/7602475/90139413-a1e25480-dd78-11ea-991a-628ccec4a3e2.png">


**Result and observation**
<img width="238" alt="Capture d’écran 2020-08-13 à 15 21 05" src="https://user-images.githubusercontent.com/7602475/90139436-aa3a8f80-dd78-11ea-9a40-ee7ce2adc12a.png">

**Testing Strategy**

- Manual testing
- Unit testing
