### PR TITLE
extracts the content viewer section to reuse it on cockpit preview

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/index.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/index.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import {startsWith} from 'lodash/fp';
+import PropTypes from 'prop-types';
+import style from './style.css';
+
+function ExternalContentViewer(props) {
+  const {url, backgroundImageUrl, contentType} = props;
+
+  return startsWith('audio', contentType) ? (
+    <div className={style.podcastWrapper}>
+      <div
+        className={style.bgPodcast}
+        style={{backgroundImage: backgroundImageUrl && `url(${backgroundImageUrl})`}}
+      />
+      <audio
+        className={style.podcast}
+        controls
+        autoPlay=""
+        name="media"
+        data-name="external-content-podcast"
+        preload="auto"
+      >
+        <source src={url} type={contentType} />
+      </audio>
+    </div>
+  ) : (
+    <iframe
+      src={url}
+      frameBorder={0}
+      className={style.iframe}
+      allowFullScreen
+      data-name="external-content-iframe"
+    />
+  );
+}
+
+ExternalContentViewer.propTypes = {
+  url: PropTypes.string.isRequired,
+  backgroundImageUrl: PropTypes.string,
+  contentType: PropTypes.string
+};
+
+export default ExternalContentViewer;

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/style.css
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/style.css
@@ -1,0 +1,34 @@
+.iframe {
+  width: 100%;
+  flex-grow: 2;
+  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: hidden;
+}
+
+.podcastWrapper {
+  composes: iframe;
+  display: flex;
+  align-content: center;
+  justify-content: space-around;
+  position: relative;
+
+}
+
+.bgPodcast {
+  filter: brightness(40%) blur(5px);
+  /* To take out the white outline caused why the blur */
+  transform: scale(1.04);
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0px;
+  left: 0px;
+}
+
+.podcast {
+  align-self: center;
+}

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/article.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/article.js
@@ -1,0 +1,6 @@
+export default {
+  props: {
+    contentType: 'article',
+    url: 'https://fr.wikipedia.org/wiki/Massive_Open_Online_Course'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/default.js
@@ -1,0 +1,7 @@
+export default {
+  props: {
+    contentType: 'scorm',
+    url:
+      'https://media.radiofrance-podcast.net/podcast09/app_rf_promotion.mp3?replayCu=11171&stationId=2'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/h5p.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/h5p.js
@@ -1,0 +1,6 @@
+export default {
+  props: {
+    contentType: 'video/mp4',
+    url: 'https://coorpacademy.h5p.com/content/1291025352652664897/embed'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/podcast-no-background.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/podcast-no-background.js
@@ -1,0 +1,6 @@
+export default {
+  props: {
+    url: 'https://static.coorpacademy.com/site/podcasts/Weekly%20wash%20up_20200608_FINAL.mp3',
+    contentType: 'audio/mp3'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/podcast.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/podcast.js
@@ -1,0 +1,10 @@
+import {defaultsDeep} from 'lodash/fp';
+import Default from './podcast-no-background';
+
+const {props} = Default;
+
+export default {
+  props: defaultsDeep(props, {
+    backgroundImageUrl: 'https://static.coorpacademy.com/site/podcast.jpg'
+  })
+};

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/video.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/video.js
@@ -1,0 +1,6 @@
+export default {
+  props: {
+    contentType: 'video/mp4',
+    url: 'https://www.youtube.com/embed/nLMZd05FQKc'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/youtube-podcast.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/fixtures/youtube-podcast.js
@@ -1,0 +1,11 @@
+import {defaultsDeep} from 'lodash/fp';
+import Default from './podcast-no-background';
+
+const {props} = Default;
+
+export default {
+  props: defaultsDeep(props, {
+    url: 'https://www.youtube.com/embed/nLMZd05FQKc',
+    contentType: 'video/mp4'
+  })
+};

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/podcast.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/test/podcast.js
@@ -1,0 +1,29 @@
+import browserEnv from 'browser-env';
+import test from 'ava';
+import React from 'react';
+import {mount, configure} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import ExternalContentViewer from '..';
+import podcastFixture from './fixtures/podcast';
+import podcastYoutubeFixture from './fixtures/youtube-podcast';
+
+browserEnv();
+configure({adapter: new Adapter()});
+
+test('when the media is a mp3 podcast, it shouldnt display an iframe but only a the podcast tag', t => {
+  const wrapper = mount(<ExternalContentViewer {...podcastFixture.props} />);
+  const podcast = wrapper.find('[data-name="external-content-podcast"]');
+  const iframe = wrapper.find('[data-name="external-content-iframe"]');
+  t.assert(podcast.exists());
+  t.assert(!iframe.exists());
+  t.pass();
+});
+
+test('when the media is a youtube podcast, it should display an iframe and no podcast tag', t => {
+  const wrapper = mount(<ExternalContentViewer {...podcastYoutubeFixture.props} />);
+  const podcast = wrapper.find('[data-name="external-content-podcast"]');
+  const iframe = wrapper.find('[data-name="external-content-iframe"]');
+  t.assert(!podcast.exists());
+  t.assert(iframe.exists());
+  t.pass();
+});

--- a/packages/@coorpacademy-components/src/template/external-course/index.js
+++ b/packages/@coorpacademy-components/src/template/external-course/index.js
@@ -2,12 +2,13 @@ import React from 'react';
 import {NovaSolidInterfaceFeedbackInterfaceQuestionMark as QuestionIcon} from '@coorpacademy/nova-icons';
 import {convert} from 'css-color-function';
 import classnames from 'classnames';
-import {get, getOr, keys, identity, isNil, startsWith} from 'lodash/fp';
+import {get, getOr, keys, identity, isNil} from 'lodash/fp';
 import PropTypes from 'prop-types';
 import {EXTERNAL_CONTENT_ICONS} from '../../util/external-content';
 import Provider from '../../atom/provider';
 import Loader from '../../atom/loader';
 import Button from '../../atom/button';
+import ExternalContentViewer from '../../molecule/external-content-viewer';
 import style from './style.css';
 
 class ExternalCourse extends React.Component {
@@ -61,38 +62,16 @@ class ExternalCourse extends React.Component {
     const IconType = EXTERNAL_CONTENT_ICONS[type].icon;
     const IconColor = EXTERNAL_CONTENT_ICONS[type].color;
 
-    const content = startsWith('audio', contentType) ? (
-      <div className={style.podcastWrapper}>
-        <div
-          className={style.bgPodcast}
-          style={{backgroundImage: backgroundImageUrl && `url(${backgroundImageUrl})`}}
-        />
-        <audio
-          className={style.podcast}
-          controls
-          autoPlay=""
-          name="media"
-          data-name="external-content-podcast"
-          preload="auto"
-        >
-          <source src={url} type={contentType} />
-        </audio>
-      </div>
-    ) : (
-      <iframe
-        src={url}
-        frameBorder={0}
-        className={style.iframe}
-        allowFullScreen
-        data-name="external-content-iframe"
-      />
-    );
     const mainContentSlot = loading ? (
       <div className={style.loader}>
         <Loader />
       </div>
     ) : (
-      content
+      <ExternalContentViewer
+        url={url}
+        backgroundImageUrl={backgroundImageUrl}
+        contentType={contentType}
+      />
     );
 
     const completeButton = !isNil(complete) ? (

--- a/packages/@coorpacademy-components/src/template/external-course/style.css
+++ b/packages/@coorpacademy-components/src/template/external-course/style.css
@@ -89,14 +89,6 @@
   height: 15px;
 }
 
-.iframe {
-  width: 100%;
-  flex-grow: 2;
-  overflow: hidden;
-  overflow-x: hidden;
-  overflow-y: hidden;
-}
-
 .link {
   display: inline-flex;
   align-items: center;
@@ -141,33 +133,4 @@
   .footer .leftSection, .footer .rightSection {
     display: none;
   }
-}
-
-.podcastWrapper {
-  composes: iframe;
-  display: flex;
-  align-content: center;
-  justify-content: space-around;
-  position: relative;
-
-}
-
-.bgPodcast {
-  filter: brightness(40%) blur(5px);
-  /* To take out the white outline caused why the blur */
-  transform: scale(1.04);
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: cover;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0px;
-  left: 0px;
-}
-
-.podcast {
-  align-self: center;
-  z-index: 1;
-  margin: auto;
 }

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -67,6 +67,7 @@ import MoleculeDisciplinePartners from './../src/molecule/discipline-partners';
 import MoleculeDisciplineScope from './../src/molecule/discipline-scope';
 import MoleculeDragAndDrop from './../src/molecule/drag-and-drop';
 import MoleculeExternalContentButton from './../src/molecule/external-content-button';
+import MoleculeExternalContentViewer from './../src/molecule/external-content-viewer';
 import MoleculeFeedback from './../src/molecule/feedback';
 import MoleculeFilters from './../src/molecule/filters';
 import MoleculeForumForumComment from './../src/molecule/forum/forum-comment';
@@ -421,6 +422,13 @@ import MoleculeExternalContentButtonFixtureArticle from '../src/molecule/externa
 import MoleculeExternalContentButtonFixturePodcast from '../src/molecule/external-content-button/test/fixtures/podcast';
 import MoleculeExternalContentButtonFixtureScorm from '../src/molecule/external-content-button/test/fixtures/scorm';
 import MoleculeExternalContentButtonFixtureVideo from '../src/molecule/external-content-button/test/fixtures/video';
+import MoleculeExternalContentViewerFixtureArticle from '../src/molecule/external-content-viewer/test/fixtures/article';
+import MoleculeExternalContentViewerFixtureDefault from '../src/molecule/external-content-viewer/test/fixtures/default';
+import MoleculeExternalContentViewerFixtureH5P from '../src/molecule/external-content-viewer/test/fixtures/h5p';
+import MoleculeExternalContentViewerFixturePodcastNoBackground from '../src/molecule/external-content-viewer/test/fixtures/podcast-no-background';
+import MoleculeExternalContentViewerFixturePodcast from '../src/molecule/external-content-viewer/test/fixtures/podcast';
+import MoleculeExternalContentViewerFixtureVideo from '../src/molecule/external-content-viewer/test/fixtures/video';
+import MoleculeExternalContentViewerFixtureYoutubePodcast from '../src/molecule/external-content-viewer/test/fixtures/youtube-podcast';
 import MoleculeFeedbackFixtureDefault from '../src/molecule/feedback/test/fixtures/default';
 import MoleculeFeedbackFixtureFailExitNode from '../src/molecule/feedback/test/fixtures/fail-exit-node';
 import MoleculeFeedbackFixtureFailureWithTitleAndDescriptionAndVideo from '../src/molecule/feedback/test/fixtures/failure-with-title-and-description-and-video';
@@ -899,6 +907,7 @@ export const components = {
     MoleculeDisciplineScope,
     MoleculeDragAndDrop,
     MoleculeExternalContentButton,
+    MoleculeExternalContentViewer,
     MoleculeFeedback,
     MoleculeFilters,
     MoleculeHero,
@@ -1404,6 +1413,15 @@ export const fixtures = {
       Podcast: MoleculeExternalContentButtonFixturePodcast,
       Scorm: MoleculeExternalContentButtonFixtureScorm,
       Video: MoleculeExternalContentButtonFixtureVideo
+    },
+    MoleculeExternalContentViewer: {
+      Article: MoleculeExternalContentViewerFixtureArticle,
+      Default: MoleculeExternalContentViewerFixtureDefault,
+      H5P: MoleculeExternalContentViewerFixtureH5P,
+      PodcastNoBackground: MoleculeExternalContentViewerFixturePodcastNoBackground,
+      Podcast: MoleculeExternalContentViewerFixturePodcast,
+      Video: MoleculeExternalContentViewerFixtureVideo,
+      YoutubePodcast: MoleculeExternalContentViewerFixtureYoutubePodcast
     },
     MoleculeFeedback: {
       Default: MoleculeFeedbackFixtureDefault,


### PR DESCRIPTION
**Detailed purpose of the PR**

- Refactors ExternalCourse template component and extracts the content viewer section to reuse it on cockpit preview to a new molecule component ExternalContentViewer.
- UI remains unchanged

**Result and observation**

<img width="721" alt="Screenshot 2020-09-15 at 18 25 27" src="https://user-images.githubusercontent.com/33550261/93237824-ecdcf680-f780-11ea-99d9-2c1c5f5dd74f.png">
<img width="721" alt="Screenshot 2020-09-15 at 18 25 41" src="https://user-images.githubusercontent.com/33550261/93237837-f1091400-f780-11ea-9a03-76f2c3c60e8c.png">


- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing

