### PR TITLE
[Fix] Remove estraverse-fb unmaintained dependency in favour of estraverse 5.2, fix locales test error

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@coorpacademy/update-node": "^4.3.0",
     "codecov": "^3.8.3",
-    "estraverse-fb": "1.3.2",
+    "estraverse": "^5.2.0",
     "lerna": "^4.0.0",
     "mkdirp": "^1.0.4"
   }

--- a/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/cards-list/test/index.js
@@ -129,7 +129,7 @@ test('should return scrollWidth and call onScroll if exist', t => {
   cardsList.unmount();
 });
 
-test('should update componenet when resizing', t => {
+test('should update component when resizing', t => {
   const {props} = Card;
   const props_ = {
     cards: times(() => props, 3)

--- a/test/helpers/locales.js
+++ b/test/helpers/locales.js
@@ -9,7 +9,7 @@ const remove = require('lodash/fp/remove');
 const flatMap = require('lodash/fp/flatMap');
 const mapValues = require('lodash/fp/mapValues');
 const difference = require('lodash/fp/difference');
-const estraverse = require('estraverse-fb');
+const estraverse = require('estraverse');
 const babelESLint = require('babel-eslint');
 
 const forbiddenCharacters = /:/;
@@ -25,6 +25,11 @@ function interpolate(str) {
 
 estraverse.VisitorKeys.ExperimentalRestProperty = [];
 estraverse.VisitorKeys.ExperimentalSpreadProperty = [];
+estraverse.VisitorKeys.ExportDefaultSpecifier = [];
+estraverse.VisitorKeys.JSXElement = [];
+estraverse.VisitorKeys.JSXFragment = [];
+estraverse.VisitorKeys.ClassProperty = [];
+estraverse.VisitorKeys.OptionalMemberExpression = [];
 
 function position(node) {
   return `${node.loc.start.line}:${node.loc.start.column}`;

--- a/test/helpers/locales.js
+++ b/test/helpers/locales.js
@@ -23,13 +23,14 @@ function interpolate(str) {
   return [value[1]].concat(interpolate(str.substring(value.index + value[0].length)));
 }
 
-estraverse.VisitorKeys.ExperimentalRestProperty = [];
-estraverse.VisitorKeys.ExperimentalSpreadProperty = [];
-estraverse.VisitorKeys.ExportDefaultSpecifier = [];
-estraverse.VisitorKeys.JSXElement = [];
-estraverse.VisitorKeys.JSXFragment = [];
-estraverse.VisitorKeys.ClassProperty = [];
-estraverse.VisitorKeys.OptionalMemberExpression = [];
+estraverse.VisitorKeys.ExperimentalRestProperty = ['argument'];
+estraverse.VisitorKeys.ExperimentalSpreadProperty = ['argument'];
+estraverse.VisitorKeys.JSXElement = ['openingElement', 'children', 'closingElement'];
+estraverse.VisitorKeys.JSXFragment = ['openingFragment', 'children', 'closingFragment'];
+
+estraverse.VisitorKeys.ClassProperty = ['body', 0];
+estraverse.VisitorKeys.OptionalMemberExpression = ['value'];
+estraverse.VisitorKeys.ExportDefaultSpecifier = ['specifiers', 0];
 
 function position(node) {
   return `${node.loc.start.line}:${node.loc.start.column}`;

--- a/test/helpers/locales.js
+++ b/test/helpers/locales.js
@@ -26,8 +26,17 @@ function interpolate(str) {
 estraverse.VisitorKeys.ExperimentalRestProperty = ['argument'];
 estraverse.VisitorKeys.ExperimentalSpreadProperty = ['argument'];
 estraverse.VisitorKeys.JSXElement = ['openingElement', 'children', 'closingElement'];
+estraverse.VisitorKeys.JSXOpeningElement = ['name', 'attributes'];
+estraverse.VisitorKeys.JSXClosingElement = ['name'];
+estraverse.VisitorKeys.JSXIdentifier = [];
+estraverse.VisitorKeys.JSXText = [];
+estraverse.VisitorKeys.JSXOpeningFragment = ['name', 'attributes'];
+estraverse.VisitorKeys.JSXClosingFragment = ['name'];
+estraverse.VisitorKeys.JSXMemberExpression = ['object', 'property'];
+estraverse.VisitorKeys.JSXAttribute = ['name', 'value'];
+estraverse.VisitorKeys.JSXSpreadAttribute = ['argument'];
+estraverse.VisitorKeys.JSXExpressionContainer = ['expression'];
 estraverse.VisitorKeys.JSXFragment = ['openingFragment', 'children', 'closingFragment'];
-
 estraverse.VisitorKeys.ClassProperty = ['body', 0];
 estraverse.VisitorKeys.OptionalMemberExpression = ['value'];
 estraverse.VisitorKeys.ExportDefaultSpecifier = ['specifiers', 0];

--- a/yarn.lock
+++ b/yarn.lock
@@ -8797,11 +8797,6 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse-fb@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.2.tgz#d323a4cb5e5ac331cea033413a9253e1643e07c4"
-  integrity sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=
-
 estraverse@^4.0.0, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
@@ -8816,6 +8811,11 @@ estraverse@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
   integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+
+estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- Removes estraverse-fb unmaintained dependency in favour of estraverse 5.2
- Fixes [locales test error](https://app.travis-ci.com/github/CoorpAcademy/components/jobs/528396120). 
- Patches VisitorKeys for estraverse (ExportDefaultSpecifier, JSXElement, JSXFragment, ClassProperty, OptionalMemberExpression)

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
