### PR TITLE
[Teams] Improve data name of popin's children

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/teams-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/teams-popin/index.js
@@ -37,15 +37,15 @@ const TeamsPopin = props => {
       ) : (
         <div className={style.popin}>
           {Icon}
-          <div className={style.header} data-name="popin-header">
+          <div className={style.header} data-name={`popin-header-${type}`}>
             {header}
           </div>
-          <p className={style.content} data-name="popin-content">
+          <p className={style.content} data-name={`popin-content-${type}`}>
             {content}
           </p>
           {buttonLabel && onButtonClick ? (
             <div className={style.buttonContainer}>
-              <Cta submitValue={buttonLabel} onClick={onButtonClick} />
+              <Cta submitValue={buttonLabel} onClick={onButtonClick} name={`popin-cta-${type}`} />
             </div>
           ) : null}
         </div>
@@ -55,8 +55,8 @@ const TeamsPopin = props => {
 };
 
 TeamsPopin.propTypes = {
-  header: PropTypes.string.isRequired,
-  content: PropTypes.string.isRequired,
+  header: PropTypes.string,
+  content: PropTypes.string,
   buttonLabel: PropTypes.string,
   onButtonClick: PropTypes.func,
   type: PropTypes.oneOf(['login', 'reload', 'loginFailed', 'addressError', 'wrong']),

--- a/packages/@coorpacademy-components/src/molecule/teams-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/teams-popin/index.js
@@ -32,7 +32,7 @@ const TeamsPopin = props => {
     <div className={style.background}>
       {isLoading ? (
         <div className={style.loader}>
-          <Loader data-name="teams-pipin-loader" />
+          <Loader data-name="teams-popin-loader" />
         </div>
       ) : (
         <div className={style.popin}>


### PR DESCRIPTION
- Improve data name of popin children 
- Make header and content optional ( to now get warnings when we are loading data  => the isLoading is true )

![Capture d’écran 2021-01-04 à 00 38 53](https://user-images.githubusercontent.com/58167920/103491657-e81e7a00-4e25-11eb-96cc-758bb7a45fad.png)

  
**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
