### PR TITLE
Optimization of dashboard rendering

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/dashboard/battle-request-list/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/battle-request-list/index.js
@@ -25,4 +25,4 @@ BattleRequestList.propTypes = {
   requests: PropTypes.arrayOf(PropTypes.shape(BattleRequest.propTypes))
 };
 
-export default BattleRequestList;
+export default React.memo(BattleRequestList);

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/index.js
@@ -85,7 +85,7 @@ IconView.propTypes = {
   contentType: PropTypes.string
 };
 
-class CardsList extends React.Component {
+class CardsList extends React.PureComponent {
   static propTypes = {
     contentType: PropTypes.string,
     dataName: PropTypes.string,

--- a/packages/@coorpacademy-components/src/molecule/dashboard/news-list/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/news-list/index.js
@@ -49,4 +49,4 @@ NewsList.propTypes = {
   loading: PropTypes.bool
 };
 
-export default NewsList;
+export default React.memo(NewsList);

--- a/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/index.js
@@ -54,4 +54,4 @@ StartBattle.propTypes = {
   href: PropTypes.string
 };
 
-export default StartBattle;
+export default React.memo(StartBattle);

--- a/packages/@coorpacademy-components/src/template/common/dashboard/index.js
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/index.js
@@ -23,6 +23,8 @@ const Dashboard = props => {
   const buildSectionComponent = section => {
     const {type} = section;
     switch (type) {
+      case 'hero':
+        return <Hero hero={hero} welcome={welcome} />;
       case 'battleRequests':
         return <BattleRequestList {...section} />;
       case 'cards':
@@ -42,10 +44,11 @@ const Dashboard = props => {
     return <div key={index}>{sectionView}</div>;
   };
 
-  const sectionsList = sections.map(buildSection);
+  const sectionsList = [{type: 'hero', key: 'hero'}, ...sections].map(section => (
+    <div key={section.key}>{buildSection(section)}</div>
+  ));
   return (
     <div className={style.wrapper} data-name="dashboard">
-      <Hero hero={hero} welcome={welcome} />
       {sectionsList}
     </div>
   );

--- a/packages/@coorpacademy-components/src/template/common/dashboard/index.js
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/index.js
@@ -8,9 +8,9 @@ import NewsList from '../../../molecule/dashboard/news-list';
 import StartBattle from '../../../molecule/dashboard/start-battle';
 import style from './style.css';
 
-const Hero = ({hero, welcome}) => (
-  <div className={style.hero}>{hero ? <HeroCard {...hero} /> : <Slide {...welcome} />}</div>
-);
+const Hero = React.memo(function Hero({hero, welcome}) {
+  return <div className={style.hero}>{hero ? <HeroCard {...hero} /> : <Slide {...welcome} />}</div>;
+});
 
 Hero.propTypes = {
   hero: PropTypes.shape(HeroCard.propTypes),

--- a/packages/@coorpacademy-components/src/template/common/dashboard/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/test/fixtures/default.js
@@ -23,19 +23,24 @@ export default {
     },
     sections: [
       defaultsDeep(requestsProps, {
-        type: 'battleRequests'
+        type: 'battleRequests',
+        key: 'battleRequests'
       }),
       defaultsDeep(cardsProps, {
-        type: 'cards'
+        type: 'cards',
+        key: 'playlist1'
       }),
       defaultsDeep(manyCardsProps, {
-        type: 'cards'
+        type: 'cards',
+        key: 'playlist2'
       }),
       defaultsDeep(battleProps, {
-        type: 'battle'
+        type: 'battle',
+        key: 'battle'
       }),
       defaultsDeep(newsProps, {
-        type: 'news'
+        type: 'news',
+        key: 'news'
       })
     ]
   }

--- a/packages/@coorpacademy-components/src/template/common/dashboard/test/fixtures/empty-requests.js
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/test/fixtures/empty-requests.js
@@ -19,19 +19,24 @@ export default {
     ...props,
     sections: [
       defaultsDeep(requestsProps, {
-        type: 'battleRequests'
+        type: 'battleRequests',
+        key: 'battleRequests'
       }),
       defaultsDeep(cardsProps, {
-        type: 'cards'
+        type: 'cards',
+        key: 'playlist1'
       }),
       defaultsDeep(manyCardsProps, {
-        type: 'cards'
+        type: 'cards',
+        key: 'playlist1'
       }),
       defaultsDeep(battleProps, {
-        type: 'battle'
+        type: 'battle',
+        key: 'battle'
       }),
       defaultsDeep(newsProps, {
-        type: 'news'
+        type: 'news',
+        key: 'news'
       })
     ]
   }


### PR DESCRIPTION
- React.memo
- React.PureComponent
- key

Les sections sont maintenant réordonnées et non plus recréées grâce à l'attribut `key`.
Les components des sections sont memorisés pour éviter un rendu si les props ou state n'ont pas changé.