### PR TITLE
[Teams] Centralize the Teams popup in the screen

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/teams-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/teams-popin/style.css
@@ -18,10 +18,10 @@
   justify-content: center;
   box-sizing: border-box;
   overflow: hidden;
+  display: flex;
 }
 
 .popin {
-  top: 30%;
   position: absolute;
   overflow: auto;
   width: 35%;


### PR DESCRIPTION
PR to put the Teams popin in the center of the page

**Before**

<img width="284" alt="Capture d’écran 2020-12-03 à 16 21 50" src="https://user-images.githubusercontent.com/58167920/101049525-e55d0a80-3583-11eb-9087-5525d5d7c54a.png">



**After**


<img width="284" alt="Capture d’écran 2020-12-03 à 16 21 29" src="https://user-images.githubusercontent.com/58167920/101049521-e42bdd80-3583-11eb-95ca-9d69713b07a4.png">



<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
