### PR TITLE
Adapte dashboard preview & add it to update brand

### DIFF
--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/dashboard-popin.css
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/dashboard-popin.css
@@ -1,0 +1,65 @@
+@value breakpoints: "../../variables/breakpoints.css";
+@value mobile from breakpoints;
+@value colors: "../../variables/colors.css";
+@value dark from colors;
+@value light from colors;
+@value grey from colors;
+@value white from colors;
+
+.default {
+  z-index: 20;
+  top: 0;
+  display: flex;
+  margin: 0;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.7);
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  overflow: auto;
+}
+
+.popin {
+  position: fixed;
+  width: 460px;
+  overflow: auto;
+  background: white;
+  text-align: center;
+  padding-bottom: 20px;
+  top: 50%;
+  left: 50%;
+  box-shadow: 0 0 15px 0 rgba(166, 166, 166, 0.84);
+  transform: translate(-50%, -50%);
+}
+
+.header {
+  display: flex;
+  width: 100%;
+  height: 35px;
+  background: light;
+  align-items: center;
+  justify-content: center;
+  color: grey;
+  font-size: 15px;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.content {
+  color: dark;
+  padding: 20px 0;
+  box-sizing: border-box;
+}
+
+.content img,
+.content iframe {
+  max-width: 100%;
+}
+
+@media mobile {
+  .popin {
+    width: 100%;
+    left: 0;
+    margin: 0;
+  }
+}

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/dashboard-popin.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/dashboard-popin.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {getOr} from 'lodash/fp';
+import stopPropagation from '../../util/bubbling';
+import Provider from '../../atom/provider';
+import Button from '../../atom/button';
+import style from './dashboard-popin.css';
+
+const DashboardPopin = (props, context) => {
+  const {skin} = context;
+
+  const {ctaLabel, ctaOnClick, header, closeOnClick, content} = props;
+
+  function createMarkup() {
+    return {__html: content};
+  }
+
+  const primary = getOr('#00B0FF', ['common', 'primary'], skin);
+
+  return (
+    <div className={style.default} onClick={closeOnClick}>
+      <div className={style.popin} onClick={stopPropagation}>
+        <div className={style.header} onClick={closeOnClick} data-name="popin-header">
+          {header}
+        </div>
+        <div className={style.content}>
+          <div
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={createMarkup()}
+          />
+        </div>
+        <Button
+          type="link"
+          onClick={ctaOnClick}
+          submitValue={ctaLabel}
+          style={{
+            backgroundColor: primary
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+DashboardPopin.contextTypes = {
+  skin: Provider.childContextTypes.skin
+};
+
+DashboardPopin.propTypes = {
+  ctaLabel: PropTypes.string,
+  ctaOnClick: PropTypes.func,
+  closeOnClick: PropTypes.func,
+  header: PropTypes.string,
+  content: PropTypes.string
+};
+
+export default DashboardPopin;

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/index.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/index.js
@@ -143,7 +143,7 @@ const BrandDashboard = (props, context) => {
   }
 
   return (
-    <div className={style.container}>
+    <div>
       <Sidebar items={sidebarItems} />
       <div className={style.dashboardContent}>
         <Dashboard error={error} selected={currentDashboard} url={url} />

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/index.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/index.js
@@ -1,0 +1,188 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {noop, getOr, kebabCase, keys} from 'lodash/fp';
+import Sidebar from '../sidebar';
+import Provider from '../../atom/provider';
+import Loader from '../../template/app-player/loading';
+import DashboardPopin from './dashboard-popin';
+import style from './style.css';
+
+const currentDashboardSidebarSection = ({
+  currentDashboard,
+  onUpdateVersion,
+  onUpdateField,
+  inputParams
+}) => {
+  const dashboardDescription = {
+    title: currentDashboard.name,
+    type: 'info',
+    value: currentDashboard.description
+  };
+  const dashboardVersion = {
+    title: 'Version',
+    type: 'select',
+    name: 'version-field',
+    onChange: onUpdateVersion,
+    options: keys(currentDashboard.versions).map(v => ({
+      name: v,
+      value: v,
+      selected: v === currentDashboard.currentVersion
+    }))
+  };
+  const paramInputs = currentDashboard.schema.map(schema => ({
+    title: schema,
+    name: `${kebabCase(schema)}-field`,
+    type: 'inputtext',
+    onChange: newValue => onUpdateField(schema, newValue),
+    value: getOr('', schema, inputParams)
+  }));
+  return [dashboardDescription, ...paramInputs, dashboardVersion];
+};
+
+const Dashboard = (props, context) => {
+  const {url, error, selected} = props;
+  const {skin, translate} = context;
+  const body = () => {
+    if (selected) {
+      if (url) return <iframe src={url} className={style.dashboardIframe} frameBorder="0" />;
+      if (!error) return <Loader />;
+    } else if (!error) {
+      return (
+        <div
+          className={style.dashboardNoSelection}
+          style={{color: getOr('#00B0FF', 'common.primary', skin)}}
+        >
+          {translate('Select a dashboard in the Sidebar')}
+        </div>
+      );
+    }
+    return null;
+  };
+  return (
+    <div className={style.dashboardSelection}>
+      <h1 className={style.dashboardTitle}>
+        {getOr(translate('No Selected Dashboard'), 'name', selected)}
+      </h1>
+      {body()}
+    </div>
+  );
+};
+
+Dashboard.propTypes = {
+  url: PropTypes.string,
+  error: PropTypes.string,
+  selected: PropTypes.shape({
+    name: PropTypes.string
+  })
+};
+
+Dashboard.contextTypes = {
+  skin: Provider.childContextTypes.skin,
+  translate: Provider.childContextTypes.translate
+};
+
+const ErrorPopin = ({onErrorRedirect, ctaLabel, error}, {translate}) => {
+  return error ? (
+    <DashboardPopin
+      header={translate('An Error Occurred')}
+      ctaLabel={ctaLabel}
+      ctaOnClick={onErrorRedirect}
+      closeOnClick={onErrorRedirect}
+    >
+      <p>{error}</p>
+    </DashboardPopin>
+  ) : null;
+};
+
+ErrorPopin.propTypes = {
+  onErrorRedirect: PropTypes.func.isRequired,
+  ctaLabel: PropTypes.string.isRequired,
+  error: PropTypes.string
+};
+
+ErrorPopin.contextTypes = {
+  translate: Provider.childContextTypes.translate
+};
+
+const BrandDashboard = (props, context) => {
+  const {
+    dashboards = [],
+    currentDashboard,
+    onUpdateVersion = noop,
+    onUpdateField = noop,
+    onErrorRedirect = noop,
+    inputParams = {},
+    url,
+    error
+  } = props;
+
+  const {translate} = context;
+
+  if (!dashboards || dashboards.length === 0) {
+    if (error)
+      return (
+        <ErrorPopin
+          ctaLabel={translate('Reload')}
+          error={error}
+          onErrorRedirect={onErrorRedirect}
+        />
+      );
+    return <Loader />;
+  }
+
+  const sidebarItems = [];
+  if (currentDashboard) {
+    sidebarItems.push(
+      currentDashboardSidebarSection({
+        currentDashboard,
+        onUpdateVersion,
+        onUpdateField,
+        inputParams
+      })
+    );
+  }
+
+  return (
+    <div className={style.container}>
+      <Sidebar items={sidebarItems} />
+      <div className={style.dashboardContent}>
+        <Dashboard error={error} selected={currentDashboard} url={url} />
+        <ErrorPopin
+          ctaLabel={translate('Back to Dashboard Home')}
+          error={error}
+          onErrorRedirect={onErrorRedirect}
+        />
+      </div>
+    </div>
+  );
+};
+
+BrandDashboard.contextTypes = {
+  skin: Provider.childContextTypes.skin,
+  translate: Provider.childContextTypes.translate
+};
+
+BrandDashboard.propTypes = {
+  dashboards: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      href: PropTypes.string,
+      description: PropTypes.string.isRequired
+    })
+  ),
+  currentDashboard: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    currentVersion: PropTypes.string.isRequired,
+    versions: PropTypes.shape({}).isRequired,
+    schema: PropTypes.arrayOf(PropTypes.string)
+  }),
+  url: PropTypes.string,
+  error: PropTypes.string,
+  onUpdateVersion: PropTypes.func,
+  onUpdateField: PropTypes.func,
+  onErrorRedirect: PropTypes.func,
+  inputParams: PropTypes.shape({})
+};
+
+export default BrandDashboard;

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/style.css
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/style.css
@@ -1,0 +1,45 @@
+@value breakpoints: "../../variables/breakpoints.css";
+@value mobile from breakpoints;
+@value tablet from breakpoints;
+@value desktop from breakpoints;
+@value colors: "../../variables/colors.css";
+@value dark from colors;
+@value light from colors;
+
+.dashboardContent {
+  font-family: "Open Sans";
+  width: 100%;
+  text-align: center;
+  margin: 0 20px 20px 0px;
+  display: flex;
+  flex-direction: column;  
+  min-height: 700px;
+}
+
+.dashboardSelection {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.dashboardTitle {
+  font-size: 24px;
+  color: dark;
+  border: 1px solid light;
+  padding: 10px;
+  flex-grow: 0;
+}
+
+.dashboardIframe {
+  width: 100%;
+  height: 100%;
+  flex-grow: 1;
+}
+
+.dashboardNoSelection {
+  font-size: 20px;
+  font-weight: bold;
+  padding: 40px;
+}
+
+/* TODO: mobile rendering */

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/default.js
@@ -1,0 +1,25 @@
+import Header from '../../../setup-header/test/fixtures/default';
+
+export default {
+  props: {
+    header: Header.props,
+    dashboards: [
+      {
+        name: 'Analytics Engagement',
+        description: "Stats d'engagement des utilisateurs",
+        href: '/dashboards/analytics-engagement'
+      },
+      {
+        name: 'Analytics Content',
+        description: 'Stats de consommation du contenu',
+        href: '/dashboards/analytics-content'
+      },
+      {
+        name: 'Analytics Partners',
+        description: 'Stats de consommation du contenu du partenaire',
+        href: '/dashboards/analytics-partners'
+      }
+    ],
+    onSelectDashboard: dashboard => console.log('SELECTED', dashboard)
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/error.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/error.js
@@ -1,0 +1,8 @@
+import Header from '../../../setup-header/test/fixtures/default';
+
+export default {
+  props: {
+    header: Header.props,
+    error: 'Bug while Loading'
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/loading.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/loading.js
@@ -1,0 +1,7 @@
+import Header from '../../../setup-header/test/fixtures/default';
+
+export default {
+  props: {
+    header: Header.props
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected-error.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected-error.js
@@ -1,0 +1,44 @@
+import Header from '../../../setup-header/test/fixtures/default';
+
+export default {
+  props: {
+    header: Header.props,
+    dashboards: [
+      {
+        name: 'Analytics Engagement',
+        description: "Stats d'engagement des utilisateurs",
+        href: '/dashboards/analytics-engagement'
+      },
+      {
+        name: 'Analytics Content',
+        description: 'Stats de consommation du contenu',
+        href: '/dashboards/analytics-content'
+      },
+      {
+        name: 'Analytics Partners',
+        description: 'Stats de consommation du contenu du partenaire',
+        href: '/dashboards/analytics-partners'
+      }
+    ],
+    currentDashboard: {
+      name: 'Analytics Content',
+      description: 'Stats de consommation du contenu',
+      versions: {
+        v1: 'aa-ee-bb-cc-dd',
+        v2: 'aa-ee-bb-cc-dd-ff',
+        v3: 'aa-ee-bb-cc-dd-xx'
+      },
+      currentVersion: 'v2',
+      schema: ['platform', 'provider']
+    },
+    url: null,
+    error: 'Shit happened',
+    onErrorRedirect: () => console.log('REDIRECT TO BE DONE'),
+    onSelectDashboard: dashboard => console.log('SELECTED', dashboard),
+    onUpdateVersion: version => console.log('VERSION', version),
+    onUpdateField: (field, value) => console.log('UPDATE', field, value),
+    inputParams: {
+      provider: 'connect'
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected-loading.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected-loading.js
@@ -1,0 +1,42 @@
+import Header from '../../../setup-header/test/fixtures/default';
+
+export default {
+  props: {
+    header: Header.props,
+    dashboards: [
+      {
+        name: 'Analytics Engagement',
+        description: "Stats d'engagement des utilisateurs",
+        href: '/dashboards/analytics-engagement'
+      },
+      {
+        name: 'Analytics Content',
+        description: 'Stats de consommation du contenu',
+        href: '/dashboards/analytics-content'
+      },
+      {
+        name: 'Analytics Partners',
+        description: 'Stats de consommation du contenu du partenaire',
+        href: '/dashboards/analytics-partners'
+      }
+    ],
+    currentDashboard: {
+      name: 'Analytics Content',
+      description: 'Stats de consommation du contenu',
+      versions: {
+        v1: 'aa-ee-bb-cc-dd',
+        v2: 'aa-ee-bb-cc-dd-ff',
+        v3: 'aa-ee-bb-cc-dd-xx'
+      },
+      currentVersion: 'v2',
+      schema: ['platform', 'provider']
+    },
+    url: null,
+    onSelectDashboard: dashboard => console.log('SELECTED', dashboard),
+    onUpdateVersion: version => console.log('VERSION', version),
+    onUpdateField: (field, value) => console.log('UPDATE', field, value),
+    inputParams: {
+      provider: 'connect'
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected.js
@@ -1,0 +1,43 @@
+import Header from '../../../setup-header/test/fixtures/default';
+
+export default {
+  props: {
+    header: Header.props,
+    dashboards: [
+      {
+        name: 'Analytics Engagement',
+        description: "Stats d'engagement des utilisateurs",
+        href: '/dashboards/analytics-engagement'
+      },
+      {
+        name: 'Analytics Content',
+        description: 'Stats de consommation du contenu',
+        href: '/dashboards/analytics-content'
+      },
+      {
+        name: 'Analytics Partners',
+        description: 'Stats de consommation du contenu du partenaire',
+        href: '/dashboards/analytics-partners'
+      }
+    ],
+    currentDashboard: {
+      name: 'Analytics Content',
+      description: 'Stats de consommation du contenu',
+      versions: {
+        v1: 'aa-ee-bb-cc-dd',
+        v2: 'aa-ee-bb-cc-dd-ff',
+        v3: 'aa-ee-bb-cc-dd-xx'
+      },
+      currentVersion: 'v2',
+      schema: ['platform', 'provider']
+    },
+    url: 'https://coorpacademy.github.io/',
+    onSelectDashboard: dashboard => console.log('SELECTED', dashboard),
+    onUpdateVersion: version => console.log('VERSION', version),
+    onUpdateField: (field, value) => console.log('UPDATE', field, value),
+    inputParams: {
+      platform: 'up',
+      provider: 'connect'
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/on-update-field.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/on-update-field.js
@@ -1,0 +1,51 @@
+import browserEnv from 'browser-env';
+import test from 'ava';
+import React from 'react';
+import PropTypes from 'prop-types';
+import {mount, configure} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import DashboardPreview from '..';
+import defaultFixture from './fixtures/selected';
+
+browserEnv();
+configure({adapter: new Adapter()});
+
+test('should call the onUpdateField function with the value of the target', t => {
+  t.plan(3);
+
+  const selector = 'li[data-name="platform-field"] input';
+  const onChange = (field, value) => {
+    t.is(field, 'platform');
+    t.is(value, 'toto');
+  };
+
+  const wrapper = mount(<DashboardPreview {...defaultFixture.props} onUpdateField={onChange} />, {
+    context: {translate: id => id},
+    childContextTypes: {translate: PropTypes.func}
+  });
+
+  t.true(wrapper.find(selector).exists());
+
+  wrapper.find(selector).simulate('change', {
+    target: {
+      value: 'toto'
+    }
+  });
+});
+
+test('should not crash if the onUpdateField function has not been specified', t => {
+  t.plan(1);
+  const selector = 'li[data-name="platform-field"] input';
+  const wrapper = mount(<DashboardPreview {...defaultFixture.props} onUpdateField={undefined} />, {
+    context: {translate: id => id},
+    childContextTypes: {translate: PropTypes.func}
+  });
+
+  t.true(wrapper.find(selector).exists());
+
+  wrapper.find(selector).simulate('change', {
+    target: {
+      value: 'toto'
+    }
+  });
+});

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/on-update-version.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/on-update-version.js
@@ -1,0 +1,53 @@
+import browserEnv from 'browser-env';
+import test from 'ava';
+import React from 'react';
+import PropTypes from 'prop-types';
+import {mount, configure} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import DashboardPreview from '..';
+import defaultFixture from './fixtures/selected';
+
+browserEnv();
+configure({adapter: new Adapter()});
+
+test('should call the onUpdateVersion function with the value of the target', t => {
+  t.plan(2);
+
+  const selector = 'li[data-name="version-field"] select';
+  const onChange = value => {
+    t.is(value, 'foo');
+  };
+
+  const wrapper = mount(<DashboardPreview {...defaultFixture.props} onUpdateVersion={onChange} />, {
+    context: {translate: id => id},
+    childContextTypes: {translate: PropTypes.func}
+  });
+
+  t.true(wrapper.find(selector).exists());
+
+  wrapper.find(selector).simulate('change', {
+    target: {
+      value: 'foo'
+    }
+  });
+});
+
+test('should not crash if the onUpdateVersion function has not been specified', t => {
+  t.plan(1);
+  const selector = 'li[data-name="version-field"] select';
+  const wrapper = mount(
+    <DashboardPreview {...defaultFixture.props} onUpdateVersion={undefined} />,
+    {
+      context: {translate: id => id},
+      childContextTypes: {translate: PropTypes.func}
+    }
+  );
+
+  t.true(wrapper.find(selector).exists());
+
+  wrapper.find(selector).simulate('change', {
+    target: {
+      value: 'foo'
+    }
+  });
+});

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
@@ -7,6 +7,7 @@ import Sidebar from '../../../organism/sidebar';
 import BrandForm from '../../../organism/brand-form';
 import BrandTable from '../../../organism/brand-table';
 import BrandUpload from '../../../organism/brand-upload';
+import BrandDashboard from '../../../organism/brand-dashboard';
 import Notification from '../../../atom/notification';
 import Loader from '../../../atom/loader';
 import Layout from '../layout';
@@ -40,6 +41,8 @@ const BrandUpdate = Layout(props => {
         return <BrandTable {...cont} />;
       case 'upload':
         return <BrandUpload {...cont} />;
+      case 'dashboard':
+        return <BrandDashboard {...cont} />;
     }
   };
 
@@ -108,6 +111,11 @@ BrandUpdate.propTypes = {
       ...BrandUpload.propTypes,
       key: PropTypes.string,
       type: PropTypes.oneOf(['upload'])
+    }),
+    PropTypes.shape({
+      ...BrandDashboard.propTypes,
+      key: PropTypes.string,
+      type: PropTypes.oneOf(['dashboard'])
     })
   ]),
   details: PropTypes.shape({

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/dashboards-analytics.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/dashboards-analytics.js
@@ -1,0 +1,17 @@
+import {defaultsDeep} from 'lodash/fp';
+import BrandTabs from '../../../../../molecule/brand-tabs/test/fixtures/analytics';
+import BrandDashboard from '../../../../../organism/brand-dashboard/test/fixtures/selected';
+import Default from './default';
+
+const {props} = Default;
+const {tabs} = BrandTabs.props;
+
+export default {
+  props: defaultsDeep(props, {
+    tabs,
+    content: defaultsDeep(BrandDashboard.props, {
+      type: 'dashboard',
+      header: {}
+    })
+  })
+};

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -122,6 +122,7 @@ import MoleculeVideoPlayer from './../src/molecule/video-player';
 import OrganismAccordionContainer from './../src/organism/accordion/container';
 import OrganismAccordionPart from './../src/organism/accordion/part';
 import OrganismAccordionToggler from './../src/organism/accordion/toggler';
+import OrganismBrandDashboard from './../src/organism/brand-dashboard';
 import OrganismBrandForm from './../src/organism/brand-form';
 import OrganismBrandTable from './../src/organism/brand-table';
 import OrganismBrandUpload from './../src/organism/brand-upload';
@@ -643,6 +644,12 @@ import OrganismAccordionPartFixtureOpen from '../src/organism/accordion/part/tes
 import OrganismAccordionTogglerFixtureAllAreOpenable from '../src/organism/accordion/toggler/test/fixtures/all-are-openable';
 import OrganismAccordionTogglerFixtureNoChildrens from '../src/organism/accordion/toggler/test/fixtures/no-childrens';
 import OrganismAccordionTogglerFixtureOnlyOne from '../src/organism/accordion/toggler/test/fixtures/only-one';
+import OrganismBrandDashboardFixtureDefault from '../src/organism/brand-dashboard/test/fixtures/default';
+import OrganismBrandDashboardFixtureError from '../src/organism/brand-dashboard/test/fixtures/error';
+import OrganismBrandDashboardFixtureLoading from '../src/organism/brand-dashboard/test/fixtures/loading';
+import OrganismBrandDashboardFixtureSelectedError from '../src/organism/brand-dashboard/test/fixtures/selected-error';
+import OrganismBrandDashboardFixtureSelectedLoading from '../src/organism/brand-dashboard/test/fixtures/selected-loading';
+import OrganismBrandDashboardFixtureSelected from '../src/organism/brand-dashboard/test/fixtures/selected';
 import OrganismBrandFormFixtureAnalytics from '../src/organism/brand-form/test/fixtures/analytics';
 import OrganismBrandFormFixtureAnimations from '../src/organism/brand-form/test/fixtures/animations';
 import OrganismBrandFormFixtureCohort from '../src/organism/brand-form/test/fixtures/cohort';
@@ -852,6 +859,7 @@ import TemplateBackOfficeBrandUpdateFixtureAnimations from '../src/template/back
 import TemplateBackOfficeBrandUpdateFixtureCohortError from '../src/template/back-office/brand-update/test/fixtures/cohort-error';
 import TemplateBackOfficeBrandUpdateFixtureCohort from '../src/template/back-office/brand-update/test/fixtures/cohort';
 import TemplateBackOfficeBrandUpdateFixtureDashboard from '../src/template/back-office/brand-update/test/fixtures/dashboard';
+import TemplateBackOfficeBrandUpdateFixtureDashboardsAnalytics from '../src/template/back-office/brand-update/test/fixtures/dashboards-analytics';
 import TemplateBackOfficeBrandUpdateFixtureDefault from '../src/template/back-office/brand-update/test/fixtures/default';
 import TemplateBackOfficeBrandUpdateFixtureGeneralSettingsSuccess from '../src/template/back-office/brand-update/test/fixtures/general-settings-success';
 import TemplateBackOfficeBrandUpdateFixtureGeneralSettings from '../src/template/back-office/brand-update/test/fixtures/general-settings';
@@ -1055,6 +1063,7 @@ export const components = {
     OrganismAccordionToggler
   },
   Organism: {
+    OrganismBrandDashboard,
     OrganismBrandForm,
     OrganismBrandTable,
     OrganismBrandUpload,
@@ -1855,6 +1864,14 @@ export const fixtures = {
     }
   },
   Organism: {
+    OrganismBrandDashboard: {
+      Default: OrganismBrandDashboardFixtureDefault,
+      Error: OrganismBrandDashboardFixtureError,
+      Loading: OrganismBrandDashboardFixtureLoading,
+      SelectedError: OrganismBrandDashboardFixtureSelectedError,
+      SelectedLoading: OrganismBrandDashboardFixtureSelectedLoading,
+      Selected: OrganismBrandDashboardFixtureSelected
+    },
     OrganismBrandForm: {
       Analytics: OrganismBrandFormFixtureAnalytics,
       Animations: OrganismBrandFormFixtureAnimations,
@@ -2158,6 +2175,7 @@ export const fixtures = {
       CohortError: TemplateBackOfficeBrandUpdateFixtureCohortError,
       Cohort: TemplateBackOfficeBrandUpdateFixtureCohort,
       Dashboard: TemplateBackOfficeBrandUpdateFixtureDashboard,
+      DashboardsAnalytics: TemplateBackOfficeBrandUpdateFixtureDashboardsAnalytics,
       Default: TemplateBackOfficeBrandUpdateFixtureDefault,
       GeneralSettingsSuccess: TemplateBackOfficeBrandUpdateFixtureGeneralSettingsSuccess,
       GeneralSettings: TemplateBackOfficeBrandUpdateFixtureGeneralSettings,


### PR DESCRIPTION
This pr adaptes the `dashboards preview` to be used in `brand update` component and add it in `brand update` comonent as content 
[Ticket](https://trello.com/c/3Qjz40g4)

DashboardPreview => BrandDashboard


![brandhDashboard](https://user-images.githubusercontent.com/58167920/120486865-ba7a3480-c3b5-11eb-9ca7-c32c468aeeae.gif)


UpdateBrand with BrandDashboard

![brandDashboard](https://user-images.githubusercontent.com/58167920/120487028-e2699800-c3b5-11eb-85d8-add371dc3fc5.gif)
<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
