### PR TITLE
fix podcast display over IE11

### DIFF
--- a/packages/@coorpacademy-components/src/template/external-course/style.css
+++ b/packages/@coorpacademy-components/src/template/external-course/style.css
@@ -168,4 +168,6 @@
 
 .podcast {
   align-self: center;
+  z-index: 1;
+  margin: auto;
 }


### PR DESCRIPTION
**Detailed purpose of the PR**
Fixes external content audio display bug on ie11 (ie11 styling support to display the audio element when a background is used).

Display on chrome:

<img width="729" alt="Screenshot 2020-09-15 at 14 46 01" src="https://user-images.githubusercontent.com/33550261/93211955-39fda000-f762-11ea-8121-166e1dfd85d3.png">

Display on ie11: (disclaimer: error message due to local ie11 config, not due to the components)
![Screenshot 2020-09-15 at 14 39 19](https://user-images.githubusercontent.com/33550261/93212092-6b766b80-f762-11ea-9c0f-895bc2133f1c.png)

With the correct configs it should display this on ie11:
![Screenshot 2020-09-15 at 14 43 57](https://user-images.githubusercontent.com/33550261/93212159-821cc280-f762-11ea-8a54-aed98d04217e.png)


**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
