### PR TITLE
fix: gradient should be only for c-external cards with background images

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/card/index.js
@@ -51,7 +51,7 @@ const CardBackground = ({type, image, empty}, {skin}) => {
               backgroundColor: iconColor,
               backgroundImage: `url('${image}')`
             }}
-            className={style.externalContentHeader}
+            className={classnames(style.externalContentHeader, style.externalBackground)}
           >
             {_backgroundIcon}
           </div>

--- a/packages/@coorpacademy-components/src/molecule/card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/card/style.css
@@ -261,10 +261,13 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
+}
+
+.course .externalBackground {
   background-position: 50%;
 }
 
-.course .externalContentHeader::after {
+.course .externalBackground::after {
   position: absolute;
   content: '';
   width: 100%;
@@ -279,7 +282,7 @@
   );
 }
 
-.course .externalContentHeader::before {
+.course .externalBackground::before {
   position: absolute;
   content: '';
   width: 100%;


### PR DESCRIPTION
**Detailed purpose of the PR**

A visual bug was introduce by a previous PR, gradient was also added to external cards without background image. This PR fixes this.

Before (problem with Podcast card)

<img width="1096" alt="Capture d’écran 2020-08-13 à 18 21 30" src="https://user-images.githubusercontent.com/7602475/90160272-dadaf300-dd91-11ea-83b2-6ac7966a8e93.png">

**Result and observation**

<img width="1086" alt="Capture d’écran 2020-08-13 à 18 25 00" src="https://user-images.githubusercontent.com/7602475/90160637-56d53b00-dd92-11ea-92b2-587344a667f6.png">

**Testing Strategy**

- Already covered by tests
- Manual testing
- Unit testing
