### PR TITLE
Audio-learning

### DIFF
--- a/packages/@coorpacademy-components/src/atom/resource-miniature/index.js
+++ b/packages/@coorpacademy-components/src/atom/resource-miniature/index.js
@@ -3,33 +3,33 @@ import PropTypes from 'prop-types';
 import {get, keys} from 'lodash/fp';
 import {
   NovaSolidAudioAudioControlPlay as PlayIcon,
-  NovaLineFilesOfficeFileOfficePdf as PDFIcon
+  NovaLineFilesOfficeFileOfficePdf as PDFIcon,
+  NovaCompositionCoorpacademyMicrophone as PodcastIcon
 } from '@coorpacademy/nova-icons';
 import classnames from 'classnames';
 import Provider from '../provider';
 import {innerHTML} from '../label/style.css';
 import style from './style.css';
 
-const STYLE_TYPES = {
-  pdf: style.pdf,
-  video: style.video
+const TYPES = {
+  pdf: {style: style.pdf, icon: PDFIcon},
+  audio: {style: style.audio, icon: PodcastIcon},
+  video: {style: style.video, icon: PlayIcon}
 };
 
 const ResourceMiniature = (props, context) => {
   const {skin} = context;
   const {type, description, poster, onClick: handleOnClick, selected = false} = props;
   const descriptionClassName = selected ? style.selectedDescription : style.description;
-  const dark = get('common.dark', skin);
   const white = get('common.white', skin);
   const primary = get('common.primary', skin);
   const posterOutlineColor = selected ? primary : white;
-
+  const Icon = TYPES[type].icon;
   return (
-    <div className={STYLE_TYPES[type]} onClick={handleOnClick} data-type={type}>
+    <div className={TYPES[type].style} onClick={handleOnClick} data-type={type}>
       <div className={style.posterWrapper} style={{borderColor: posterOutlineColor}}>
         <div className={style.poster} style={{backgroundImage: `url(${poster})`}} />
-        {type === 'video' && !selected ? <PlayIcon color={white} className={style.icon} /> : null}
-        {type === 'pdf' ? <PDFIcon className={style.icon} color={dark} /> : null}
+        {!selected ? <Icon color={white} className={style.icon} /> : null}
       </div>
       <div
         className={classnames(descriptionClassName, innerHTML)}
@@ -41,7 +41,7 @@ const ResourceMiniature = (props, context) => {
 };
 
 ResourceMiniature.propTypes = {
-  type: PropTypes.oneOf(keys(STYLE_TYPES)),
+  type: PropTypes.oneOf(keys(TYPES)),
   selected: PropTypes.bool,
   description: PropTypes.string,
   poster: PropTypes.string,

--- a/packages/@coorpacademy-components/src/atom/resource-miniature/style.css
+++ b/packages/@coorpacademy-components/src/atom/resource-miniature/style.css
@@ -1,5 +1,5 @@
 @value colors: "../../variables/colors.css";
-@value light from colors;
+@value lightMediumGray from colors;
 @value white from colors;
 @value breakpoints: "../../variables/breakpoints.css";
 @value mobile from breakpoints;
@@ -15,11 +15,9 @@
   align-items: center;
 }
 
-.video {
-  composes: resource;
-}
-
-.pdf {
+.video,
+.pdf,
+.audio {
   composes: resource;
 }
 
@@ -31,7 +29,7 @@
   width: 70px;
   height: 45px;
   border: 1px solid ;
-  box-shadow: 1px 1px 3px light;
+  box-shadow: 1px 1px 3px lightMediumGray;
 }
 
 .poster {
@@ -40,10 +38,7 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-}
-
-.pdf .poster {
-  background-color: light;
+  background-color: lightMediumGray;
 }
 
 .icon {

--- a/packages/@coorpacademy-components/src/atom/resource-miniature/test/fixtures/audio.js
+++ b/packages/@coorpacademy-components/src/atom/resource-miniature/test/fixtures/audio.js
@@ -1,0 +1,10 @@
+export default {
+  props: {
+    type: 'audio',
+    description: "Chapitre 1. Diagramme du l'hiérarchie du contenu.",
+    mediaUrl:
+      '//static.coorpacademy.com/content/CoorpAcademy/content-bnpp/cockpit-letsgetdigital-migration/raw/sample-1618502603227.aac',
+    poster:
+      '//static.coorpacademy.com/content/CoorpAcademy/content-partnerships-svp/cockpit-partner-svp/poster/poster-1480426784168.jpg'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/answer/index.js
+++ b/packages/@coorpacademy-components/src/molecule/answer/index.js
@@ -9,10 +9,12 @@ import Qcm from '../questions/qcm';
 import QcmGraphic from '../questions/qcm-graphic';
 import QuestionRange from '../questions/question-range';
 import Template from '../questions/template';
+import Audio from '../audio';
 import style from './style.css';
 
 export const TYPE_IMAGE = 'img';
 export const TYPE_VIDEO = 'video';
+export const TYPE_AUDIO = 'audio';
 
 const MediaView = ({media}) => {
   const {videoId, type, ...childProps} = media;
@@ -32,6 +34,12 @@ const MediaView = ({media}) => {
           <VideoPlayer {...omit('id', childProps)} id={videoId} height="100%" width="100%" />
         </div>
       );
+    case TYPE_AUDIO:
+      return (
+        <div className={style.audio}>
+          <Audio {...omit('id', childProps)} height="100%" width="100%" />
+        </div>
+      );
     default:
       return null;
   }
@@ -49,8 +57,13 @@ const imgPropType = PropTypes.shape({
   url: PropTypes.string.isRequired
 });
 
+const audioPropType = PropTypes.shape({
+  type: isType(TYPE_AUDIO).isRequired,
+  mediaUrl: PropTypes.string.isRequired
+});
+
 MediaView.propTypes = {
-  media: PropTypes.oneOfType([videoPropType, imgPropType])
+  media: PropTypes.oneOfType([videoPropType, imgPropType, audioPropType])
 };
 
 const Answer = props => {

--- a/packages/@coorpacademy-components/src/molecule/answer/style.css
+++ b/packages/@coorpacademy-components/src/molecule/answer/style.css
@@ -28,6 +28,14 @@
   justify-content: center;
   margin-bottom: 30px;
 }
+.audio {
+  height: 180px;
+  width: 360px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 30px;
+}
 
 @media mobile {
   .wrapper {

--- a/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/audio.js
+++ b/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/audio.js
@@ -1,0 +1,15 @@
+import FreeText from '../../../questions/free-text/test/fixtures/default';
+
+export default {
+  props: {
+    model: {
+      ...FreeText.props,
+      type: 'freeText'
+    },
+    media: {
+      type: 'audio',
+      mediaUrl:
+        'https://static.coorpacademy.com/content/CoorpAcademy/content-bnpp/cockpit-letsgetdigital-migration/raw/sample-1618502603227.aac'
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/qcm-short-audio.js
+++ b/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/qcm-short-audio.js
@@ -1,0 +1,28 @@
+import Qcm from '../../../questions/qcm/test/fixtures/short-answers';
+
+const answerProps = Qcm.props;
+
+export default {
+  props: {
+    model: {
+      ...answerProps,
+      type: 'qcm'
+    },
+    media: {
+      type: 'audio',
+      mimeType: 'audio/acc',
+      poster: 'https://picsum.photos/500/300',
+      mediaUrl:
+        '//static.coorpacademy.com/content/CoorpAcademy/content-bnpp/cockpit-letsgetdigital-migration/raw/sample-1618502603227.aac',
+      _id: '590b9be24f7b862e0046e577',
+      subtitles: [],
+      posters: [],
+      src: [],
+      onClick: () => {},
+      onPlay: () => console.log('play'),
+      onPause: () => console.log('pause'),
+      onResume: () => console.log('resume'),
+      onEnded: () => console.log('end')
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/audio/index.js
+++ b/packages/@coorpacademy-components/src/molecule/audio/index.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import {get} from 'lodash/fp';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {NovaCompositionCoorpacademyMicrophone as PodcastIcon} from '@coorpacademy/nova-icons';
+import Provider from '../../atom/provider';
+import {innerHTML} from '../../atom/label/style.css';
+import style from './style.css';
+
+class Audio extends React.Component {
+  static propTypes = {
+    description: PropTypes.string,
+    mediaUrl: PropTypes.string,
+    poster: PropTypes.string,
+    onPlay: PropTypes.func
+  };
+
+  static contextTypes = {
+    skin: Provider.childContextTypes.skin
+  };
+
+  constructor(props, context) {
+    super(props, context);
+    this.handlePlay = this.handlePlay.bind(this);
+    this.audioElement = null;
+    this.setAudio = this.setAudio.bind(this);
+  }
+
+  shouldComponentUpdate(nextProps) {
+    const {mediaUrl} = this.props;
+    return nextProps.mediaUrl !== mediaUrl;
+  }
+
+  componentDidUpdate() {
+    this.audioElement.load();
+  }
+
+  setAudio = element => {
+    this.audioElement = element;
+  };
+
+  handlePlay(e) {
+    const {onPlay} = this.props;
+    if (onPlay) onPlay(e);
+  }
+
+  render() {
+    const {description, mediaUrl, poster} = this.props;
+    const {skin} = this.context;
+
+    const white = get('common.white', skin);
+    return (
+      <div className={style.frame} style={{backgroundImage: `url(${poster})`}}>
+        <PodcastIcon color={white} className={style.icon} />
+        {description ? (
+          <div
+            className={classnames(style.description, innerHTML)}
+            data-name="audioDescription"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{__html: description}}
+          />
+        ) : null}
+        <audio
+          className={style.audio}
+          controls
+          controlsList="nodownload"
+          ref={this.setAudio}
+          autoPlay=""
+          onPlay={this.handlePlay}
+          name="media"
+          data-name="audio"
+          preload="auto"
+        >
+          <source src={mediaUrl} />
+        </audio>
+      </div>
+    );
+  }
+}
+
+export default Audio;

--- a/packages/@coorpacademy-components/src/molecule/audio/style.css
+++ b/packages/@coorpacademy-components/src/molecule/audio/style.css
@@ -1,0 +1,52 @@
+@value colors: "../../variables/colors.css";
+@value light from colors;
+@value medium from colors;
+@value dark from colors;
+
+.frame {
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background-color: medium;
+  color: white;
+  background-size: cover;
+  background-position: center;
+  position: relative;
+}
+.frame:before {
+  content: '';
+  width: 100%;
+  height: 100%;
+  left: 0px;
+  top: 0px;
+  background-color: color(dark a(50%));
+  position: absolute;
+}
+.icon {
+  width: 40px;
+  height: 40px;
+  z-index: 1;
+}
+
+.audio {
+  align-self: center;
+  margin: 25px auto 0px auto;
+  outline: none;
+  transition: all 0.25s linear;
+}
+.audio:hover {
+  transform: scale(1.05);
+  filter: drop-shadow(2px 3px 3px #333);
+}
+
+.description {
+  font-family: 'Open Sans';
+  font-weight: 600;
+  text-align: center;
+  font-size: 12px;
+  margin: 24px 5px 0 5px;
+  z-index: 1;
+}

--- a/packages/@coorpacademy-components/src/molecule/audio/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/audio/test/fixtures/default.js
@@ -1,0 +1,9 @@
+export default {
+  props: {
+    type: 'audio',
+    description: "Chapitre 1. Diagramme du l'hiérarchie du contenu.",
+    mediaUrl:
+      '//static.coorpacademy.com/content/CoorpAcademy/content-bnpp/cockpit-letsgetdigital-migration/raw/sample-1618502603227.aac',
+    onPlay: () => console.log('played audio!')
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/audio/test/fixtures/with-poster.js
+++ b/packages/@coorpacademy-components/src/molecule/audio/test/fixtures/with-poster.js
@@ -1,0 +1,9 @@
+export default {
+  props: {
+    type: 'audio',
+    poster: 'https://i.pinimg.com/originals/c4/a7/ba/c4a7ba862d5a4fec87db9bdfcf3ace7a.gif',
+    mediaUrl:
+      '//static.coorpacademy.com/content/CoorpAcademy/content-bnpp/cockpit-letsgetdigital-migration/raw/sample-1618502603227.aac',
+    onPlay: () => console.log('played audio!')
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/audio/test/on-click.js
+++ b/packages/@coorpacademy-components/src/molecule/audio/test/on-click.js
@@ -1,0 +1,47 @@
+import browserEnv from 'browser-env';
+import test from 'ava';
+import React from 'react';
+import {mount, configure} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {once} from 'lodash/fp';
+import Audio from '..';
+import defaultFixture from './fixtures/default';
+
+browserEnv();
+configure({adapter: new Adapter()});
+
+test('should call listeners within props', t => {
+  t.plan(3);
+
+  window.HTMLMediaElement.prototype.load = () => {
+    t.pass();
+  };
+  const onPlay = once(() => t.pass());
+
+  const component = <Audio {...defaultFixture.props} onPlay={onPlay} />;
+  const audioPlayer = mount(component);
+  const instance = audioPlayer.instance();
+
+  instance.handlePlay();
+
+  audioPlayer.setProps({
+    mediaUrl:
+      '//static.coorpacademy.com/content/CoorpAcademy/content-bnpp/cockpit-letsgetdigital-migration/raw/3-methodes-efficaces-pour-gerer-les-conflits-1619536987180.mp3'
+  });
+  t.pass();
+});
+
+test('should call listeners without onPlay handler', t => {
+  t.plan(1);
+
+  window.HTMLMediaElement.prototype.load = () => {
+    t.fail();
+  };
+
+  const component = <Audio {...defaultFixture.props} onPlay={null} />;
+  const audioPlayer = mount(component);
+  const instance = audioPlayer.instance();
+
+  instance.handlePlay();
+  t.pass();
+});

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/index.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/index.js
@@ -25,6 +25,7 @@ function ExternalContentViewer(props) {
       <audio
         className={style.podcast}
         controls
+        controlsList="nodownload"
         autoPlay=""
         name="media"
         data-name="external-content-podcast"

--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/style.css
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/style.css
@@ -32,6 +32,13 @@
   align-self: center;
   z-index: 1;
   margin: auto;
+  outline: none;
+  transition: all 0.25s linear;
+}
+
+.podcast:hover {
+  transform: scale(1.05);
+  filter: drop-shadow(2px 3px 3px #333);
 }
 
 .podcastWrapperCockpit {

--- a/packages/@coorpacademy-components/src/molecule/feedback/index.js
+++ b/packages/@coorpacademy-components/src/molecule/feedback/index.js
@@ -4,7 +4,7 @@ import {pipe, get, extend} from 'lodash/fp';
 import classnames from 'classnames';
 
 import {innerHTML} from '../../atom/label/style.css';
-import ResourcePlayer, {TYPE_IMAGE, TYPE_VIDEO, TYPE_PDF} from '../resource-player';
+import ResourcePlayer, {TYPE_IMAGE, TYPE_VIDEO, TYPE_PDF, TYPE_AUDIO} from '../resource-player';
 import style from './style.css';
 
 const Feedback = (props, context) => {
@@ -52,7 +52,7 @@ Feedback.propTypes = {
   title: PropTypes.string,
   description: PropTypes.string,
   media: PropTypes.shape({
-    type: PropTypes.oneOf([TYPE_IMAGE, TYPE_PDF, TYPE_VIDEO]),
+    type: PropTypes.oneOf([TYPE_IMAGE, TYPE_PDF, TYPE_VIDEO, TYPE_AUDIO]),
     src: PropTypes.array
   }),
   mediaDescription: PropTypes.string

--- a/packages/@coorpacademy-components/src/molecule/feedback/test/fixtures/success-with-title-and-description-and-audio.js
+++ b/packages/@coorpacademy-components/src/molecule/feedback/test/fixtures/success-with-title-and-description-and-audio.js
@@ -1,0 +1,21 @@
+export default {
+  props: {
+    type: 'success',
+    title: 'VOTRE ATOUT SÉDUCTION: LA GLAM ATTITUDE (MAJORITÉ DE A)',
+    description:
+      'Oh, la surprise ! Oui, bon, c’est toujours cool de lire ce qu’on sait déjà : vous n’êtes qu’harmonie. Une tête bien faite sur un corps bien balancé. La nature vous a gâtée, mais l’ADN ne suffit pas. C’est à force de sport, de vie healthy, que vous êtes parvenue à ce résultat. Vous avez aussi l’intelligence de vous mettre en valeur : la belle allure, le sourire de vamp, les cheveux Elsève, jamais de fashion faux pas. Et vous n’êtes pas qu’apparence. Dedans, il y a un cerveau qui tourne. Mais le préjugé de la ravissante idiote n’est jamais loin. Terrible. Que faire ? D’abord, ne pas s’excuser d’être belle (on ne se met pas à porter des gros pulls et à bouffer des rollmops pour casser l’image !). Ensuite, en ne ratant jamais l’occasion de sortir des idées futfut, de l’analyse maligne, de bluffer par l’esprit. Pas pour l’épate. Juste pour que les hommes ne s’intéressent pas à vous QUE pour vos beaux yeux.',
+    mediaDescription: 'Voulez-vous voir le chemin idéal?',
+    media: {
+      type: 'audio',
+      mediaUrl:
+        '//static.coorpacademy.com/content/CoorpAcademy/content-bnpp/cockpit-letsgetdigital-migration/raw/sample-1618502603227.aac',
+      mimeType: 'audio/aac',
+      poster:
+        '//static.coorpacademy.com/content/CoorpAcademy/content-partnerships-svp/cockpit-partner-svp/poster/poster-1480426784168.jpg',
+      description: 'Vous avez la glam attitude',
+      subtitles: [],
+      posters: [],
+      src: []
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/resource-player/index.js
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/index.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import {omit, get} from 'lodash/fp';
 import {NovaSolidVideosVideoControlPlay as Play} from '@coorpacademy/nova-icons';
 import Pdf from '../pdf';
+import Audio from '../audio';
 import VideoPlayer from '../video-player';
 import Life from '../../atom/life';
 import Provider from '../../atom/provider';
@@ -12,6 +13,7 @@ import style from './style.css';
 export const TYPE_IMAGE = 'img';
 export const TYPE_PDF = 'pdf';
 export const TYPE_VIDEO = 'video';
+export const TYPE_AUDIO = 'audio';
 
 const isType = name => PropTypes.oneOf([name]);
 
@@ -26,6 +28,13 @@ const pdfPropType = PropTypes.shape({
   description: PropTypes.string.isRequired,
   mediaUrl: PropTypes.string.isRequired,
   ...Pdf.propTypes
+});
+
+const audioPropType = PropTypes.shape({
+  type: isType(TYPE_AUDIO).isRequired,
+  description: PropTypes.string.isRequired,
+  mediaUrl: PropTypes.string.isRequired,
+  ...Audio.propTypes
 });
 
 const imgPropType = PropTypes.shape({
@@ -43,6 +52,8 @@ const ResourceElement = props => {
       return <div className={style.img} style={{backgroundImage: `url(${url})`}} />;
     case TYPE_PDF:
       return <Pdf {...childProps} />;
+    case TYPE_AUDIO:
+      return <Audio {...childProps} />;
     case TYPE_VIDEO:
       return (
         <VideoPlayer
@@ -58,7 +69,7 @@ const ResourceElement = props => {
 };
 
 ResourceElement.propTypes = {
-  resource: PropTypes.oneOfType([videoPropType, pdfPropType, imgPropType]),
+  resource: PropTypes.oneOfType([videoPropType, pdfPropType, imgPropType, audioPropType]),
   autoplay: PropTypes.bool,
   disableAutostart: PropTypes.bool
 };
@@ -103,7 +114,7 @@ OverlayElement.propTypes = {
 class ResourcePlayer extends React.Component {
   static propTypes = {
     className: PropTypes.string,
-    resource: PropTypes.oneOfType([videoPropType, pdfPropType, imgPropType]),
+    resource: PropTypes.oneOfType([videoPropType, pdfPropType, imgPropType, audioPropType]),
     overlay: PropTypes.shape({
       title: PropTypes.string,
       text: PropTypes.string,
@@ -136,6 +147,7 @@ class ResourcePlayer extends React.Component {
       {
         [TYPE_IMAGE]: style.image,
         [TYPE_PDF]: style.pdf,
+        [TYPE_AUDIO]: style.audio,
         [TYPE_VIDEO]: style.video
       }[type],
       customClassName

--- a/packages/@coorpacademy-components/src/molecule/resource-player/style.css
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/style.css
@@ -22,6 +22,11 @@
   background-color: transparent;
 }
 
+.audio {
+  composes: video;
+  background-color: transparent;
+}
+
 .overlay {
   background-color: rgba(0, 0, 0, 0.8);
   transition: all 0.5s;

--- a/packages/@coorpacademy-components/src/molecule/resource-player/test/fixtures/audio.js
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/test/fixtures/audio.js
@@ -1,0 +1,18 @@
+export default {
+  props: {
+    resource: {
+      type: 'audio',
+      description: "Chapitre 1. Diagramme du l'hiérarchie du contenu.",
+      mediaUrl:
+        '//static.coorpacademy.com/content/CoorpAcademy/content-bnpp/cockpit-letsgetdigital-migration/raw/sample-1618502603227.aac',
+      poster:
+        '//static.coorpacademy.com/content/CoorpAcademy/content-partnerships-svp/cockpit-partner-svp/poster/poster-1480426784168.jpg',
+      _id: '590b9be24f7b862e0046e577',
+      subtitles: [],
+      posters: [],
+      src: [],
+      onClick: () => {},
+      onPlay: () => console.log('played audio')
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/scope-content/index.js
+++ b/packages/@coorpacademy-components/src/molecule/scope-content/index.js
@@ -2,7 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {get, getOr} from 'lodash/fp';
 import classnames from 'classnames';
-import {NovaLineAudioAudioControlPlay as PlayIcon} from '@coorpacademy/nova-icons';
+import {
+  NovaLineAudioAudioControlPlay as PlayIcon,
+  NovaLineFilesOfficeFileOfficePdf as PDFIcon,
+  NovaCompositionCoorpacademyMicrophone as PodcastIcon
+} from '@coorpacademy/nova-icons';
 import Button from '../../atom/button';
 import Link from '../../atom/link';
 import Provider from '../../atom/provider';
@@ -74,6 +78,8 @@ const ScopeContent = (props, context) => {
         <div className={style.imgWrapper}>
           <img src={media.image} />
           {type === 'video' ? <PlayIcon className={style.play} color={white} /> : null}
+          {type === 'pdf' ? <PDFIcon className={style.play} color={white} /> : null}
+          {type === 'audio' ? <PodcastIcon className={style.play} color={white} /> : null}
         </div>
         <div
           className={classnames(style.mediaTitle, innerHTML)}

--- a/packages/@coorpacademy-components/src/molecule/scope-content/test/fixtures/medias.js
+++ b/packages/@coorpacademy-components/src/molecule/scope-content/test/fixtures/medias.js
@@ -16,27 +16,27 @@ export default {
       medias: [
         {
           title: 'Titre de la vidéo',
-          image: 'http://lorempixel.com/300/300/business',
+          image: 'https://picsum.photos/250/150',
           type: 'video',
           onClick: () => true
         },
         {
           title: 'Titre 2',
-          image: 'http://lorempixel.com/300/300/business',
+          image: 'https://picsum.photos/250/150',
           type: 'video',
           onClick: () => true
         },
         {
           title: 'Blabla vidéo',
-          image: 'http://lorempixel.com/300/300/business',
+          image: 'https://picsum.photos/250/150',
           type: 'pdf',
           href: '#1',
           target: '_blank'
         },
         {
           title: 'Titre de la vidéo',
-          image: 'http://lorempixel.com/300/300/business',
-          type: 'pdf',
+          image: 'https://picsum.photos/250/150',
+          type: 'audio',
           href: '#2',
           target: '_blank'
         }

--- a/packages/@coorpacademy-components/src/organism/resource-browser/test/fixtures/audio.js
+++ b/packages/@coorpacademy-components/src/organism/resource-browser/test/fixtures/audio.js
@@ -1,0 +1,34 @@
+export default {
+  props: {
+    resources: [
+      {
+        type: 'audio',
+        description: "Chapitre 1. Diagramme du l'hiérarchie du contenu.",
+        mediaUrl:
+          '//static.coorpacademy.com/content/CoorpAcademy/content-bnpp/cockpit-letsgetdigital-migration/raw/sample-1618502603227.aac',
+        _id: '590b9be24f7b862e0046e577',
+        poster:
+          '//static.coorpacademy.com/content/CoorpAcademy/content-partnerships-svp/cockpit-partner-svp/poster/poster-1480426784168.jpg',
+        subtitles: [],
+        posters: [],
+        src: [],
+        selected: true,
+        onClick: () => {},
+        onPlay: () => console.log('played audio!')
+      },
+      {
+        type: 'video',
+        poster: '//static.coorpacademy.com/content/digital/miniatures_cours/avance/1A1.png',
+        description: 'Le concept de Knowledge Graph',
+        mimeType: 'application/vimeo',
+        videoId: '89404998\n',
+        _id: '590b862e2e967f64333ad45f',
+        subtitles: [],
+        posters: [],
+        src: [],
+        selected: false,
+        onClick: () => {}
+      }
+    ]
+  }
+};

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/index.js
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/index.js
@@ -12,6 +12,7 @@ import Loader from '../../../../atom/loader';
 import Swapper from '../../../../hoc/swapper';
 import VideoPlayer from '../../../../molecule/video-player';
 import PDF from '../../../../molecule/pdf';
+import Audio from '../../../../molecule/audio';
 import ResourceBrowser from '../../../../organism/resource-browser';
 import {innerHTML} from '../../../../atom/label/style.css';
 import Footer from './footer';
@@ -206,6 +207,7 @@ ContextVideo.propTypes = {
 const CONTEXT_MEDIA = {
   img: ContextImage,
   pdf: PDF,
+  audio: Audio,
   video: ContextVideo
 };
 
@@ -216,7 +218,8 @@ const ContextMedia = ({media}) => {
       data-name="contextMedia"
       className={classnames(
         style.contextWrapper,
-        media.type === 'pdf' ? style.contexPdftWrapper : null
+        media.type === 'pdf' ? style.contextPdfWrapper : null,
+        media.type === 'audio' ? style.contextAudioWrapper : null
       )}
     >
       <ContentType {...media} />
@@ -233,6 +236,10 @@ ContextMedia.propTypes = {
     PropTypes.shape({
       ...PDF.propTypes,
       type: PropTypes.oneOf(['pdf'])
+    }),
+    PropTypes.shape({
+      ...Audio.propTypes,
+      type: PropTypes.oneOf(['audio'])
     }),
     PropTypes.shape({
       ...ContextVideo.propTypes,

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/style.css
@@ -252,9 +252,14 @@
   text-align: center;
 }
 
-.contexPdftWrapper {
+.contextPdfWrapper {
   width: 341px;
   height: 241px;
+}
+
+.contextAudioWrapper {
+  width: 380px;
+  height: 240px;
 }
 
 .contextMedia {

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/test/fixtures/context-with-audio.js
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/test/fixtures/context-with-audio.js
@@ -1,0 +1,18 @@
+import Context from './context';
+
+export default {
+  props: {
+    ...Context.props,
+    slideContext: {
+      ...Context.props.slideContext,
+      media: {
+        type: 'audio',
+        description: 'Audio description',
+        mimeType: 'audio/aac',
+        poster: 'https://picsum.photos/500/300',
+        mediaUrl:
+          '//static.coorpacademy.com/content/CoorpAcademy/content-bnpp/cockpit-letsgetdigital-migration/raw/sample-1618502603227.aac'
+      }
+    }
+  }
+};

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -44,6 +44,7 @@ import HocAnimationScheduler from './../src/hoc/animation-scheduler';
 import HocSwapper from './../src/hoc/swapper';
 import HocTransition from './../src/hoc/transition';
 import MoleculeAnswer from './../src/molecule/answer';
+import MoleculeAudio from './../src/molecule/audio';
 import MoleculeBattleRequest from './../src/molecule/battle-request';
 import MoleculeBrandCard from './../src/molecule/brand-card';
 import MoleculeBrandCardCreate from './../src/molecule/brand-card-create';
@@ -285,6 +286,7 @@ import AtomRadioGroupFixtureEmpty from '../src/atom/radio-group/test/fixtures/em
 import AtomRadioGroupFixtureLastSelected from '../src/atom/radio-group/test/fixtures/last-selected';
 import AtomRangeFixtureDefault from '../src/atom/range/test/fixtures/default';
 import AtomRangeFixtureMulti from '../src/atom/range/test/fixtures/multi';
+import AtomResourceMiniatureFixtureAudio from '../src/atom/resource-miniature/test/fixtures/audio';
 import AtomResourceMiniatureFixturePdf from '../src/atom/resource-miniature/test/fixtures/pdf';
 import AtomResourceMiniatureFixtureSelectedPdf from '../src/atom/resource-miniature/test/fixtures/selected-pdf';
 import AtomResourceMiniatureFixtureSelectedVideo from '../src/atom/resource-miniature/test/fixtures/selected-video';
@@ -329,16 +331,20 @@ import HocAnimationSchedulerFixtureParallel from '../src/hoc/animation-scheduler
 import HocAnimationSchedulerFixtureSeries from '../src/hoc/animation-scheduler/test/fixtures/series';
 import HocSwapperFixtureDefault from '../src/hoc/swapper/test/fixtures/default';
 import HocTransitionFixtureFlipSquare from '../src/hoc/transition/test/fixtures/flip-square';
+import MoleculeAnswerFixtureAudio from '../src/molecule/answer/test/fixtures/audio';
 import MoleculeAnswerFixtureDefault from '../src/molecule/answer/test/fixtures/default';
 import MoleculeAnswerFixtureDropDown from '../src/molecule/answer/test/fixtures/drop-down';
 import MoleculeAnswerFixtureQcmArabic from '../src/molecule/answer/test/fixtures/qcm-arabic';
 import MoleculeAnswerFixtureQcmDrag from '../src/molecule/answer/test/fixtures/qcm-drag';
 import MoleculeAnswerFixtureQcmGraphic from '../src/molecule/answer/test/fixtures/qcm-graphic';
+import MoleculeAnswerFixtureQcmShortAudio from '../src/molecule/answer/test/fixtures/qcm-short-audio';
 import MoleculeAnswerFixtureQcmShortVideo from '../src/molecule/answer/test/fixtures/qcm-short-video';
 import MoleculeAnswerFixtureQcmShort from '../src/molecule/answer/test/fixtures/qcm-short';
 import MoleculeAnswerFixtureQcm from '../src/molecule/answer/test/fixtures/qcm';
 import MoleculeAnswerFixtureRange from '../src/molecule/answer/test/fixtures/range';
 import MoleculeAnswerFixtureTemplate from '../src/molecule/answer/test/fixtures/template';
+import MoleculeAudioFixtureDefault from '../src/molecule/audio/test/fixtures/default';
+import MoleculeAudioFixtureWithPoster from '../src/molecule/audio/test/fixtures/with-poster';
 import MoleculeBattleRequestFixtureArabic from '../src/molecule/battle-request/test/fixtures/arabic';
 import MoleculeBattleRequestFixtureDefault from '../src/molecule/battle-request/test/fixtures/default';
 import MoleculeBrandCardFixtureDefault from '../src/molecule/brand-card/test/fixtures/default';
@@ -459,6 +465,7 @@ import MoleculeFeedbackFixtureDefault from '../src/molecule/feedback/test/fixtur
 import MoleculeFeedbackFixtureFailExitNode from '../src/molecule/feedback/test/fixtures/fail-exit-node';
 import MoleculeFeedbackFixtureFailureWithTitleAndDescriptionAndVideo from '../src/molecule/feedback/test/fixtures/failure-with-title-and-description-and-video';
 import MoleculeFeedbackFixtureSuccessExitNode from '../src/molecule/feedback/test/fixtures/success-exit-node';
+import MoleculeFeedbackFixtureSuccessWithTitleAndDescriptionAndAudio from '../src/molecule/feedback/test/fixtures/success-with-title-and-description-and-audio';
 import MoleculeFeedbackFixtureSuccessWithTitleAndDescriptionAndImage from '../src/molecule/feedback/test/fixtures/success-with-title-and-description-and-image';
 import MoleculeFeedbackFixtureSuccessWithTitleAndDescriptionAndPdf from '../src/molecule/feedback/test/fixtures/success-with-title-and-description-and-pdf';
 import MoleculeFeedbackFixtureSuccessWithTitleAndDescription from '../src/molecule/feedback/test/fixtures/success-with-title-and-description';
@@ -534,6 +541,7 @@ import MoleculeQuestionsQcmGraphicFixtureNoSelected from '../src/molecule/questi
 import MoleculeQuestionsQuestionRangeFixtureDefault from '../src/molecule/questions/question-range/test/fixtures/default';
 import MoleculeQuestionsTemplateFixtureDefault from '../src/molecule/questions/template/test/fixtures/default';
 import MoleculeQuestionsTemplateFixtureMultiple from '../src/molecule/questions/template/test/fixtures/multiple';
+import MoleculeResourcePlayerFixtureAudio from '../src/molecule/resource-player/test/fixtures/audio';
 import MoleculeResourcePlayerFixtureImage from '../src/molecule/resource-player/test/fixtures/image';
 import MoleculeResourcePlayerFixtureJwplayerWithOverlay from '../src/molecule/resource-player/test/fixtures/jwplayer-with-overlay';
 import MoleculeResourcePlayerFixturePdfWithOverlay from '../src/molecule/resource-player/test/fixtures/pdf-with-overlay';
@@ -679,6 +687,7 @@ import OrganismMoocHeaderFixtureTeams from '../src/organism/mooc-header/test/fix
 import OrganismMoocHeaderFixtureUserChangePassword from '../src/organism/mooc-header/test/fixtures/user-change-password';
 import OrganismPopinFixtureDefault from '../src/organism/popin/test/fixtures/default';
 import OrganismResourceBrowserFixtureArabic from '../src/organism/resource-browser/test/fixtures/arabic';
+import OrganismResourceBrowserFixtureAudio from '../src/organism/resource-browser/test/fixtures/audio';
 import OrganismResourceBrowserFixtureH5P from '../src/organism/resource-browser/test/fixtures/h5p';
 import OrganismResourceBrowserFixtureJwplayerWithOverlay from '../src/organism/resource-browser/test/fixtures/jwplayer-with-overlay';
 import OrganismResourceBrowserFixtureJwplayer from '../src/organism/resource-browser/test/fixtures/jwplayer';
@@ -731,6 +740,7 @@ import TemplateAppPlayerPlayerSlidesFixtureArabicQcm from '../src/template/app-p
 import TemplateAppPlayerPlayerSlidesFixtureArabicResources from '../src/template/app-player/player/slides/test/fixtures/arabic-resources';
 import TemplateAppPlayerPlayerSlidesFixtureArabic from '../src/template/app-player/player/slides/test/fixtures/arabic';
 import TemplateAppPlayerPlayerSlidesFixtureClue from '../src/template/app-player/player/slides/test/fixtures/clue';
+import TemplateAppPlayerPlayerSlidesFixtureContextWithAudio from '../src/template/app-player/player/slides/test/fixtures/context-with-audio';
 import TemplateAppPlayerPlayerSlidesFixtureContextWithImage from '../src/template/app-player/player/slides/test/fixtures/context-with-image';
 import TemplateAppPlayerPlayerSlidesFixtureContextWithPdf from '../src/template/app-player/player/slides/test/fixtures/context-with-pdf';
 import TemplateAppPlayerPlayerSlidesFixtureContextWithVideo from '../src/template/app-player/player/slides/test/fixtures/context-with-video';
@@ -953,6 +963,7 @@ export const components = {
   },
   Molecule: {
     MoleculeAnswer,
+    MoleculeAudio,
     MoleculeBattleRequest,
     MoleculeBrandCard,
     MoleculeBrandCardCreate,
@@ -1286,6 +1297,7 @@ export const fixtures = {
       Multi: AtomRangeFixtureMulti
     },
     AtomResourceMiniature: {
+      Audio: AtomResourceMiniatureFixtureAudio,
       Pdf: AtomResourceMiniatureFixturePdf,
       SelectedPdf: AtomResourceMiniatureFixtureSelectedPdf,
       SelectedVideo: AtomResourceMiniatureFixtureSelectedVideo,
@@ -1360,16 +1372,22 @@ export const fixtures = {
   },
   Molecule: {
     MoleculeAnswer: {
+      Audio: MoleculeAnswerFixtureAudio,
       Default: MoleculeAnswerFixtureDefault,
       DropDown: MoleculeAnswerFixtureDropDown,
       QcmArabic: MoleculeAnswerFixtureQcmArabic,
       QcmDrag: MoleculeAnswerFixtureQcmDrag,
       QcmGraphic: MoleculeAnswerFixtureQcmGraphic,
+      QcmShortAudio: MoleculeAnswerFixtureQcmShortAudio,
       QcmShortVideo: MoleculeAnswerFixtureQcmShortVideo,
       QcmShort: MoleculeAnswerFixtureQcmShort,
       Qcm: MoleculeAnswerFixtureQcm,
       Range: MoleculeAnswerFixtureRange,
       Template: MoleculeAnswerFixtureTemplate
+    },
+    MoleculeAudio: {
+      Default: MoleculeAudioFixtureDefault,
+      WithPoster: MoleculeAudioFixtureWithPoster
     },
     MoleculeBattleRequest: {
       Arabic: MoleculeBattleRequestFixtureArabic,
@@ -1521,6 +1539,7 @@ export const fixtures = {
       FailExitNode: MoleculeFeedbackFixtureFailExitNode,
       FailureWithTitleAndDescriptionAndVideo: MoleculeFeedbackFixtureFailureWithTitleAndDescriptionAndVideo,
       SuccessExitNode: MoleculeFeedbackFixtureSuccessExitNode,
+      SuccessWithTitleAndDescriptionAndAudio: MoleculeFeedbackFixtureSuccessWithTitleAndDescriptionAndAudio,
       SuccessWithTitleAndDescriptionAndImage: MoleculeFeedbackFixtureSuccessWithTitleAndDescriptionAndImage,
       SuccessWithTitleAndDescriptionAndPdf: MoleculeFeedbackFixtureSuccessWithTitleAndDescriptionAndPdf,
       SuccessWithTitleAndDescription: MoleculeFeedbackFixtureSuccessWithTitleAndDescription
@@ -1597,6 +1616,7 @@ export const fixtures = {
       Max: MoleculeProgressBarFixtureMax
     },
     MoleculeResourcePlayer: {
+      Audio: MoleculeResourcePlayerFixtureAudio,
       Image: MoleculeResourcePlayerFixtureImage,
       JwplayerWithOverlay: MoleculeResourcePlayerFixtureJwplayerWithOverlay,
       PdfWithOverlay: MoleculeResourcePlayerFixturePdfWithOverlay,
@@ -1898,6 +1918,7 @@ export const fixtures = {
     },
     OrganismResourceBrowser: {
       Arabic: OrganismResourceBrowserFixtureArabic,
+      Audio: OrganismResourceBrowserFixtureAudio,
       H5P: OrganismResourceBrowserFixtureH5P,
       JwplayerWithOverlay: OrganismResourceBrowserFixtureJwplayerWithOverlay,
       Jwplayer: OrganismResourceBrowserFixtureJwplayer,
@@ -2078,6 +2099,7 @@ export const fixtures = {
       ArabicResources: TemplateAppPlayerPlayerSlidesFixtureArabicResources,
       Arabic: TemplateAppPlayerPlayerSlidesFixtureArabic,
       Clue: TemplateAppPlayerPlayerSlidesFixtureClue,
+      ContextWithAudio: TemplateAppPlayerPlayerSlidesFixtureContextWithAudio,
       ContextWithImage: TemplateAppPlayerPlayerSlidesFixtureContextWithImage,
       ContextWithPdf: TemplateAppPlayerPlayerSlidesFixtureContextWithPdf,
       ContextWithVideo: TemplateAppPlayerPlayerSlidesFixtureContextWithVideo,

--- a/packages/@coorpacademy-player-store/src/definitions/models.js
+++ b/packages/@coorpacademy-player-store/src/definitions/models.js
@@ -43,7 +43,7 @@ export const VIDEO_TRACK_TYPE: {
 
 type Url = string;
 type AspectRatio = '16:9' | '4:3';
-type ResourceType = 'video' | 'pdf';
+type ResourceType = 'video' | 'pdf' | 'audio';
 
 // eslint-disable-next-line no-shadow
 type MimeType =

--- a/packages/@coorpacademy-player-store/src/utils/state-extract.js
+++ b/packages/@coorpacademy-player-store/src/utils/state-extract.js
@@ -487,6 +487,7 @@ const getMedia = (media: Media): Media | void => {
   const resource = get('src.0', media);
   switch (type) {
     case 'img':
+    case 'audio':
       return {
         ...resource,
         type,

--- a/packages/@coorpacademy-progression-engine/src/types.js
+++ b/packages/@coorpacademy-progression-engine/src/types.js
@@ -14,11 +14,14 @@ export type VideoMimeType =
   | 'application/omniPlayer'
   | 'application/vimeo';
 
+export type AudioMimeType = 'audio/aac' | 'audio/x-aac' | 'audio/mpeg';
+
 export type ResourceMimeType =
   | 'video/mp4'
   | 'image/jpeg'
   | 'image/png'
   | 'application/pdf'
+  | AudioMimeType
   | VideoMimeType;
 
 export type Answer = Array<string>;
@@ -39,8 +42,10 @@ export type SUCCESS = 'success';
 export type IMG = 'img';
 export type VIDEO = 'video';
 export type PDF = 'pdf';
+export type AUDIO = 'audio';
 export type SCORM = 'scorm';
 export type ARTICLE = 'article';
+export type PODCAST = 'podcast';
 export type ContentType =
   | DISCIPLINE
   | CHAPTER
@@ -51,8 +56,10 @@ export type ContentType =
   | SUCCESS
   | IMG
   | PDF
+  | AUDIO
   | VIDEO
   | SCORM
+  | PODCAST
   | ARTICLE;
 
 export type LessonType = VIDEO | PDF | IMG;
@@ -255,7 +262,7 @@ export type Source = {|
   url: Url
 |};
 
-export type MediaType = 'img' | 'video' | 'pdf';
+export type MediaType = 'img' | 'video' | 'pdf' | 'audio';
 export type Media = {
   type?: MediaType,
   description?: string,


### PR DESCRIPTION
support de l'audio dans :
- le context des questions (avec ou sans cover)
- les lessons (avec ou sans cover)
- le media de la question
- le feedback (avec ou sans cover)

Le tag audio ne se refresh pas quand celui-ci change de source.  Le problème se rencontrait le player de lessons avec plusieurs audios dedans. J'ai suivi les recommandations suivante: https://stackoverflow.com/questions/40885776/reactjs-not-rendering-html-audio-correctly-after-first-render

https://user-images.githubusercontent.com/15608581/116367502-b59af180-a807-11eb-9667-cc6a30d278fb.mp4



https://user-images.githubusercontent.com/15608581/116367470-ad42b680-a807-11eb-8ec5-104bff632c7c.mp4





**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing
