### PR TITLE
patch: adds data-name for CMS pages links in mooc footer

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-footer/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-footer/index.js
@@ -71,6 +71,7 @@ function MoocFooter(props) {
                 data-text={page.title}
                 className={style.pageLink}
                 target={page.target}
+                data-name={page.title}
               >
                 {page.title}
               </Link>


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
adds data-name for CMS pages links in mooc footer

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Testing Strategy**

- [x] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
