### PR TITLE
Styles: podcast background image

### DIFF
--- a/packages/@coorpacademy-components/src/template/external-course/style.css
+++ b/packages/@coorpacademy-components/src/template/external-course/style.css
@@ -151,9 +151,11 @@
   position: relative;
 
 }
+
 .bgPodcast {
-  filter: blur(5px);
-  opacity: 0.5;
+  filter: brightness(40%) blur(5px);
+  /* To take out the white outline caused why the blur */
+  transform: scale(1.04);
   background-repeat: no-repeat;
   background-position: center center;
   background-size: cover;

--- a/packages/@coorpacademy-components/src/template/external-course/test/fixtures/podcast.js
+++ b/packages/@coorpacademy-components/src/template/external-course/test/fixtures/podcast.js
@@ -5,7 +5,6 @@ const {props} = Default;
 
 export default {
   props: defaultsDeep(props, {
-    backgroundImageUrl:
-      'https://api-staging.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/page_discipline/1_recherche_en_ligne.jpg&amp;h=400&amp;w=400&amp;q=80&amp;m=contain'
+    backgroundImageUrl: 'https://static.coorpacademy.com/site/podcast.jpg'
   })
 };


### PR DESCRIPTION
**Detailed purpose of the PR**

Fixes styling for the background image (in external-course template) of the audio podcasts (external content that are an audio media type), applies a black filter instead of the white one, takes out the white outline caused by the blur filter.


**Result and observation** 

<img width="723" alt="Screenshot 2020-09-14 at 14 30 21" src="https://user-images.githubusercontent.com/33550261/93089429-947ff900-f69b-11ea-8c4c-5bc2d64cc184.png">


<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
