### PR TITLE
allow to hide complete button

### DIFF
--- a/packages/@coorpacademy-components/src/template/external-course/index.js
+++ b/packages/@coorpacademy-components/src/template/external-course/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {NovaSolidInterfaceFeedbackInterfaceQuestionMark as QuestionIcon} from '@coorpacademy/nova-icons';
 import {convert} from 'css-color-function';
 import classnames from 'classnames';
-import {get, getOr, keys, identity} from 'lodash/fp';
+import {get, getOr, keys, identity, isNil} from 'lodash/fp';
 import PropTypes from 'prop-types';
 import {EXTERNAL_CONTENT_ICONS} from '../../util/external-content';
 import Provider from '../../atom/provider';
@@ -57,6 +57,25 @@ class ExternalCourse extends React.Component {
       <iframe src={url} frameBorder={0} className={style.iframe} allowFullScreen />
     );
 
+    const completeButton = !isNil(complete) ? (
+      <Button
+        type="button"
+        disabled={loading ? true : complete.disabled}
+        onClick={loading ? identity : this.handleOnClick(complete)}
+        submitValue={complete.label}
+        style={{
+          backgroundColor:
+            complete.disabled || loading ? convert(`color(${primary} a(-50%))`) : primary,
+          cursor: loading ? 'progress' : 'pointer'
+        }}
+        className={classnames(
+          style.completeCta,
+          complete.disabled || loading ? style.disabled : null,
+          loading ? style.loading : null
+        )}
+      />
+    ) : null;
+
     return (
       <div className={style.default}>
         <div className={style.header}>
@@ -87,22 +106,7 @@ class ExternalCourse extends React.Component {
               <span>{warning.label}</span>
             </div>
           </div>
-          <Button
-            type="button"
-            disabled={loading ? true : complete.disabled}
-            onClick={loading ? identity : this.handleOnClick(complete)}
-            submitValue={complete.label}
-            style={{
-              backgroundColor:
-                complete.disabled || loading ? convert(`color(${primary} a(-50%))`) : primary,
-              cursor: loading ? 'progress' : 'pointer'
-            }}
-            className={classnames(
-              style.completeCta,
-              complete.disabled || loading ? style.disabled : null,
-              loading ? style.loading : null
-            )}
-          />
+          {completeButton}
           <div className={style.rightSection} />
         </div>
       </div>

--- a/packages/@coorpacademy-components/src/template/external-course/test/fixtures/h5p.js
+++ b/packages/@coorpacademy-components/src/template/external-course/test/fixtures/h5p.js
@@ -1,0 +1,16 @@
+export default {
+  props: {
+    name: 'Video H5P',
+    type: 'video',
+    url: 'https://coorpacademy.h5p.com/content/1291025352652664897/embed',
+    quit: {
+      label: 'close',
+      onClick: () => console.log('close')
+    },
+    warning: {
+      label: 'Report an error',
+      onClick: () => console.log('Report an error')
+    },
+    loading: false
+  }
+};

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -823,6 +823,7 @@ import TemplateCommonSearchPageFixtureNoResultWithRecommendations from '../src/t
 import TemplateCommonSearchPageFixtureNoResult from '../src/template/common/search-page/test/fixtures/no-result';
 import TemplateExternalCourseFixtureArticle from '../src/template/external-course/test/fixtures/article';
 import TemplateExternalCourseFixtureDefault from '../src/template/external-course/test/fixtures/default';
+import TemplateExternalCourseFixtureH5P from '../src/template/external-course/test/fixtures/h5p';
 import TemplateExternalCourseFixtureLoading from '../src/template/external-course/test/fixtures/loading';
 import TemplateExternalCourseFixturePodcast from '../src/template/external-course/test/fixtures/podcast';
 import TemplateExternalCourseFixtureVideo from '../src/template/external-course/test/fixtures/video';
@@ -1816,6 +1817,7 @@ export const fixtures = {
     TemplateExternalCourse: {
       Article: TemplateExternalCourseFixtureArticle,
       Default: TemplateExternalCourseFixtureDefault,
+      H5P: TemplateExternalCourseFixtureH5P,
       Loading: TemplateExternalCourseFixtureLoading,
       Podcast: TemplateExternalCourseFixturePodcast,
       Video: TemplateExternalCourseFixtureVideo


### PR DESCRIPTION
**Detailed purpose of the PR**

For some external courses (such as videos with H5P content), complete button should not be display. This PR hiddens the button when complete property is nil.

**Result and observation**


<img width="1143" alt="Screenshot 2020-09-04 at 14 07 13" src="https://user-images.githubusercontent.com/7602475/92237652-01cfa500-eeb8-11ea-85f9-5b3b6c0b8a12.png">

**Testing Strategy**

- Manual testing
- Unit testing
