### PR TITLE
Add a rectangular prop && fullWidth option prop (for certifications "See More" button revamp)

### DIFF
--- a/packages/@coorpacademy-components/src/atom/cta/index.js
+++ b/packages/@coorpacademy-components/src/atom/cta/index.js
@@ -20,7 +20,9 @@ class CTA extends React.Component {
     secondary: PropTypes.bool,
     small: PropTypes.bool,
     className: PropTypes.string,
-    logout: PropTypes.bool
+    logout: PropTypes.bool,
+    rectangular: PropTypes.bool,
+    fullWidth: PropTypes.bool
   };
 
   static contextTypes = {
@@ -102,7 +104,9 @@ class CTA extends React.Component {
       secondary = false,
       onClick,
       className,
-      logout = false
+      logout = false,
+      rectangular = false,
+      fullWidth = false
     } = this.props;
 
     return (
@@ -119,6 +123,8 @@ class CTA extends React.Component {
           light ? style.lightButton : null,
           secondary ? style.secondaryButton : null,
           logout ? style.logoutButton : null,
+          rectangular ? style.rectangularButton : null,
+          fullWidth ? style.fullWidth : null,
           className
         )}
         data-name={ctaName || 'cta'}

--- a/packages/@coorpacademy-components/src/atom/cta/style.css
+++ b/packages/@coorpacademy-components/src/atom/cta/style.css
@@ -110,3 +110,13 @@
   stroke-width: 2px;
   color: negative;
 }
+
+.rectangularButton {
+  composes: button;
+  border-radius: 4px;
+}
+
+.fullWidth {
+  width: 100%;
+  text-align: center;
+}

--- a/packages/@coorpacademy-components/src/atom/cta/test/fixtures/rectangular-secondary-fullwidth.js
+++ b/packages/@coorpacademy-components/src/atom/cta/test/fixtures/rectangular-secondary-fullwidth.js
@@ -1,0 +1,10 @@
+import primary from './primary';
+
+export default {
+  props: {
+    ...primary.props,
+    rectangular: true,
+    secondary: true,
+    fullWidth: true
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/cta/test/fixtures/rectangular-secondary.js
+++ b/packages/@coorpacademy-components/src/atom/cta/test/fixtures/rectangular-secondary.js
@@ -1,0 +1,9 @@
+import primary from './primary';
+
+export default {
+  props: {
+    ...primary.props,
+    rectangular: true,
+    secondary: true
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/cta/test/fixtures/rectangular.js
+++ b/packages/@coorpacademy-components/src/atom/cta/test/fixtures/rectangular.js
@@ -1,0 +1,8 @@
+import primary from './primary';
+
+export default {
+  props: {
+    ...primary.props,
+    rectangular: true
+  }
+};

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -191,6 +191,9 @@ import AtomCtaFixtureLogout from '../src/atom/cta/test/fixtures/logout';
 import AtomCtaFixtureNoSubmitValue from '../src/atom/cta/test/fixtures/no-submit-value';
 import AtomCtaFixturePrimarySmall from '../src/atom/cta/test/fixtures/primary-small';
 import AtomCtaFixturePrimary from '../src/atom/cta/test/fixtures/primary';
+import AtomCtaFixtureRectangularSecondaryFullwidth from '../src/atom/cta/test/fixtures/rectangular-secondary-fullwidth';
+import AtomCtaFixtureRectangularSecondary from '../src/atom/cta/test/fixtures/rectangular-secondary';
+import AtomCtaFixtureRectangular from '../src/atom/cta/test/fixtures/rectangular';
 import AtomCtaFixtureSecondarySmall from '../src/atom/cta/test/fixtures/secondary-small';
 import AtomCtaFixtureSecondary from '../src/atom/cta/test/fixtures/secondary';
 import AtomDifficultyLevelFixtureEasy from '../src/atom/difficulty-level/test/fixtures/easy';
@@ -1133,6 +1136,9 @@ export const fixtures = {
       NoSubmitValue: AtomCtaFixtureNoSubmitValue,
       PrimarySmall: AtomCtaFixturePrimarySmall,
       Primary: AtomCtaFixturePrimary,
+      RectangularSecondaryFullwidth: AtomCtaFixtureRectangularSecondaryFullwidth,
+      RectangularSecondary: AtomCtaFixtureRectangularSecondary,
+      Rectangular: AtomCtaFixtureRectangular,
       SecondarySmall: AtomCtaFixtureSecondarySmall,
       Secondary: AtomCtaFixtureSecondary
     },


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- Adds a rectangular prop && fullWidth option prop (for certifications "See More" button revamp)

**Result and observation**
Rectangular:
<img width="143" alt="Screenshot 2021-03-03 at 13 58 57" src="https://user-images.githubusercontent.com/33550261/109809539-af81fd80-7c28-11eb-8318-12b85e400555.png">

Fullwidth (+ rectangular):
![Screenshot 2021-03-03 at 13 58 46](https://user-images.githubusercontent.com/33550261/109809494-a2fda500-7c28-11eb-88d8-edcdaf09d2df.png)


<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing
