### PR TITLE
Fix Get the App coorp's logo size and padding

### DIFF
--- a/packages/@coorpacademy-components/src/organism/get-the-app/index.js
+++ b/packages/@coorpacademy-components/src/organism/get-the-app/index.js
@@ -142,7 +142,7 @@ const GetTheApp = (props, context) => {
   return (
     <div className={style.container}>
       <div className={style.coorpAppLogoWrapper}>
-        <CoorpAppLogo height={64} width={250} className={style.coorpAppLogo} />
+        <CoorpAppLogo height={51} width={250} className={style.coorpAppLogo} />
       </div>
       <div className={style.store}>
         <Header {...storeStep} />

--- a/packages/@coorpacademy-components/src/organism/get-the-app/index.js
+++ b/packages/@coorpacademy-components/src/organism/get-the-app/index.js
@@ -142,7 +142,7 @@ const GetTheApp = (props, context) => {
   return (
     <div className={style.container}>
       <div className={style.coorpAppLogoWrapper}>
-        <CoorpAppLogo height={64} width={305} className={style.coorpAppLogo} />
+        <CoorpAppLogo height={64} width={250} className={style.coorpAppLogo} />
       </div>
       <div className={style.store}>
         <Header {...storeStep} />

--- a/packages/@coorpacademy-components/src/organism/get-the-app/style.css
+++ b/packages/@coorpacademy-components/src/organism/get-the-app/style.css
@@ -29,6 +29,7 @@
   width: 100%;
   height: 100%;
   background-color: xtraLightGrey;
+  padding-top: 32px;
 }
 
 .coorpAppLogo {


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
- Fixes Get the App coorp's logo size and padding.


**Result and observation**

![Screenshot 2021-03-08 at 10 50 43](https://user-images.githubusercontent.com/33550261/110304673-2984fe80-7ffc-11eb-99b0-8e1a9ced6a00.png)
![Screenshot 2021-03-08 at 10 47 30](https://user-images.githubusercontent.com/33550261/110304747-3ace0b00-7ffc-11eb-8fee-ee322f24205d.png)




<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
