### PR TITLE
Set height 100% to pdf & audio

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/audio/style.css
+++ b/packages/@coorpacademy-components/src/molecule/audio/style.css
@@ -9,7 +9,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 343px;
+  height: 100%;
   background-color: medium;
   color: white;
   background-size: cover;

--- a/packages/@coorpacademy-components/src/molecule/pdf/style.css
+++ b/packages/@coorpacademy-components/src/molecule/pdf/style.css
@@ -9,7 +9,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 343px;
+  height: 100%;
   background-color: medium;
   color: white;
   background-size: cover;

--- a/packages/@coorpacademy-components/src/molecule/resource-player/index.js
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import {omit, get} from 'lodash/fp';
 import {NovaSolidVideosVideoControlPlay as Play} from '@coorpacademy/nova-icons';
 import Pdf from '../pdf';
@@ -141,24 +140,26 @@ class ResourcePlayer extends React.Component {
     const {className: customClassName, resource, overlay: propsOverlay} = this.props;
     const {overlay: stateOverlay, autoplay} = this.state;
     const {type} = resource;
-    const className = classnames(
-      {
-        [TYPE_IMAGE]: style.image,
-        [TYPE_PDF]: style.pdf,
-        [TYPE_AUDIO]: style.audio,
-        [TYPE_VIDEO]: style.video
-      }[type],
-      customClassName
-    );
 
     const overlayView = stateOverlay ? (
       <OverlayElement {...stateOverlay} onClick={this.handleOverlay} />
     ) : null;
 
     return (
-      <div data-name={type} className={className}>
-        {overlayView}
-        <ResourceElement {...this.props} disableAutostart={!!propsOverlay} autoplay={autoplay} />
+      <div data-name={type} className={customClassName}>
+        <div
+          className={
+            {
+              [TYPE_IMAGE]: style.image,
+              [TYPE_PDF]: style.pdf,
+              [TYPE_AUDIO]: style.audio,
+              [TYPE_VIDEO]: style.video
+            }[type]
+          }
+        >
+          {overlayView}
+          <ResourceElement {...this.props} disableAutostart={!!propsOverlay} autoplay={autoplay} />
+        </div>
       </div>
     );
   }

--- a/packages/@coorpacademy-components/src/molecule/resource-player/style.css
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/style.css
@@ -1,7 +1,6 @@
 .image {
-  overflow: hidden;
   display: flex;
-  height: 100%;
+  height: 343px;
 }
 
 .image .img {
@@ -14,7 +13,8 @@
 .video {
   background-color: black;
   position: relative;
-  overflow: hidden;
+  height: 343px;
+  width: 100%;
 }
 
 .pdf {

--- a/packages/@coorpacademy-components/src/molecule/video-player/style.css
+++ b/packages/@coorpacademy-components/src/molecule/video-player/style.css
@@ -1,5 +1,6 @@
 .wrapper {
   width: 100%;
+  height: 100%;
   position: relative;
   display: flex; 
   align-items: center;

--- a/packages/@coorpacademy-components/src/template/app-player/player/test/fixtures/context-with-audio.js
+++ b/packages/@coorpacademy-components/src/template/app-player/player/test/fixtures/context-with-audio.js
@@ -1,0 +1,9 @@
+import Context from '../../slides/test/fixtures/context-with-audio';
+
+const playerProps = Context.props;
+
+export default {
+  props: {
+    player: playerProps
+  }
+};

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -789,6 +789,7 @@ import TemplateAppPlayerPlayerSlidesFixtureWithMinHeight from '../src/template/a
 import TemplateAppPlayerPlayerFixtureArabicQcm from '../src/template/app-player/player/test/fixtures/arabic-qcm';
 import TemplateAppPlayerPlayerFixtureBackground from '../src/template/app-player/player/test/fixtures/background';
 import TemplateAppPlayerPlayerFixtureClue from '../src/template/app-player/player/test/fixtures/clue';
+import TemplateAppPlayerPlayerFixtureContextWithAudio from '../src/template/app-player/player/test/fixtures/context-with-audio';
 import TemplateAppPlayerPlayerFixtureContextWithImage from '../src/template/app-player/player/test/fixtures/context-with-image';
 import TemplateAppPlayerPlayerFixtureContextWithPdf from '../src/template/app-player/player/test/fixtures/context-with-pdf';
 import TemplateAppPlayerPlayerFixtureContextWithVideo from '../src/template/app-player/player/test/fixtures/context-with-video';
@@ -2040,6 +2041,7 @@ export const fixtures = {
       ArabicQcm: TemplateAppPlayerPlayerFixtureArabicQcm,
       Background: TemplateAppPlayerPlayerFixtureBackground,
       Clue: TemplateAppPlayerPlayerFixtureClue,
+      ContextWithAudio: TemplateAppPlayerPlayerFixtureContextWithAudio,
       ContextWithImage: TemplateAppPlayerPlayerFixtureContextWithImage,
       ContextWithPdf: TemplateAppPlayerPlayerFixtureContextWithPdf,
       ContextWithVideo: TemplateAppPlayerPlayerFixtureContextWithVideo,


### PR DESCRIPTION
- Rollback de la solution d'@audric-coorp.
- La hauteur des components pdf et audio sont maintenant dynamique.

![Capture d’écran 2021-07-07 à 14 42 03](https://user-images.githubusercontent.com/509108/124761405-0dee1e00-df32-11eb-8a5b-a38d6bbaa0ab.png)

## Regression (une fois mergé)

http://coorpacademy.github.io/components/components/?path=/story/moleculedisciplinescope--pdf
http://coorpacademy.github.io/components/components/?path=/story/moleculedisciplinescope--audio
http://coorpacademy.github.io/components/components/?path=/story/moleculedisciplinescope--medias

http://coorpacademy.github.io/components/components/?path=/story/templateappplayerplayer--contextwithpdf
http://coorpacademy.github.io/components/components/?path=/story/templateappplayerplayer--contextwithaudio (nouvelle fixture)
http://coorpacademy.github.io/components/components/?path=/story/templateappplayerplayer--mediaomniplayer
http://coorpacademy.github.io/components/components/?path=/story/templateappplayerplayer--contextwithimage