### PR TITLE
[Setup] Allow a set of image types (or all) for ImageUpload

### DIFF
--- a/packages/@coorpacademy-components/src/atom/image-upload/index.js
+++ b/packages/@coorpacademy-components/src/atom/image-upload/index.js
@@ -1,6 +1,6 @@
 import React, {useMemo} from 'react';
 import PropTypes from 'prop-types';
-import {join} from 'lodash/fp';
+import {join, map, pipe} from 'lodash/fp';
 import DragAndDrop from '../drag-and-drop';
 import {ImagePropType} from '../../util/proptypes';
 import style from './style.css';
@@ -16,7 +16,7 @@ const ImageUpload = ({
   onChange,
   onReset = null,
   name,
-  imageTypes
+  imageTypes = ['*']
 }) => {
   const handleReset = onReset
     ? useMemo(
@@ -27,7 +27,10 @@ const ImageUpload = ({
         [onReset]
       )
     : null;
-  const acceptedImages = imageTypes ? join(',image/', imageTypes) : '*';
+  const acceptedImages = pipe(
+    map(t => `image/${t}`),
+    join(',')
+  )(imageTypes);
   return (
     <DragAndDrop
       title={title}
@@ -44,7 +47,7 @@ const ImageUpload = ({
           <input
             type="file"
             name={name}
-            accept={`image/${acceptedImages}`}
+            accept={acceptedImages}
             disabled={loading}
             className={style.input}
             onChange={onChange}

--- a/packages/@coorpacademy-components/src/atom/image-upload/index.js
+++ b/packages/@coorpacademy-components/src/atom/image-upload/index.js
@@ -1,6 +1,8 @@
 import React, {useMemo} from 'react';
 import PropTypes from 'prop-types';
+import {join} from 'lodash/fp';
 import DragAndDrop from '../drag-and-drop';
+import {ImagePropType} from '../../util/proptypes';
 import style from './style.css';
 
 const ImageUpload = ({
@@ -14,7 +16,7 @@ const ImageUpload = ({
   onChange,
   onReset = null,
   name,
-  imageType = '*'
+  imageTypes
 }) => {
   const handleReset = onReset
     ? useMemo(
@@ -25,6 +27,7 @@ const ImageUpload = ({
         [onReset]
       )
     : null;
+  const acceptedImages = imageTypes ? join(',image/', imageTypes) : '*';
   return (
     <DragAndDrop
       title={title}
@@ -41,7 +44,7 @@ const ImageUpload = ({
           <input
             type="file"
             name={name}
-            accept={`image/${imageType}`}
+            accept={`image/${acceptedImages}`}
             disabled={loading}
             className={style.input}
             onChange={onChange}
@@ -60,7 +63,7 @@ ImageUpload.propTypes = {
   name: PropTypes.string,
   onChange: PropTypes.func,
   onReset: PropTypes.func,
-  imageType: PropTypes.string
+  imageTypes: PropTypes.arrayOf(ImagePropType)
 };
 
 export default ImageUpload;

--- a/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/desktop-reset-description-multiple.js
+++ b/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/desktop-reset-description-multiple.js
@@ -1,0 +1,10 @@
+import DesktopReset from './desktop-reset-description';
+
+const {props} = DesktopReset;
+
+export default {
+  props: {
+    ...props,
+    imageTypes: ['png', 'jpg', 'svg']
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/desktop-reset-description-only-png.js
+++ b/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/desktop-reset-description-only-png.js
@@ -5,6 +5,10 @@ const {props} = DesktopReset;
 export default {
   props: {
     ...props,
-    imageType: 'png'
+    previewContent: {
+      type: 'image',
+      src: 'https://static.coorpacademy.com/content/up/raw/batman.png'
+    },
+    imageTypes: ['png']
   }
 };

--- a/packages/@coorpacademy-components/src/util/proptypes.js
+++ b/packages/@coorpacademy-components/src/util/proptypes.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import includes from 'lodash/fp/includes';
 import stringMatching from 'extended-proptypes/lib/validators/stringMatching';
 
 export ColorPropType from 'extended-proptypes/lib/validators/color';
@@ -12,3 +13,10 @@ const PATH_REGEXP = /^\/([-a-zA-Z0-9@:%_\\+.~#?&//=]*)$/;
 export const PathPropType = stringMatching(PATH_REGEXP);
 
 export const SrcPropType = PropTypes.oneOfType([UrlPropType, PathPropType]);
+
+export const ImagePropType = (propValue, key, componentName) => {
+  if (includes(propValue[key], ['jpg', 'png', 'svg'])) return;
+  return new Error(
+    `Invalid prop value: ${propValue[key]}, at component: ${componentName}. Expected a valid image type: jpg, png or svg.`
+  );
+};

--- a/packages/@coorpacademy-components/src/util/test/proptypes.js
+++ b/packages/@coorpacademy-components/src/util/test/proptypes.js
@@ -1,7 +1,14 @@
 import PropTypes from 'prop-types';
 import {forEach, set, split, map, concat} from 'lodash/fp';
 import test from 'ava';
-import {ColorPropType, HexPropType, UrlPropType, PathPropType, SrcPropType} from '../proptypes';
+import {
+  ColorPropType,
+  HexPropType,
+  ImagePropType,
+  UrlPropType,
+  PathPropType,
+  SrcPropType
+} from '../proptypes';
 
 const validMacro = (t, proptype, values) => {
   forEach(value => {
@@ -70,3 +77,23 @@ test('SrcPropType should pass when valid source is passed', validMacro, SrcPropT
   'https://static.coorpacademy.com/content/digital/raw/login-bg-1491236164055.jpg'
 ]);
 test('SrcPropType should throw error when incorrect source is passed', failMacro, SrcPropType, [0]);
+
+test('ImagePropType should pass when correct image type is passed', validMacro, ImagePropType, [
+  'svg',
+  'jpg',
+  'png'
+]);
+
+test(
+  'ImagePropType should throw error when incorrect image type is passed: misspelled',
+  failMacro,
+  ImagePropType,
+  ['sgv']
+);
+
+test(
+  'ImagePropType should throw error when incorrect image type is passed: not included',
+  failMacro,
+  ImagePropType,
+  ['pdf', 'another']
+);

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -207,6 +207,7 @@ import AtomDragAndDropFixtureWithChildren from '../src/atom/drag-and-drop/test/f
 import AtomDragAndDropFixtureWithImageReset from '../src/atom/drag-and-drop/test/fixtures/with-image-reset';
 import AtomDragAndDropFixtureWithImage from '../src/atom/drag-and-drop/test/fixtures/with-image';
 import AtomDragAndDropFixtureWithVideo from '../src/atom/drag-and-drop/test/fixtures/with-video';
+import AtomImageUploadFixtureDesktopResetDescriptionMultiple from '../src/atom/image-upload/test/fixtures/desktop-reset-description-multiple';
 import AtomImageUploadFixtureDesktopResetDescriptionOnlyPng from '../src/atom/image-upload/test/fixtures/desktop-reset-description-only-png';
 import AtomImageUploadFixtureDesktopResetDescription from '../src/atom/image-upload/test/fixtures/desktop-reset-description';
 import AtomImageUploadFixtureDesktopResetNoDescription from '../src/atom/image-upload/test/fixtures/desktop-reset-no-description';
@@ -1164,6 +1165,7 @@ export const fixtures = {
       WithVideo: AtomDragAndDropFixtureWithVideo
     },
     AtomImageUpload: {
+      DesktopResetDescriptionMultiple: AtomImageUploadFixtureDesktopResetDescriptionMultiple,
       DesktopResetDescriptionOnlyPng: AtomImageUploadFixtureDesktopResetDescriptionOnlyPng,
       DesktopResetDescription: AtomImageUploadFixtureDesktopResetDescription,
       DesktopResetNoDescription: AtomImageUploadFixtureDesktopResetNoDescription,


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- Allow a set of image types (or all) for ImageUpload

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

![Kapture 2021-03-31 at 19 54 48](https://user-images.githubusercontent.com/33550261/113189025-09430b00-925b-11eb-8dbc-d934c89f721c.gif)


<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
