### PR TITLE
refactor brand dashboard

### DIFF
--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/dashboard-popin.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/dashboard-popin.js
@@ -17,10 +17,15 @@ const DashboardPopin = (props, context) => {
 
   const primary = getOr('#00B0FF', ['common', 'primary'], skin);
 
+  function onCloseClick(e) {
+    stopPropagation(e);
+    closeOnClick(e);
+  }
+
   return (
-    <div className={style.default} onClick={closeOnClick}>
-      <div className={style.popin} onClick={stopPropagation}>
-        <div className={style.header} onClick={closeOnClick} data-name="popin-header">
+    <div className={style.default} onClick={onCloseClick}>
+      <div className={style.popin}>
+        <div className={style.header} onClick={onCloseClick} data-name="popin-header">
           {header}
         </div>
         <div className={style.content}>

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/index.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/index.js
@@ -11,7 +11,8 @@ const currentDashboardSidebarSection = ({
   currentDashboard,
   onUpdateVersion,
   onUpdateField,
-  inputParams
+  inputParams,
+  dashboardVersionTitle
 }) => {
   const dashboardDescription = {
     title: currentDashboard.name,
@@ -19,7 +20,7 @@ const currentDashboardSidebarSection = ({
     value: currentDashboard.description
   };
   const dashboardVersion = {
-    title: 'Version',
+    title: dashboardVersionTitle,
     type: 'select',
     name: 'version-field',
     onChange: onUpdateVersion,
@@ -108,12 +109,10 @@ const BrandDashboard = (props, context) => {
   const {
     dashboards = [],
     currentDashboard,
-    onUpdateVersion = noop,
-    onUpdateField = noop,
     onErrorRedirect = noop,
-    inputParams = {},
     url,
-    error
+    error,
+    sidebarItems
   } = props;
 
   const {translate} = context;
@@ -128,18 +127,6 @@ const BrandDashboard = (props, context) => {
         />
       );
     return <Loader />;
-  }
-
-  const sidebarItems = [];
-  if (currentDashboard) {
-    sidebarItems.push(
-      currentDashboardSidebarSection({
-        currentDashboard,
-        onUpdateVersion,
-        onUpdateField,
-        inputParams
-      })
-    );
   }
 
   return (
@@ -177,10 +164,31 @@ BrandDashboard.propTypes = {
     versions: PropTypes.shape({}).isRequired,
     schema: PropTypes.arrayOf(PropTypes.string)
   }),
+  sidebarItems: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.shape({
+        title: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
+        value: PropTypes.string.isRequired
+      }),
+      PropTypes.shape({
+        title: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
+        name: PropTypes.string,
+        onChange: PropTypes.func.isRequired,
+        option: PropTypes.bool.isRequired
+      }),
+      PropTypes.shape({
+        title: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
+        name: PropTypes.string,
+        value: PropTypes.string,
+        onChange: PropTypes.func
+      })
+    ])
+  ),
   url: PropTypes.string,
   error: PropTypes.string,
-  onUpdateVersion: PropTypes.func,
-  onUpdateField: PropTypes.func,
   onErrorRedirect: PropTypes.func,
   inputParams: PropTypes.shape({})
 };

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/index.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/index.js
@@ -1,44 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {noop, getOr, kebabCase, keys} from 'lodash/fp';
+import {noop, getOr} from 'lodash/fp';
 import Sidebar from '../sidebar';
 import Provider from '../../atom/provider';
 import Loader from '../../template/app-player/loading';
 import DashboardPopin from './dashboard-popin';
 import style from './style.css';
-
-const currentDashboardSidebarSection = ({
-  currentDashboard,
-  onUpdateVersion,
-  onUpdateField,
-  inputParams,
-  dashboardVersionTitle
-}) => {
-  const dashboardDescription = {
-    title: currentDashboard.name,
-    type: 'info',
-    value: currentDashboard.description
-  };
-  const dashboardVersion = {
-    title: dashboardVersionTitle,
-    type: 'select',
-    name: 'version-field',
-    onChange: onUpdateVersion,
-    options: keys(currentDashboard.versions).map(v => ({
-      name: v,
-      value: v,
-      selected: v === currentDashboard.currentVersion
-    }))
-  };
-  const paramInputs = currentDashboard.schema.map(schema => ({
-    title: schema,
-    name: `${kebabCase(schema)}-field`,
-    type: 'inputtext',
-    onChange: newValue => onUpdateField(schema, newValue),
-    value: getOr('', schema, inputParams)
-  }));
-  return [dashboardDescription, ...paramInputs, dashboardVersion];
-};
 
 const Dashboard = (props, context) => {
   const {url, error, selected} = props;

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/default.js
@@ -20,6 +20,7 @@ export default {
         href: '/dashboards/analytics-partners'
       }
     ],
-    onSelectDashboard: dashboard => console.log('SELECTED', dashboard)
+    onSelectDashboard: dashboard => console.log('SELECTED', dashboard),
+    sidebarItems: []
   }
 };

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected-error.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected-error.js
@@ -39,6 +39,7 @@ export default {
     onUpdateField: (field, value) => console.log('UPDATE', field, value),
     inputParams: {
       provider: 'connect'
-    }
+    },
+    sidebarItems: []
   }
 };

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected-loading.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected-loading.js
@@ -37,6 +37,7 @@ export default {
     onUpdateField: (field, value) => console.log('UPDATE', field, value),
     inputParams: {
       provider: 'connect'
-    }
+    },
+    sidebarItems: []
   }
 };

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/fixtures/selected.js
@@ -38,6 +38,34 @@ export default {
     inputParams: {
       platform: 'up',
       provider: 'connect'
-    }
+    },
+    sidebarItems: [
+      {title: 'Analytics Engagement', type: 'info', value: `Stats d'engagement des utilisateurs`},
+      {
+        title: 'platform',
+        name: 'platform-field',
+        type: 'inputtext',
+        onChange: (field, value) => console.log('UPDATE', field, value),
+        value: 'up'
+      },
+      {
+        title: 'provider',
+        name: 'provider-field',
+        type: 'inputtext',
+        onChange: (field, value) => console.log('UPDATE', field, value),
+        value: 'connect'
+      },
+      {
+        title: 'Version',
+        type: 'select',
+        name: 'version-field',
+        onChange: version => console.log('VERSION', version),
+        options: [
+          {name: 'v1', value: 'v1', selected: false},
+          {name: 'v2', value: 'v2', selected: true},
+          {name: 'v3', value: 'aa-ee-bb-cc-dd-xx', selected: false}
+        ]
+      }
+    ]
   }
 };

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/on-update-field.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/on-update-field.js
@@ -11,32 +11,15 @@ browserEnv();
 configure({adapter: new Adapter()});
 
 test('should call the onUpdateField function with the value of the target', t => {
-  t.plan(3);
+  t.plan(2);
 
   const selector = 'li[data-name="platform-field"] input';
-  const onChange = (field, value) => {
-    t.is(field, 'platform');
+  const onChange = value => {
     t.is(value, 'toto');
   };
+  defaultFixture.props.sidebarItems[1].onChange = onChange;
 
   const wrapper = mount(<DashboardPreview {...defaultFixture.props} onUpdateField={onChange} />, {
-    context: {translate: id => id},
-    childContextTypes: {translate: PropTypes.func}
-  });
-
-  t.true(wrapper.find(selector).exists());
-
-  wrapper.find(selector).simulate('change', {
-    target: {
-      value: 'toto'
-    }
-  });
-});
-
-test('should not crash if the onUpdateField function has not been specified', t => {
-  t.plan(1);
-  const selector = 'li[data-name="platform-field"] input';
-  const wrapper = mount(<DashboardPreview {...defaultFixture.props} onUpdateField={undefined} />, {
     context: {translate: id => id},
     childContextTypes: {translate: PropTypes.func}
   });

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/on-update-field.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/on-update-field.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {mount, configure} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import DashboardPreview from '..';
+import BrandDashboard from '..';
 import defaultFixture from './fixtures/selected';
 
 browserEnv();
@@ -19,7 +19,7 @@ test('should call the onUpdateField function with the value of the target', t =>
   };
   defaultFixture.props.sidebarItems[1].onChange = onChange;
 
-  const wrapper = mount(<DashboardPreview {...defaultFixture.props} onUpdateField={onChange} />, {
+  const wrapper = mount(<BrandDashboard {...defaultFixture.props} onUpdateField={onChange} />, {
     context: {translate: id => id},
     childContextTypes: {translate: PropTypes.func}
   });

--- a/packages/@coorpacademy-components/src/organism/brand-dashboard/test/on-update-version.js
+++ b/packages/@coorpacademy-components/src/organism/brand-dashboard/test/on-update-version.js
@@ -4,44 +4,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {mount, configure} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import DashboardPreview from '..';
+import BrandDashboard from '..';
 import defaultFixture from './fixtures/selected';
 
 browserEnv();
 configure({adapter: new Adapter()});
 
-test('should call the onUpdateVersion function with the value of the target', t => {
+test('should call the onChange function with the value of the target', t => {
   t.plan(2);
 
   const selector = 'li[data-name="version-field"] select';
   const onChange = value => {
     t.is(value, 'foo');
   };
+  defaultFixture.props.sidebarItems[3].onChange = onChange;
 
-  const wrapper = mount(<DashboardPreview {...defaultFixture.props} onUpdateVersion={onChange} />, {
+  const wrapper = mount(<BrandDashboard {...defaultFixture.props} />, {
     context: {translate: id => id},
     childContextTypes: {translate: PropTypes.func}
   });
-
-  t.true(wrapper.find(selector).exists());
-
-  wrapper.find(selector).simulate('change', {
-    target: {
-      value: 'foo'
-    }
-  });
-});
-
-test('should not crash if the onUpdateVersion function has not been specified', t => {
-  t.plan(1);
-  const selector = 'li[data-name="version-field"] select';
-  const wrapper = mount(
-    <DashboardPreview {...defaultFixture.props} onUpdateVersion={undefined} />,
-    {
-      context: {translate: id => id},
-      childContextTypes: {translate: PropTypes.func}
-    }
-  );
 
   t.true(wrapper.find(selector).exists());
 


### PR DESCRIPTION
This pr adaptes the `dashboards preview` to be used in `brand update` component and add it in `brand update` comonent as content 
[Ticket](https://trello.com/c/3Qjz40g4)

DashboardPreview => BrandDashboard


![brandhDashboard](https://user-images.githubusercontent.com/58167920/120486865-ba7a3480-c3b5-11eb-9ca7-c32c468aeeae.gif)


UpdateBrand with BrandDashboard

![brandDashboard](https://user-images.githubusercontent.com/58167920/120487028-e2699800-c3b5-11eb-85d8-add371dc3fc5.gif)


Error popin 

![image](https://user-images.githubusercontent.com/58167920/120658019-5a52c380-c485-11eb-8151-6e385431373c.png)

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
