### PR TITLE
Fix - resource titles overlap

### DIFF
--- a/packages/@coorpacademy-components/src/atom/resource-miniature/style.css
+++ b/packages/@coorpacademy-components/src/atom/resource-miniature/style.css
@@ -8,11 +8,11 @@
 .resource {
   position: relative;
   width: auto;
-  height: 52px;
+  min-height: 52px;
   cursor: pointer;
   margin-bottom: 8px;
   display: flex;
-  align-items: center;
+  align-items: start;
   flex: 1 0 52px;
 }
 


### PR DESCRIPTION
 https://app.prodpad.com/ideas/3730/canvas
https://app.prodpad.com/ideas/3731/canvas

Le titre des vignettes du player vidéo se chevauchent lorsque le texte est trop long.
https://tourism-covid.coorpacademy.com/discipline/dis_4kDyKFNsu?level=advanced


## BEFORE
<img width="832" alt="Capture d’écran 2021-08-09 à 10 58 31" src="https://user-images.githubusercontent.com/15608581/128683253-b8240ef9-aa15-4122-81d3-5663da3bae91.png">

## AFTER
<img width="831" alt="Capture d’écran 2021-08-09 à 10 58 11" src="https://user-images.githubusercontent.com/15608581/128683262-cda0b47e-655e-4d77-b971-20554258f836.png">


<!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
