### PR TITLE
Fix popin-end overflow

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/resource-player/style.css
+++ b/packages/@coorpacademy-components/src/molecule/resource-player/style.css
@@ -1,6 +1,6 @@
 .image {
   display: flex;
-  height: 343px;
+  height: 100%;
 }
 
 .image .img {
@@ -13,7 +13,7 @@
 .video {
   background-color: black;
   position: relative;
-  height: 343px;
+  height: 100%;
   width: 100%;
 }
 

--- a/packages/@coorpacademy-components/src/organism/resource-browser/index.js
+++ b/packages/@coorpacademy-components/src/organism/resource-browser/index.js
@@ -32,13 +32,15 @@ const ResourceBrowser = props => {
   const selectedResource = find(({selected}) => selected, resources);
   return (
     <div data-name="resourceBrowser" className={classnames(style.default, className)}>
-      {selectedResource ? (
-        <ResourcePlayer
-          overlay={overlay}
-          className={style.resourcePlayer}
-          resource={selectedResource}
-        />
-      ) : null}
+      <div className={style.resourcePlayerWrapper}>
+        {selectedResource ? (
+          <ResourcePlayer
+            overlay={overlay}
+            className={style.resourcePlayer}
+            resource={selectedResource}
+          />
+        ) : null}
+      </div>
       <Resources resources={resources} className={className} />
     </div>
   );

--- a/packages/@coorpacademy-components/src/organism/resource-browser/style.css
+++ b/packages/@coorpacademy-components/src/organism/resource-browser/style.css
@@ -15,6 +15,10 @@
   max-height: 343px;
 }
 
+.resourcePlayerWrapper {
+  height: 343px;
+}
+
 .resourcePlayer {
   width: 609px;
   display: flex;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/509108/125758698-0ecaac8f-ff01-4362-87e7-09dd3253fc99.png)

Le player est fluide, c'est à son parent de lui fixer ses dimensions.
ResourceBrowser -> 343px
PopinEnd -> 241px

https://coorpacademy.github.io/components/components/?path=/story/templateappplayerpopinend--nextleveladaptiveimg