### PR TITLE
use onClick in edit brand card instade of href

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/brand-card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-card/index.js
@@ -51,7 +51,7 @@ BrandCard.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
   edit: PropTypes.string.isRequired,
-  editHref: PropTypes.string.isRequired,
+  editHref: PropTypes.string,
   onEditClick: PropTypes.func,
   see: PropTypes.string.isRequired,
   seeHref: PropTypes.string.isRequired,

--- a/packages/@coorpacademy-components/src/molecule/brand-card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-card/index.js
@@ -7,7 +7,17 @@ import Description from './description';
 import style from './style.css';
 
 const BrandCard = props => {
-  const {title, edit, editHref, see, seeHref, image, description, maintenance = false} = props;
+  const {
+    title,
+    edit,
+    editHref,
+    onEditClick,
+    see,
+    seeHref,
+    image,
+    description,
+    maintenance = false
+  } = props;
   const maintenanceView = maintenance ? (
     <div className={style.lockWrapper}>
       <LockIcon className={style.lockIcon} height={80} />
@@ -23,7 +33,7 @@ const BrandCard = props => {
       <div className={style.information} data-name={`info-${title}`}>
         <h3>{title}</h3>
         <div className={style.edit}>
-          <Link href={editHref} data-name={`edit-${title}`}>
+          <Link href={editHref} onClick={onEditClick} data-name={`edit-${title}`}>
             {edit}
           </Link>
         </div>
@@ -42,6 +52,7 @@ BrandCard.propTypes = {
   description: PropTypes.string,
   edit: PropTypes.string.isRequired,
   editHref: PropTypes.string.isRequired,
+  onEditClick: PropTypes.func,
   see: PropTypes.string.isRequired,
   seeHref: PropTypes.string.isRequired,
   image: PropTypes.string.isRequired,

--- a/packages/@coorpacademy-components/src/molecule/brand-card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-card/index.js
@@ -54,7 +54,7 @@ BrandCard.propTypes = {
   editHref: PropTypes.string,
   onEditClick: PropTypes.func,
   see: PropTypes.string.isRequired,
-  seeHref: PropTypes.string.isRequired,
+  seeHref: PropTypes.string,
   image: PropTypes.string.isRequired,
   maintenance: PropTypes.bool
 };

--- a/packages/@coorpacademy-components/src/molecule/brand-card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/brand-card/style.css
@@ -103,6 +103,7 @@
 .edit {
   composes: link;
   border-right: 1px solid xtraLightGrey;
+  cursor: pointer;
 }
 
 .edit a:hover {

--- a/packages/@coorpacademy-components/src/molecule/brand-card/test/fixtures/with-description.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-card/test/fixtures/with-description.js
@@ -3,7 +3,7 @@ export default {
     title: 'Chanel iJoin',
     edit: 'Edit Platform',
     description: '<p>C.C.I. Pays de la loire</p><p>Digital Culture</p>',
-    editHref: '#',
+    onEditClick: () => console.log('onEditClick'),
     see: 'See Platform',
     seeHref: '#',
     maintenance: true,


### PR DESCRIPTION
Use onClick instead of href
this will halp us to dispatch action when user click edit platform ( to get dashboards for exemple ) 
<img width="294" alt="image" src="https://user-images.githubusercontent.com/58167920/123285132-134c7100-d50d-11eb-93d0-79ef1878f209.png">

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
