### PR TITLE
ie footer css support

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-footer/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-footer/style.css
@@ -114,6 +114,7 @@
   font-size: 14px;
   max-width: 200px;
   cursor: pointer;
+  padding-bottom: 6.5px;
 }
 
 .pageLink:hover {
@@ -316,7 +317,7 @@
 
   .sectionWrapper {
     padding-right: 0px;
-    padding-bottom: 0px;
+    padding-bottom: 10px;
     min-width: 100%;
     flex-grow: 1;
     align-content: flex-start;
@@ -348,9 +349,19 @@
   .pagesList {
     margin-top: 8px;
     margin-bottom: 4px;
-    border-bottom: solid 2em transparent;
-    box-shadow: 0 1px 0 -1px lightBlack;
     background: black padding-box;
+    position: relative;
+  }
+
+  .pagesList::after {
+    content: "";
+    width: 100%;
+    height: 1px;
+    position: absolute;
+    bottom: -15px;
+    left: 0px;
+    border-bottom: solid 2em transparent;
+    box-shadow: 0 1px 0 lightBlack;
   }
 }
 


### PR DESCRIPTION
**Detailed purpose of the PR**

 - fix footer css to support ie11 (sitemap section divisor horizontal gray line)
 - adds more spacing between page links

![image](https://user-images.githubusercontent.com/33550261/92001302-cfe70300-ed3e-11ea-8df1-f430ce77d1e2.png)


**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [x] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
