### PR TITLE
Fix author overflow over footer

### DIFF
--- a/packages/@coorpacademy-components/src/template/common/discipline/index.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/index.js
@@ -23,31 +23,33 @@ const Discipline = (props, context) => {
   } = props;
 
   return (
-    <div data-name="discipline" className={style.wrapper}>
-      <div className={style.header}>
-        <DisciplineHeader image={image} video={video} title={title} description={description} />
-      </div>
-      <div className={style.sticky}>
-        <div className={style.cta}>
-          <DisciplineCTA
-            type={'discipline'}
-            start={start}
-            buy={buy}
-            startLabel={startLabel}
-            buyLabel={buyLabel}
+    <div data-name="discipline">
+      <div className={style.wrapper}>
+        <div className={style.header}>
+          <DisciplineHeader image={image} video={video} title={title} description={description} />
+        </div>
+        <div className={style.sticky}>
+          <div className={style.cta}>
+            <DisciplineCTA
+              type={'discipline'}
+              start={start}
+              buy={buy}
+              startLabel={startLabel}
+              buyLabel={buyLabel}
+            />
+          </div>
+          <div className={style.partners}>
+            <DisciplinePartners authors={authors} />
+          </div>
+        </div>
+        <div className={style.content}>
+          <DisciplineScope
+            content={level}
+            levels={levels}
+            selected={selected}
+            onClick={changeLevel}
           />
         </div>
-        <div className={style.partners}>
-          <DisciplinePartners authors={authors} />
-        </div>
-      </div>
-      <div className={style.content}>
-        <DisciplineScope
-          content={level}
-          levels={levels}
-          selected={selected}
-          onClick={changeLevel}
-        />
       </div>
     </div>
   );

--- a/packages/@coorpacademy-components/src/template/common/discipline/index.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/index.js
@@ -3,6 +3,7 @@ import DisciplineCTA from '../../../molecule/discipline-cta';
 import DisciplineHeader from '../../../molecule/discipline-header';
 import DisciplinePartners from '../../../molecule/discipline-partners';
 import DisciplineScope from '../../../molecule/discipline-scope';
