### PR TITLE
Skip content fetch when validating answer[mobile]

### DIFF
--- a/packages/@coorpacademy-player-store/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/answers.js
@@ -103,7 +103,7 @@ export const editAnswer = (newValue: string | Array<string> | Choice) => (
   });
 };
 
-export const validateAnswer = (partialPayload: PostAnswerPartialPayload) => async (
+export const validateAnswer = (partialPayload: PostAnswerPartialPayload, {skipNextSlideFetch = false}) => async (
   dispatch: Dispatch,
   getState: GetState,
   {services}: Options
@@ -139,7 +139,7 @@ export const validateAnswer = (partialPayload: PostAnswerPartialPayload) => asyn
 
   const state = getState();
 
-  if (get('nextContent.type', progressionState) === 'slide') {
+  if (!skipNextSlideFetch && get('nextContent.type', progressionState) === 'slide') {
     await dispatch(fetchSlideChapter(nextContentRef));
   }
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/answers.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/answers.js
@@ -103,11 +103,10 @@ export const editAnswer = (newValue: string | Array<string> | Choice) => (
   });
 };
 
-export const validateAnswer = (partialPayload: PostAnswerPartialPayload, {skipNextSlideFetch = false}) => async (
-  dispatch: Dispatch,
-  getState: GetState,
-  {services}: Options
-): DispatchedAction => {
+export const validateAnswer = (
+  partialPayload: PostAnswerPartialPayload,
+  {skipNextSlideFetch}: {skipNextSlideFetch: boolean} = {skipNextSlideFetch: false}
+) => async (dispatch: Dispatch, getState: GetState, {services}: Options): DispatchedAction => {
   const initialState = getState();
   const slide = getCurrentSlide(initialState);
 

--- a/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-accordion.js
+++ b/packages/@coorpacademy-player-store/src/actions/ui/test/answers-validation/check-accordion.js
@@ -194,6 +194,21 @@ test(
 );
 
 test(
+  'should provide a correct answer and see tips opened but without fetching next content',
+  macro,
+  stateWithSlideAndManyResources,
+  services(correctAnswer),
+  validateAnswer({}, {skipNextSlideFetch: true}),
+  flatten([
+    answer(correctAnswer),
+    accordionIsOpenAt(ACCORDION_TIPS),
+    progressionUpdated,
+    fetchCorrection,
+  ]),
+  5
+);
+
+test(
   'should provide a wrong answer and see lesson opened',
   macro,
   stateWithSlideAndManyResources,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,11 +2280,6 @@
     lodash "^4.17.15"
     prettier "1.16.4"
 
-"@coorpacademy/nova-icons@3.9.1":
-  version "3.9.1"
-  resolved "https://registry.npmjs.org/@coorpacademy/nova-icons/-/nova-icons-3.9.1.tgz#54bcc2de260da5c6dba85a3c1c02ba31c1ec4f19"
-  integrity sha512-1AlZe0WYWJouo0VyrZdcVNBjI2WOGVoqATxeZM7CzYRAg23g/gACTCferdg6hucEp8LzpvSATygwbJU7flWMCQ==
-
 "@coorpacademy/update-node@^3.16.0":
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/@coorpacademy/update-node/-/update-node-3.16.0.tgz#be0e0fb98733fd670a2d519c141363d586430443"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,6 +2280,11 @@
     lodash "^4.17.15"
     prettier "1.16.4"
 
+"@coorpacademy/nova-icons@3.9.1":
+  version "3.9.1"
+  resolved "https://registry.npmjs.org/@coorpacademy/nova-icons/-/nova-icons-3.9.1.tgz#54bcc2de260da5c6dba85a3c1c02ba31c1ec4f19"
+  integrity sha512-1AlZe0WYWJouo0VyrZdcVNBjI2WOGVoqATxeZM7CzYRAg23g/gACTCferdg6hucEp8LzpvSATygwbJU7flWMCQ==
+
 "@coorpacademy/update-node@^3.16.0":
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/@coorpacademy/update-node/-/update-node-3.16.0.tgz#be0e0fb98733fd670a2d519c141363d586430443"


### PR DESCRIPTION
On mobile, the fetch content stuff is done when mounting the player, so the engine knows how to get the next content, that way we don't need to do it when validating the answer.

This goes with https://github.com/CoorpAcademy/mobile/pull/637

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing
