### PR TITLE
fix style, show progression data on import user

### DIFF
--- a/packages/@coorpacademy-components/src/organism/brand-upload/style.css
+++ b/packages/@coorpacademy-components/src/organism/brand-upload/style.css
@@ -66,6 +66,7 @@
 
 .progress div {
   background: positive;
+  position: initial;
 }
 
 @keyframes notificationAppear {


### PR DESCRIPTION
**Detailed purpose of the PR**

On setup, upload users file, the progress bar is always at 100% and progression information is not visible.

<img width="1095" alt="Screenshot 2020-10-15 at 11 53 02" src="https://user-images.githubusercontent.com/7602475/96107828-2cf8db80-0edd-11eb-8255-518d1cc62c5e.png">

This PR fixes this problem.

**Result and observation**

<img width="1123" alt="Screenshot 2020-10-15 at 11 55 54" src="https://user-images.githubusercontent.com/7602475/96108249-a264ac00-0edd-11eb-8b9e-375b5c934d41.png">

**Testing Strategy**

- Already covered by tests
- Manual testing