+import Footer from '../../../organism/mooc-footer';
 import style from './style.css';
 
 const Discipline = (props, context) => {
@@ -23,12 +24,36 @@ const Discipline = (props, context) => {
   } = props;
 
   return (
-    <div data-name="discipline">
-      <div className={style.wrapper}>
-        <div className={style.header}>
-          <DisciplineHeader image={image} video={video} title={title} description={description} />
+    <div>
+      <div data-name="discipline">
+        <div className={style.wrapper}>
+          <div className={style.header}>
+            <DisciplineHeader image={image} video={video} title={title} description={description} />
+          </div>
+          <div className={style.mobileAuthorCtaSection}>
+            <div className={style.cta}>
+              <DisciplineCTA
+                type={'discipline'}
+                start={start}
+                buy={buy}
+                startLabel={startLabel}
+                buyLabel={buyLabel}
+              />
+            </div>
+            <div className={style.partners}>
+              <DisciplinePartners authors={authors} />
+            </div>
+          </div>
+          <div className={style.content}>
+            <DisciplineScope
+              content={level}
+              levels={levels}
+              selected={selected}
+              onClick={changeLevel}
+            />
+          </div>
         </div>
-        <div className={style.mobileAuthorCtaSection}>
+        <div className={style.wideAuthorCtaSection}>
           <div className={style.cta}>
             <DisciplineCTA
               type={'discipline'}
@@ -42,29 +67,8 @@ const Discipline = (props, context) => {
             <DisciplinePartners authors={authors} />
           </div>
         </div>
-        <div className={style.content}>
-          <DisciplineScope
-            content={level}
-            levels={levels}
-            selected={selected}
-            onClick={changeLevel}
-          />
-        </div>
       </div>
-      <div className={style.wideAuthorCtaSection}>
-        <div className={style.cta}>
-          <DisciplineCTA
-            type={'discipline'}
-            start={start}
-            buy={buy}
-            startLabel={startLabel}
-            buyLabel={buyLabel}
-          />
-        </div>
-        <div className={style.partners}>
-          <DisciplinePartners authors={authors} />
-        </div>
-      </div>
+      <Footer />
     </div>
   );
 };

--- a/packages/@coorpacademy-components/src/template/common/discipline/index.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/index.js
@@ -28,7 +28,7 @@ const Discipline = (props, context) => {
         <div className={style.header}>
           <DisciplineHeader image={image} video={video} title={title} description={description} />
         </div>
-        <div className={style.sticky}>
+        <div className={style.mobileAuthorCtaSection}>
           <div className={style.cta}>
             <DisciplineCTA
               type={'discipline'}
@@ -51,7 +51,7 @@ const Discipline = (props, context) => {
           />
         </div>
       </div>
-      <div className={style.sticky2}>
+      <div className={style.wideAuthorCtaSection}>
         <div className={style.cta}>
           <DisciplineCTA
             type={'discipline'}

--- a/packages/@coorpacademy-components/src/template/common/discipline/index.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import isEmpty from 'lodash/fp/isEmpty';
 import DisciplineCTA from '../../../molecule/discipline-cta';
 import DisciplineHeader from '../../../molecule/discipline-header';
 import DisciplinePartners from '../../../molecule/discipline-partners';
@@ -21,6 +22,12 @@ const Discipline = (props, context) => {
     startLabel,
     buyLabel
   } = props;
+
+  const authorSection = isEmpty(authors) ? null : (
+    <div className={style.partners}>
+      <DisciplinePartners authors={authors} />
+    </div>
+  );
 
   return (
     <div>
@@ -63,9 +70,7 @@ const Discipline = (props, context) => {
                 buyLabel={buyLabel}
               />
             </div>
-            <div className={style.partners}>
-              <DisciplinePartners authors={authors} />
-            </div>
+            {authorSection}
           </div>
         </div>
       </div>

--- a/packages/@coorpacademy-components/src/template/common/discipline/index.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/index.js
@@ -51,6 +51,20 @@ const Discipline = (props, context) => {
           />
         </div>
       </div>
+      <div className={style.sticky2}>
+        <div className={style.cta}>
+          <DisciplineCTA
+            type={'discipline'}
+            start={start}
+            buy={buy}
+            startLabel={startLabel}
+            buyLabel={buyLabel}
+          />
+        </div>
+        <div className={style.partners}>
+          <DisciplinePartners authors={authors} />
+        </div>
+      </div>
     </div>
   );
 };

--- a/packages/@coorpacademy-components/src/template/common/discipline/index.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/index.js
@@ -3,7 +3,6 @@ import DisciplineCTA from '../../../molecule/discipline-cta';
 import DisciplineHeader from '../../../molecule/discipline-header';
 import DisciplinePartners from '../../../molecule/discipline-partners';
 import DisciplineScope from '../../../molecule/discipline-scope';
-import Footer from '../../../organism/mooc-footer';
 import style from './style.css';
 
 const Discipline = (props, context) => {
@@ -70,7 +69,6 @@ const Discipline = (props, context) => {
           </div>
         </div>
       </div>
-      <Footer />
     </div>
   );
 };

--- a/packages/@coorpacademy-components/src/template/common/discipline/index.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/index.js
@@ -25,8 +25,8 @@ const Discipline = (props, context) => {
 
   return (
     <div>
-      <div data-name="discipline">
-        <div className={style.wrapper}>
+      <div data-name="discipline" className={style.container}>
+        <div className={style.leftSection}>
           <div className={style.header}>
             <DisciplineHeader image={image} video={video} title={title} description={description} />
           </div>
@@ -53,18 +53,20 @@ const Discipline = (props, context) => {
             />
           </div>
         </div>
-        <div className={style.wideAuthorCtaSection}>
-          <div className={style.cta}>
-            <DisciplineCTA
-              type={'discipline'}
-              start={start}
-              buy={buy}
-              startLabel={startLabel}
-              buyLabel={buyLabel}
-            />
-          </div>
-          <div className={style.partners}>
-            <DisciplinePartners authors={authors} />
+        <div className={style.rightSection}>
+          <div className={style.stickySection}>
+            <div className={style.cta}>
+              <DisciplineCTA
+                type={'discipline'}
+                start={start}
+                buy={buy}
+                startLabel={startLabel}
+                buyLabel={buyLabel}
+              />
+            </div>
+            <div className={style.partners}>
+              <DisciplinePartners authors={authors} />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/@coorpacademy-components/src/template/common/discipline/style.css
+++ b/packages/@coorpacademy-components/src/template/common/discipline/style.css
@@ -23,6 +23,14 @@
   width: 280px;
 }
 
+.sticky2 {
+  position: fixed;
+  left: 50%;
+  margin-left: 330px;
+  top: 80px;
+  width: 280px;
+}
+
 .leftColumn {
   composes: column;
   float: left;
@@ -57,6 +65,11 @@
     order: 2;
     margin-left: 0px;
   }
+
+  .sticky2 {
+    display: none;
+  }
+
   .column {
     display: flex;
     flex-basis: 100%;
@@ -85,5 +98,8 @@
   }
   .sticky {
     padding: 0px;
+  }
+  .sticky2 {
+    display: none;
   }
 }

--- a/packages/@coorpacademy-components/src/template/common/discipline/style.css
+++ b/packages/@coorpacademy-components/src/template/common/discipline/style.css
@@ -15,6 +15,7 @@
 }
 
 .sticky {
+  display: none;
   position: fixed;
   left: 50%;
   margin-left: 330px;

--- a/packages/@coorpacademy-components/src/template/common/discipline/style.css
+++ b/packages/@coorpacademy-components/src/template/common/discipline/style.css
@@ -14,7 +14,7 @@
   margin-bottom: 30px;
 }
 
-.sticky {
+.mobileAuthorCtaSection {
   display: none;
   position: fixed;
   left: 50%;
@@ -23,12 +23,9 @@
   width: 280px;
 }
 
-.sticky2 {
-  position: fixed;
-  left: 50%;
-  margin-left: 330px;
-  top: 80px;
-  width: 280px;
+.wideAuthorCtaSection {
+  composes: mobileAuthorCtaSection;
+  display: block;
 }
 
 .leftColumn {
@@ -57,7 +54,7 @@
   .wrapper {
     display: flex;
   }
-  .sticky {
+  .mobileAuthorCtaSection {
     composes: wrapper from '../layout.css';
     position: inherit;
     display: flex;
@@ -66,7 +63,7 @@
     margin-left: 0px;
   }
 
-  .sticky2 {
+  .wideAuthorCtaSection {
     display: none;
   }
 
@@ -96,10 +93,10 @@
   .content {
     width: 100%;
   }
-  .sticky {
+  .mobileAuthorCtaSection {
     padding: 0px;
   }
-  .sticky2 {
+  .wideAuthorCtaSection {
     display: none;
   }
 }

--- a/packages/@coorpacademy-components/src/template/common/discipline/style.css
+++ b/packages/@coorpacademy-components/src/template/common/discipline/style.css
@@ -24,12 +24,14 @@
   box-sizing: border-box;
   position: relative;
   padding-left: 50px;
+  margin-bottom: 50px;
+  margin-top: 60px;
 }
 
 .stickySection {
   box-sizing: border-box;
   position: sticky;
-  top: 80px;
+  top: 40px;
   z-index: 1;
   width: 280px;
   padding: 0 20px;
@@ -54,7 +56,7 @@
 .cta,
 .partners {
   composes: column;
-  padding-bottom: 50px;
+  padding-top: 20px;
 }
 
 @media desktop {
@@ -82,6 +84,7 @@
 
   .header {
     order: 1;
+    width: 100%;
   }
 
   .cta {
@@ -99,6 +102,10 @@
 }
 
 @media mobile {
+  .header {
+    width: 100%;
+  }
+
   .content {
     width: 100%;
   }

--- a/packages/@coorpacademy-components/src/template/common/discipline/style.css
+++ b/packages/@coorpacademy-components/src/template/common/discipline/style.css
@@ -42,9 +42,7 @@
 .mobileAuthorCtaSection {
   display: none;
   position: fixed;
-  left: 50%;
   margin-left: 330px;
-  top: 80px;
 }
 
 .header,
@@ -96,6 +94,7 @@
 
   .content {
     order: 4;
+    width: 100%;
   }
 }
 

--- a/packages/@coorpacademy-components/src/template/common/discipline/style.css
+++ b/packages/@coorpacademy-components/src/template/common/discipline/style.css
@@ -3,11 +3,36 @@
 @value mobile from breakpoints;
 @value wide from breakpoints;
 
-.wrapper {
+.container {
   composes: wrapper from '../layout.css';
+  box-sizing: border-box;
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.leftSection {
   display: block;
   overflow: hidden;
   padding: 20px;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.rightSection {
+  box-sizing: border-box;
+  position: relative;
+  padding-left: 50px;
+}
+
+.stickySection {
+  box-sizing: border-box;
+  position: sticky;
+  top: 80px;
+  z-index: 1;
+  width: 280px;
+  padding: 0 20px;
 }
 
 .column {
@@ -20,41 +45,25 @@
   left: 50%;
   margin-left: 330px;
   top: 80px;
-  width: 280px;
-}
-
-.wideAuthorCtaSection {
-  composes: mobileAuthorCtaSection;
-  display: block;
-}
-
-.leftColumn {
-  composes: column;
-  float: left;
-  width: 840px;
-}
-
-.rightColumn {
-  composes: column;
-  float: right;
-  width: 280px;
 }
 
 .header,
 .content {
-  composes: leftColumn;
+  composes: column;
+  width: 840px;
 }
 
 .cta,
 .partners {
-  composes: rightColumn;
+  composes: column;
+  padding-bottom: 50px;
 }
 
 @media desktop {
-  .wrapper {
+  .container {
     display: flex;
   }
-  
+
   .mobileAuthorCtaSection {
     composes: wrapper from '../layout.css';
     position: inherit;
@@ -64,7 +73,7 @@
     margin-left: 0px;
   }
 
-  .wideAuthorCtaSection {
+  .rightSection {
     display: none;
   }
 
@@ -94,10 +103,12 @@
   .content {
     width: 100%;
   }
+
   .mobileAuthorCtaSection {
     padding: 0px;
   }
-  .wideAuthorCtaSection {
+
+  .rightSection {
     display: none;
   }
 }

--- a/packages/@coorpacademy-components/src/template/common/discipline/style.css
+++ b/packages/@coorpacademy-components/src/template/common/discipline/style.css
@@ -54,6 +54,7 @@
   .wrapper {
     display: flex;
   }
+  
   .mobileAuthorCtaSection {
     composes: wrapper from '../layout.css';
     position: inherit;

--- a/packages/@coorpacademy-components/src/template/common/discipline/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/test/fixtures/default.js
@@ -1,5 +1,5 @@
 import {update, uniqueId, head} from 'lodash/fp';
-import disciplineHeader from '../../../../../molecule/discipline-header/test/fixtures/default';
+import disciplineHeader from '../../../../../molecule/discipline-header/test/fixtures/long-description';
 import disciplinePartners from '../../../../../molecule/discipline-partners/test/fixtures/more-info';
 import disciplineCTA from '../../../../../molecule/discipline-cta/test/fixtures/default';
 import disciplineScope from '../../../../../molecule/discipline-scope/test/fixtures/medias';


### PR DESCRIPTION
Ticket trello: https://trello.com/c/BHjCxNmS/1915-la-case-auteur-d%C3%A9borde-par-dessus-le-footer

**Detailed purpose of the PR**

After releasing new footer, the right section of the discipline page was overlapping the footer. This PR fixes this behavior for evergreen browsers.

![author-overlap-footer](https://user-images.githubusercontent.com/7602475/96879217-0d812600-147c-11eb-8d9b-2b517fa6bc49.gif)

**Result and observation**

The cta + author section should be duplicated and the elements reorganised on the vue. 
- The left section contains the header, a cta + author section (only visible for width < 1280), the levels and the forum.
- The right section contains the cta + author section and it's only visible in wide mode. The cta + author section position was set to sticky to allow mouvement and avoid overlapping. However, this value is not supported by IE 11 and the section will not move with the scroll. We decided to merge like this.

In order to allow a better test, the Footer component was added temporary (that's why you can see it on the storybook render of the discipline template).

**Result on Chrome**
![fixed-overlap-chrome](https://user-images.githubusercontent.com/7602475/96880293-4ff73280-147d-11eb-91f9-30dc02551328.gif)

**Result on IE 11**
![author-fixed-on-IE11](https://user-images.githubusercontent.com/7602475/96880373-63a29900-147d-11eb-99d3-69c591a2bf7b.gif)

**Mobile result**

![mobile](https://user-images.githubusercontent.com/7602475/96880913-03602700-147e-11eb-8ef2-225be95c8646.gif)

**Testing Strategy**

- Already covered by tests
- Manual testing
