### PR TITLE
[MoocHeader] add color to header menu items

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -80,6 +80,7 @@ class MoocHeader extends React.Component {
         title: PropTypes.string,
         name: PropTypes.string,
         type: PropTypes.oneOf(['select', 'switch', 'link']),
+        color: PropTypes.string,
         options: PropTypes.shape({
           href: PropTypes.string,
           onChange: PropTypes.func,
@@ -383,7 +384,7 @@ class MoocHeader extends React.Component {
     if (settings) {
       const settingsElements = settings.map((setting, index) => {
         let settingView = null;
-        const {options, type, title, name: settingName = index} = setting;
+        const {options, type, title, name: settingName = index, color} = setting;
 
         switch (type) {
           case 'link': {
@@ -395,6 +396,9 @@ class MoocHeader extends React.Component {
                   skinHover
                   onClick={this.handleLinkClick}
                   target={options.target || null}
+                  style={{
+                    color
+                  }}
                 >
                   {title}
                 </Link>

--- a/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
@@ -128,6 +128,7 @@ export default {
       {
         title: 'Se déconnecter',
         type: 'link',
+        color: '#f73f52',
         options: {
           href: 'https://google.fr'
         }


### PR DESCRIPTION
Add color to header menu items , in order to set logout link color to red 


![Capture d’écran 2021-03-18 à 11 40 34](https://user-images.githubusercontent.com/58167920/111614219-a031b100-87df-11eb-8d87-976b259f61d0.png)

[Ticket](https://trello.com/c/OFTN0QbK)

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
