### PR TITLE
fix progression bar style (space left behind) when it is Nil

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/card-content/index.js
+++ b/packages/@coorpacademy-components/src/molecule/card-content/index.js
@@ -131,8 +131,8 @@ const ContentInfo = ({
   const chapterContent = type === 'chapter';
 
   const progressBar =
-    mode === MODES.HERO || (!empty && !disabled && !isNil(progress)) ? (
-      <div className={style.progressWrapper}>
+    mode === MODES.HERO || (!empty && !disabled) ? (
+      <div className={!isNil(progress) ? style.progressWrapper : style.hideProgressBar}>
         {!disabled ? (
           <div data-name="progress" className={style.progress} style={inlineProgressValueStyle} />
         ) : null}

--- a/packages/@coorpacademy-components/src/molecule/card-content/style.css
+++ b/packages/@coorpacademy-components/src/molecule/card-content/style.css
@@ -205,3 +205,8 @@
     font-size: 12px;
   }
 }
+
+.hideProgressBar {
+  composes: progressWrapper;
+  opacity: 0;
+}

--- a/packages/@coorpacademy-components/src/molecule/card-content/test/fixtures/card-no-progress-bar.js
+++ b/packages/@coorpacademy-components/src/molecule/card-content/test/fixtures/card-no-progress-bar.js
@@ -1,0 +1,9 @@
+import {MODES} from '../..';
+
+export default {
+  props: {
+    mode: MODES.CARD,
+    author: 'Coorpcademy',
+    title: 'From Mass Market to One to One targeting'
+  }
+};

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -373,6 +373,7 @@ import MoleculeCardFixtureScorm from '../src/molecule/card/test/fixtures/scorm';
 import MoleculeCardFixtureVideo from '../src/molecule/card/test/fixtures/video';
 import MoleculeCardContentFixtureAdaptivAndDisabled from '../src/molecule/card-content/test/fixtures/adaptiv-and-disabled';
 import MoleculeCardContentFixtureAdaptiv from '../src/molecule/card-content/test/fixtures/adaptiv';
+import MoleculeCardContentFixtureCardNoProgressBar from '../src/molecule/card-content/test/fixtures/card-no-progress-bar';
 import MoleculeCardContentFixtureCard from '../src/molecule/card-content/test/fixtures/card';
 import MoleculeCardContentFixtureDisabled from '../src/molecule/card-content/test/fixtures/disabled';
 import MoleculeCardContentFixtureEmpty from '../src/molecule/card-content/test/fixtures/empty';
@@ -1367,6 +1368,7 @@ export const fixtures = {
     MoleculeCardContent: {
       AdaptivAndDisabled: MoleculeCardContentFixtureAdaptivAndDisabled,
       Adaptiv: MoleculeCardContentFixtureAdaptiv,
+      CardNoProgressBar: MoleculeCardContentFixtureCardNoProgressBar,
       Card: MoleculeCardContentFixtureCard,
       Disabled: MoleculeCardContentFixtureDisabled,
       Empty: MoleculeCardContentFixtureEmpty,


### PR DESCRIPTION
**Detailed purpose of the PR**

- When progression is Nil as prop for the ContentInfo component (inside card-content), the bar is not displayed but the space should remain used as if it was there.

**Result and observation**

_Usage without progress (ex: TeamsDashboard):_  

<img width="1440" alt="Screenshot 2020-10-14 at 14 25 02" src="https://user-images.githubusercontent.com/33550261/95988375-1abd6580-0e29-11eb-8e88-952839e29a1f.png">

_Usage with progress (**remains the same**, ex: default dashboard CardList):_  

<img width="1438" alt="Screenshot 2020-10-14 at 14 26 29" src="https://user-images.githubusercontent.com/33550261/95988661-7f78c000-0e29-11eb-8e15-4ccd0549e85c.png">


**Testing Strategy**

- [x] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
