### PR TITLE
external content podcasts background option

### DIFF
--- a/packages/@coorpacademy-components/src/template/external-course/index.js
+++ b/packages/@coorpacademy-components/src/template/external-course/index.js
@@ -28,7 +28,8 @@ class ExternalCourse extends React.Component {
       label: PropTypes.string.isRequired,
       onClick: PropTypes.func
     }),
-    loading: PropTypes.bool
+    loading: PropTypes.bool,
+    backgroundImageUrl: PropTypes.string
   };
 
   static contextTypes = {
@@ -43,18 +44,43 @@ class ExternalCourse extends React.Component {
   };
 
   render() {
-    const {name, type, url, warning, complete, quit, loading} = this.props;
+    const {name, type, url, warning, complete, quit, loading, backgroundImageUrl = ''} = this.props;
     const {skin} = this.context;
     const primary = getOr('#00B0FF', 'common.primary', skin);
     const IconType = EXTERNAL_CONTENT_ICONS[type].icon;
     const IconColor = EXTERNAL_CONTENT_ICONS[type].color;
 
-    const mainContent = loading ? (
+    const content =
+      type === 'podcast' ? (
+        <div
+          className={style.podcastWrapper}
+          style={{backgroundImage: `url(${backgroundImageUrl})`}}
+        >
+          <audio
+            className={style.podcast}
+            controls
+            autoPlay=""
+            name="media"
+            data-name="external-content-podcast"
+          >
+            <source src={url} type="audio/mp3" />
+          </audio>
+        </div>
+      ) : (
+        <iframe
+          src={url}
+          frameBorder={0}
+          className={style.iframe}
+          allowFullScreen
+          data-name="external-content-iframe"
+        />
+      );
+    const mainContentSlot = loading ? (
       <div className={style.loader}>
         <Loader />
       </div>
     ) : (
-      <iframe src={url} frameBorder={0} className={style.iframe} allowFullScreen />
+      content
     );
 
     const completeButton = !isNil(complete) ? (
@@ -95,7 +121,7 @@ class ExternalCourse extends React.Component {
           </div>
           <div className={style.rightSection} />
         </div>
-        {mainContent}
+        {mainContentSlot}
         <div className={style.footer}>
           <div className={style.leftSection}>
             <div

--- a/packages/@coorpacademy-components/src/template/external-course/index.js
+++ b/packages/@coorpacademy-components/src/template/external-course/index.js
@@ -29,7 +29,8 @@ class ExternalCourse extends React.Component {
       onClick: PropTypes.func
     }),
     loading: PropTypes.bool,
-    backgroundImageUrl: PropTypes.string
+    backgroundImageUrl: PropTypes.string,
+    contentType: PropTypes.string
   };
 
   static contextTypes = {
@@ -44,37 +45,45 @@ class ExternalCourse extends React.Component {
   };
 
   render() {
-    const {name, type, url, warning, complete, quit, loading, backgroundImageUrl = ''} = this.props;
+    const {
+      name,
+      type,
+      url,
+      warning,
+      complete,
+      quit,
+      loading,
+      backgroundImageUrl = '',
+      contentType = ''
+    } = this.props;
     const {skin} = this.context;
     const primary = getOr('#00B0FF', 'common.primary', skin);
     const IconType = EXTERNAL_CONTENT_ICONS[type].icon;
     const IconColor = EXTERNAL_CONTENT_ICONS[type].color;
 
-    const content =
-      type === 'podcast' ? (
-        <div
-          className={style.podcastWrapper}
-          style={{backgroundImage: `url(${backgroundImageUrl})`}}
+    const content = contentType.startsWith('audio') ? (
+      <div className={style.podcastWrapper}>
+        <div className={style.bgPodcast} style={{backgroundImage: `url(${backgroundImageUrl})`}} />
+        <audio
+          className={style.podcast}
+          controls
+          autoPlay=""
+          name="media"
+          data-name="external-content-podcast"
+          preload="auto"
         >
-          <audio
-            className={style.podcast}
-            controls
-            autoPlay=""
-            name="media"
-            data-name="external-content-podcast"
-          >
-            <source src={url} type="audio/mp3" />
-          </audio>
-        </div>
-      ) : (
-        <iframe
-          src={url}
-          frameBorder={0}
-          className={style.iframe}
-          allowFullScreen
-          data-name="external-content-iframe"
-        />
-      );
+          <source src={url} type="audio/mp3" />
+        </audio>
+      </div>
+    ) : (
+      <iframe
+        src={url}
+        frameBorder={0}
+        className={style.iframe}
+        allowFullScreen
+        data-name="external-content-iframe"
+      />
+    );
     const mainContentSlot = loading ? (
       <div className={style.loader}>
         <Loader />

--- a/packages/@coorpacademy-components/src/template/external-course/index.js
+++ b/packages/@coorpacademy-components/src/template/external-course/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {NovaSolidInterfaceFeedbackInterfaceQuestionMark as QuestionIcon} from '@coorpacademy/nova-icons';
 import {convert} from 'css-color-function';
 import classnames from 'classnames';
-import {get, getOr, keys, identity, isNil} from 'lodash/fp';
+import {get, getOr, keys, identity, isNil, startsWith} from 'lodash/fp';
 import PropTypes from 'prop-types';
 import {EXTERNAL_CONTENT_ICONS} from '../../util/external-content';
 import Provider from '../../atom/provider';
@@ -53,17 +53,20 @@ class ExternalCourse extends React.Component {
       complete,
       quit,
       loading,
-      backgroundImageUrl = '',
-      contentType = ''
+      backgroundImageUrl,
+      contentType
     } = this.props;
     const {skin} = this.context;
     const primary = getOr('#00B0FF', 'common.primary', skin);
     const IconType = EXTERNAL_CONTENT_ICONS[type].icon;
     const IconColor = EXTERNAL_CONTENT_ICONS[type].color;
 
-    const content = contentType.startsWith('audio') ? (
+    const content = startsWith('audio', contentType) ? (
       <div className={style.podcastWrapper}>
-        <div className={style.bgPodcast} style={{backgroundImage: `url(${backgroundImageUrl})`}} />
+        <div
+          className={style.bgPodcast}
+          style={{backgroundImage: backgroundImageUrl && `url(${backgroundImageUrl})`}}
+        />
         <audio
           className={style.podcast}
           controls
@@ -72,7 +75,7 @@ class ExternalCourse extends React.Component {
           data-name="external-content-podcast"
           preload="auto"
         >
-          <source src={url} type="audio/mp3" />
+          <source src={url} type={contentType} />
         </audio>
       </div>
     ) : (

--- a/packages/@coorpacademy-components/src/template/external-course/style.css
+++ b/packages/@coorpacademy-components/src/template/external-course/style.css
@@ -145,12 +145,23 @@
 
 .podcastWrapper {
   composes: iframe;
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: cover;
   display: flex;
   align-content: center;
   justify-content: space-around;
+  position: relative;
+
+}
+.bgPodcast {
+  filter: blur(5px);
+  opacity: 0.5;
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0px;
+  left: 0px;
 }
 
 .podcast {

--- a/packages/@coorpacademy-components/src/template/external-course/style.css
+++ b/packages/@coorpacademy-components/src/template/external-course/style.css
@@ -123,7 +123,7 @@
   cursor: pointer;
 }
 
-.disabled{
+.disabled {
   pointer-events: none;
   cursor: initial;
 }
@@ -141,4 +141,18 @@
   .footer .leftSection, .footer .rightSection {
     display: none;
   }
+}
+
+.podcastWrapper {
+  composes: iframe;
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
+  display: flex;
+  align-content: center;
+  justify-content: space-around;
+}
+
+.podcast {
+  align-self: center;
 }

--- a/packages/@coorpacademy-components/src/template/external-course/test/fixtures/podcast-no-background.js
+++ b/packages/@coorpacademy-components/src/template/external-course/test/fixtures/podcast-no-background.js
@@ -15,6 +15,7 @@ export default {
     warning: {
       label: 'Report an error',
       onClick: () => console.log('Report an error')
-    }
+    },
+    contentType: 'audio/mp3'
   }
 };

--- a/packages/@coorpacademy-components/src/template/external-course/test/fixtures/podcast-no-background.js
+++ b/packages/@coorpacademy-components/src/template/external-course/test/fixtures/podcast-no-background.js
@@ -1,0 +1,20 @@
+export default {
+  props: {
+    name: 'Weekly wash up',
+    type: 'podcast',
+    url: 'https://static.coorpacademy.com/site/podcasts/Weekly%20wash%20up_20200608_FINAL.mp3',
+    quit: {
+      label: 'close',
+      onClick: () => console.log('close')
+    },
+    complete: {
+      disabled: true,
+      label: 'finish',
+      onClick: () => console.log('finish')
+    },
+    warning: {
+      label: 'Report an error',
+      onClick: () => console.log('Report an error')
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/template/external-course/test/fixtures/podcast.js
+++ b/packages/@coorpacademy-components/src/template/external-course/test/fixtures/podcast.js
@@ -6,6 +6,6 @@ const {props} = Default;
 export default {
   props: defaultsDeep(props, {
     backgroundImageUrl:
-      'https://i.pinimg.com/originals/31/bf/f7/31bff71dd4b79a76fb3f28a5219486f2.jpg'
+      'https://api-staging.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/page_discipline/1_recherche_en_ligne.jpg&amp;h=400&amp;w=400&amp;q=80&amp;m=contain'
   })
 };

--- a/packages/@coorpacademy-components/src/template/external-course/test/fixtures/podcast.js
+++ b/packages/@coorpacademy-components/src/template/external-course/test/fixtures/podcast.js
@@ -1,20 +1,11 @@
+import {defaultsDeep} from 'lodash/fp';
+import Default from './podcast-no-background';
+
+const {props} = Default;
+
 export default {
-  props: {
-    name: 'Weekly wash up',
-    type: 'podcast',
-    url: 'https://static.coorpacademy.com/site/podcasts/Weekly%20wash%20up_20200608_FINAL.mp3',
-    quit: {
-      label: 'close',
-      onClick: () => console.log('close')
-    },
-    complete: {
-      disabled: true,
-      label: 'finish',
-      onClick: () => console.log('finish')
-    },
-    warning: {
-      label: 'Report an error',
-      onClick: () => console.log('Report an error')
-    }
-  }
+  props: defaultsDeep(props, {
+    backgroundImageUrl:
+      'https://i.pinimg.com/originals/31/bf/f7/31bff71dd4b79a76fb3f28a5219486f2.jpg'
+  })
 };

--- a/packages/@coorpacademy-components/src/template/external-course/test/fixtures/youtube-podcast.js
+++ b/packages/@coorpacademy-components/src/template/external-course/test/fixtures/youtube-podcast.js
@@ -5,6 +5,7 @@ const {props} = Default;
 
 export default {
   props: defaultsDeep(props, {
+    url: 'https://www.youtube.com/embed/nLMZd05FQKc',
     contentType: 'video/mp4'
   })
 };

--- a/packages/@coorpacademy-components/src/template/external-course/test/fixtures/youtube-podcast.js
+++ b/packages/@coorpacademy-components/src/template/external-course/test/fixtures/youtube-podcast.js
@@ -1,0 +1,10 @@
+import {defaultsDeep} from 'lodash/fp';
+import Default from './podcast-no-background';
+
+const {props} = Default;
+
+export default {
+  props: defaultsDeep(props, {
+    contentType: 'video/mp4'
+  })
+};

--- a/packages/@coorpacademy-components/src/template/external-course/test/podcast.js
+++ b/packages/@coorpacademy-components/src/template/external-course/test/podcast.js
@@ -1,0 +1,19 @@
+import browserEnv from 'browser-env';
+import test from 'ava';
+import React from 'react';
+import {mount, configure} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import ExternalCourse from '..';
+import podcastFixture from './fixtures/podcast';
+
+browserEnv();
+configure({adapter: new Adapter()});
+
+test('when the media is a podcast, it shouldnt display an iframe but only a video tag', t => {
+  const wrapper = mount(<ExternalCourse {...podcastFixture.props} />);
+  const podcast = wrapper.find('[data-name="external-content-podcast"]');
+  const iframe = wrapper.find('[data-name="external-content-iframe"]');
+  t.assert(podcast.exists());
+  t.assert(!iframe.exists());
+  t.pass();
+});

--- a/packages/@coorpacademy-components/src/template/external-course/test/podcast.js
+++ b/packages/@coorpacademy-components/src/template/external-course/test/podcast.js
@@ -5,15 +5,25 @@ import {mount, configure} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import ExternalCourse from '..';
 import podcastFixture from './fixtures/podcast';
+import podcastYoutubeFixture from './fixtures/youtube-podcast';
 
 browserEnv();
 configure({adapter: new Adapter()});
 
-test('when the media is a podcast, it shouldnt display an iframe but only a video tag', t => {
+test('when the media is a mp3 podcast, it shouldnt display an iframe but only a the podcast tag', t => {
   const wrapper = mount(<ExternalCourse {...podcastFixture.props} />);
   const podcast = wrapper.find('[data-name="external-content-podcast"]');
   const iframe = wrapper.find('[data-name="external-content-iframe"]');
   t.assert(podcast.exists());
   t.assert(!iframe.exists());
+  t.pass();
+});
+
+test('when the media is a youtube podcast, it should display an iframe and no podcast tag', t => {
+  const wrapper = mount(<ExternalCourse {...podcastYoutubeFixture.props} />);
+  const podcast = wrapper.find('[data-name="external-content-podcast"]');
+  const iframe = wrapper.find('[data-name="external-content-iframe"]');
+  t.assert(!podcast.exists());
+  t.assert(iframe.exists());
   t.pass();
 });

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -828,6 +828,7 @@ import TemplateExternalCourseFixtureLoading from '../src/template/external-cours
 import TemplateExternalCourseFixturePodcastNoBackground from '../src/template/external-course/test/fixtures/podcast-no-background';
 import TemplateExternalCourseFixturePodcast from '../src/template/external-course/test/fixtures/podcast';
 import TemplateExternalCourseFixtureVideo from '../src/template/external-course/test/fixtures/video';
+import TemplateExternalCourseFixtureYoutubePodcast from '../src/template/external-course/test/fixtures/youtube-podcast';
 
 export const components = {
   Atom: {
@@ -1822,7 +1823,8 @@ export const fixtures = {
       Loading: TemplateExternalCourseFixtureLoading,
       PodcastNoBackground: TemplateExternalCourseFixturePodcastNoBackground,
       Podcast: TemplateExternalCourseFixturePodcast,
-      Video: TemplateExternalCourseFixtureVideo
+      Video: TemplateExternalCourseFixtureVideo,
+      YoutubePodcast: TemplateExternalCourseFixtureYoutubePodcast
     }
   },
   TemplateAppPlayer: {

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -825,6 +825,7 @@ import TemplateExternalCourseFixtureArticle from '../src/template/external-cours
 import TemplateExternalCourseFixtureDefault from '../src/template/external-course/test/fixtures/default';
 import TemplateExternalCourseFixtureH5P from '../src/template/external-course/test/fixtures/h5p';
 import TemplateExternalCourseFixtureLoading from '../src/template/external-course/test/fixtures/loading';
+import TemplateExternalCourseFixturePodcastNoBackground from '../src/template/external-course/test/fixtures/podcast-no-background';
 import TemplateExternalCourseFixturePodcast from '../src/template/external-course/test/fixtures/podcast';
 import TemplateExternalCourseFixtureVideo from '../src/template/external-course/test/fixtures/video';
 
@@ -1819,6 +1820,7 @@ export const fixtures = {
       Default: TemplateExternalCourseFixtureDefault,
       H5P: TemplateExternalCourseFixtureH5P,
       Loading: TemplateExternalCourseFixtureLoading,
+      PodcastNoBackground: TemplateExternalCourseFixturePodcastNoBackground,
       Podcast: TemplateExternalCourseFixturePodcast,
       Video: TemplateExternalCourseFixtureVideo
     }


### PR DESCRIPTION
**Detailed purpose of the PR**

modifies: the external-course template component for adding a background image option for mp3 podcasts, adds additional tests and fixtures, blur and filters are applied to the background image if provided

**Result and observation**

<img width="1440" alt="Screenshot 2020-09-11 at 11 47 50" src="https://user-images.githubusercontent.com/33550261/92906340-aefc6d00-f424-11ea-815c-67e462a0e2bf.png">



<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
