### PR TITLE
fix: logo aspect ratio on responsive devices

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -539,8 +539,9 @@
   }
 
   .logoMobile img {
-    height: 100%;
+    height: auto;
     max-height: 50px;
+    width: auto;
     max-width: 100px;
     display: block;
   }


### PR DESCRIPTION
### Before
<img width="593" alt="Capture d’écran 2021-03-25 à 10 58 17" src="https://user-images.githubusercontent.com/23306911/112454552-193d8500-8d59-11eb-9b6f-abf0a4a2325d.png">

### After

<img width="607" alt="Capture d’écran 2021-03-25 à 10 58 10" src="https://user-images.githubusercontent.com/23306911/112454583-2195c000-8d59-11eb-93bb-bfcbc8da2434.png">

