### PR TITLE
[Mooc-Header] Fix min-height for small logos on tablet - mobile view

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -516,11 +516,13 @@
     justify-content: flex-start;
     height: auto;
     align-items: center;
+    min-height: 60px;
   }
 
   .open {
     height: auto;
     display: flex;
+    min-height: 60px;
   }
 
   .logoWrapper {


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
-  Fixes min-height for small logos on tablet - mobile view

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**
**Before**  

![Screenshot 2021-08-04 at 14 14 46](https://user-images.githubusercontent.com/33550261/128179144-e1c3ea31-28dc-481c-9e3a-780c1d937d89.png)
![Screenshot 2021-08-04 at 14 14 53](https://user-images.githubusercontent.com/33550261/128179145-d052bcf7-45a6-4c92-9f48-fa87bcbea0b9.png)

**After**  

![Screenshot 2021-08-04 at 14 15 30](https://user-images.githubusercontent.com/33550261/128179150-25527810-dff4-400b-8f64-1ed7e577460b.png)
![Screenshot 2021-08-04 at 14 15 37](https://user-images.githubusercontent.com/33550261/128179152-d60e348f-77e0-4bfe-8844-48bfdd2d4479.png)



<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
