### PR TITLE
fix battles page link badge

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -287,7 +287,7 @@ class MoocHeader extends React.Component {
         <div className={search.value || isFocus ? style.noItems : style.items}>
           {displayedPages}
           <div className={style.more}>
-            <div className={style.currentOption} aria-haspopup="true" data-name="page-more">
+            <div className={style.currentOption} aria-haspopup="true" data-name="item-more">
               {moreLabel}
               <ArrowDown color={mediumColor} className={style.caret} />
             </div>

--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -224,7 +224,7 @@ class MoocHeader extends React.Component {
 
         const pageBadge =
           page.counter > 0 ? (
-            <Link data-name="page-badge" className={style.pageBadge}>
+            <Link href={page.href} data-name="page-badge" className={style.pageBadge}>
               {page.counter}
             </Link>
           ) : null;

--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -222,8 +222,12 @@ class MoocHeader extends React.Component {
             }
           : null;
 
-        const battlesView =
-          page.counter > 0 ? <div className={style.battlesCounter}>{page.counter}</div> : null;
+        const pageBadge =
+          page.counter > 0 ? (
+            <Link data-name="page-badge" className={style.pageBadge}>
+              {page.counter}
+            </Link>
+          ) : null;
 
         const {name: pageName = index} = page;
 
@@ -241,7 +245,7 @@ class MoocHeader extends React.Component {
             }}
           >
             {page.title}
-            {battlesView}
+            {pageBadge}
             <span
               className={style.bar}
               style={{

--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -192,7 +192,7 @@ class MoocHeader extends React.Component {
 
   render() {
     if (isEmpty(this.props)) return null;
-    const {logo = {}, pages, settings, user, links, search} = this.props;
+    const {logo = {}, pages: items, settings, user, links, search} = this.props;
     const {isFocus, isSettingsOpen, isMenuOpen} = this.state;
     const {translate, skin} = this.context;
 
@@ -214,37 +214,37 @@ class MoocHeader extends React.Component {
     const white = get('common.white', skin);
     const iconWrapperStyle = {backgroundColor: primaryColor};
 
-    if (pages) {
-      const displayedPages = pages.displayed.map((page, index) => {
-        const activeColor = page.selected
+    if (items) {
+      const displayedPages = items.displayed.map((item, index) => {
+        const activeColor = item.selected
           ? {
               color: primaryColor
             }
           : null;
 
         const pageBadge =
-          page.counter > 0 ? (
-            <Link href={page.href} data-name="page-badge" className={style.pageBadge}>
-              {page.counter}
+          item.counter > 0 ? (
+            <Link href={item.href} data-name="item-badge" className={style.itemBadge}>
+              {item.counter}
             </Link>
           ) : null;
 
-        const {name: pageName = index} = page;
+        const {name: itemName = index} = item;
 
         return (
           <Link
-            key={pageName}
-            data-name={`page-${pageName}`}
-            href={page.href}
-            className={page.selected ? style.activePage : style.page}
+            key={itemName}
+            data-name={`item-${itemName}`}
+            href={item.href}
+            className={item.selected ? style.activePage : style.item}
             skinHover
             onClick={this.handleLinkClick}
-            target={page.target || null}
+            target={item.target || null}
             style={{
               ...activeColor
             }}
           >
-            {page.title}
+            {item.title}
             {pageBadge}
             <span
               className={style.bar}
@@ -256,35 +256,35 @@ class MoocHeader extends React.Component {
         );
       });
 
-      const optionsView = pages.more.map((page, index) => {
-        const activeColor = page.selected
+      const optionsView = items.more.map((item, index) => {
+        const activeColor = item.selected
           ? {
               color: primaryColor
             }
           : null;
 
-        const {name: pageName = index} = page;
+        const {name: itemName = index} = item;
 
         return (
           <Link
-            href={page.href}
-            key={pageName}
+            href={item.href}
+            key={itemName}
             className={style.option}
-            data-name={`page-more-${pageName}`}
-            target={page.target || null}
+            data-name={`item-more-${itemName}`}
+            target={item.target || null}
             onClick={this.handleLinkClick}
             skinHover
             style={{
               ...activeColor
             }}
           >
-            {page.title}
+            {item.title}
           </Link>
         );
       });
 
       pagesView = (
-        <div className={search.value || isFocus ? style.noPages : style.pages}>
+        <div className={search.value || isFocus ? style.noItems : style.items}>
           {displayedPages}
           <div className={style.more}>
             <div className={style.currentOption} aria-haspopup="true" data-name="page-more">

--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -193,21 +193,6 @@
   width: 100%;
 }
 
-.battlesCounter {
-  position: absolute;
-  top: 15px;
-  right: 0;
-  background-color: battle;
-  font-family: 'Open Sans';
-  font-weight: 700;
-  font-size: 10px;
-  line-height: 16px;
-  color: black;
-  border-radius: 8px;
-  padding: 0 5px;
-  pointer-events: none;
-}
-
 .more {
   composes: options;
 }
@@ -303,7 +288,17 @@
   padding: 0 5px;
 }
 
+.pageBadge {
+  composes: notifications;
+  top: 10px;
+}
+
 .notifications:hover {
+  transform: scale(1.3);
+  transition: all 0.2s cubic-bezier(0.68, -0.55, 0.27, 1.55);
+}
+
+.pageBadge:hover {
   transform: scale(1.3);
   transition: all 0.2s cubic-bezier(0.68, -0.55, 0.27, 1.55);
 }
@@ -623,7 +618,7 @@
     line-height: 40px;
   }
 
-  .battlesCounter {
+  .pageBadge {
     position: relative;
     margin-top: -15px;
     right: auto;

--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -40,7 +40,7 @@
   background-color: white;
 }
 
-.noPages {
+.noItems {
   display: none;
 }
 
@@ -92,7 +92,7 @@
   align-items: center;
 }
 
-.pages .currentOption {
+.items .currentOption {
   padding: 0 0 0 20px;
 }
 
@@ -156,7 +156,7 @@
   opacity: 1;
 }
 
-.page {
+.item {
   position: relative;
   padding: 0 15px;
   cursor: pointer;
@@ -170,10 +170,10 @@
 }
 
 .activePage {
-  composes: page;
+  composes: item;
 }
 
-.page .bar {
+.item .bar {
   background-color: brand;
   height: 3px;
   width: 0;
@@ -188,7 +188,7 @@
   width: 100%;
 }
 
-.page:hover .bar {
+.item:hover .bar {
   left: 0;
   width: 100%;
 }
@@ -288,17 +288,13 @@
   padding: 0 5px;
 }
 
-.pageBadge {
+.itemBadge {
   composes: notifications;
   top: 10px;
 }
 
-.notifications:hover {
-  transform: scale(1.3);
-  transition: all 0.2s cubic-bezier(0.68, -0.55, 0.27, 1.55);
-}
-
-.pageBadge:hover {
+.notifications:hover,
+.itemBadge:hover {
   transform: scale(1.3);
   transition: all 0.2s cubic-bezier(0.68, -0.55, 0.27, 1.55);
 }
@@ -576,7 +572,7 @@
     position: absolute;
   }
 
-  .pages {
+  .items {
     width: 100%;
     padding: 10px 0;
     margin: 10px 0;
@@ -588,20 +584,20 @@
     flex-shrink: 0;
   }
 
-  .pages .page {
+  .items .item {
     line-height: 40px;
     padding: 0;
   }
 
-  .page .bar {
+  .item .bar {
     display: none;
   }
 
-  .pages .currentOption {
+  .items .currentOption {
     display: none;
   }
 
-  .pages .optionsGroup {
+  .items .optionsGroup {
     display: block;
     position: relative;
     top: 0;
@@ -613,12 +609,12 @@
     background-color: transparent;
   }
 
-  .pages .option {
+  .items .option {
     padding: 0;
     line-height: 40px;
   }
 
-  .pageBadge {
+  .itemBadge {
     position: relative;
     margin-top: -15px;
     right: auto;

--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -147,7 +147,7 @@
   height: 60px;
 }
 
-.pages {
+.items {
   height: 100%;
   border-right: 1px solid light;
   padding: 0 10px;


### PR DESCRIPTION
apply user notification style to the battles page link ( color, size ans hover style) 

Before 


![image](https://user-images.githubusercontent.com/58167920/112182583-b4b9e300-8bfd-11eb-9733-ada76119dd40.png)


After
![battles-notif-F](https://user-images.githubusercontent.com/58167920/112182390-889e6200-8bfd-11eb-80ec-f7dcf8b0e544.gif)

[ticket](https://trello.com/c/fNbKLNJk)
**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
