### PR TITLE
Fix audio learning for firefox and ie

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/audio/style.css
+++ b/packages/@coorpacademy-components/src/molecule/audio/style.css
@@ -36,6 +36,7 @@
   margin: 25px auto 0px auto;
   outline: none;
   transition: all 0.25s linear;
+  z-index: 1;
 }
 .audio:hover {
   transform: scale(1.05);


### PR DESCRIPTION
https://trello.com/c/gkJgmukS/2214-bug-audio-learning-ie-firefox

Le player audio n'est pas accessible.  Le pseudo element `before` est placé au dessus sur ie et firefox.

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
