### PR TITLE
Fix svg mediatype for ImageUpload (to svg+xml)

### DIFF
--- a/packages/@coorpacademy-components/src/atom/image-upload/index.js
+++ b/packages/@coorpacademy-components/src/atom/image-upload/index.js
@@ -16,6 +16,7 @@ const ImageUpload = ({
   onChange,
   onReset = null,
   name,
+  // See ImagePropType for accepted values
   imageTypes = ['*']
 }) => {
   const handleReset = onReset

--- a/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/desktop-reset-description-multiple.js
+++ b/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/desktop-reset-description-multiple.js
@@ -5,6 +5,6 @@ const {props} = DesktopReset;
 export default {
   props: {
     ...props,
-    imageTypes: ['png', 'jpg', 'svg']
+    imageTypes: ['png', 'jpg', 'svg+xml']
   }
 };

--- a/packages/@coorpacademy-components/src/util/proptypes.js
+++ b/packages/@coorpacademy-components/src/util/proptypes.js
@@ -15,8 +15,8 @@ export const PathPropType = stringMatching(PATH_REGEXP);
 export const SrcPropType = PropTypes.oneOfType([UrlPropType, PathPropType]);
 
 export const ImagePropType = (propValue, key, componentName) => {
-  if (includes(propValue[key], ['jpg', 'png', 'svg'])) return;
+  if (includes(propValue[key], ['jpg', 'png', 'svg+xml'])) return;
   return new Error(
-    `Invalid prop value: ${propValue[key]}, at component: ${componentName}. Expected a valid image type: jpg, png or svg.`
+    `Invalid prop value: ${propValue[key]}, at component: ${componentName}. Expected a valid image type: jpg, png or svg+xml.`
   );
 };

--- a/packages/@coorpacademy-components/src/util/test/proptypes.js
+++ b/packages/@coorpacademy-components/src/util/test/proptypes.js
@@ -79,7 +79,7 @@ test('SrcPropType should pass when valid source is passed', validMacro, SrcPropT
 test('SrcPropType should throw error when incorrect source is passed', failMacro, SrcPropType, [0]);
 
 test('ImagePropType should pass when correct image type is passed', validMacro, ImagePropType, [
-  'svg',
+  'svg+xml',
   'jpg',
   'png'
 ]);
@@ -88,7 +88,7 @@ test(
   'ImagePropType should throw error when incorrect image type is passed: misspelled',
   failMacro,
   ImagePropType,
-  ['sgv']
+  ['sgv+xml']
 );
 
 test(
@@ -96,4 +96,11 @@ test(
   failMacro,
   ImagePropType,
   ['pdf', 'another']
+);
+
+test(
+  'ImagePropType should throw error when incorrect image type is passed even if the rest are ok',
+  failMacro,
+  ImagePropType,
+  ['jpg', 'pdf']
 );

--- a/packages/@coorpacademy-components/src/util/test/proptypes.js
+++ b/packages/@coorpacademy-components/src/util/test/proptypes.js
@@ -97,10 +97,3 @@ test(
   ImagePropType,
   ['pdf', 'another']
 );
-
-test(
-  'ImagePropType should throw error when incorrect image type is passed even if the rest are ok',
-  failMacro,
-  ImagePropType,
-  ['jpg', 'pdf']
-);


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- Fixes svg mediatype for ImageUpload to svg+xml

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
