### PR TITLE
Update forms for coorpmanager

### DIFF
--- a/packages/@coorpacademy-components/src/atom/title/index.js
+++ b/packages/@coorpacademy-components/src/atom/title/index.js
@@ -1,11 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import style from './style.css';
 
-const Title = ({children}) => {
-  return <h1>{children}</h1>;
+const Title = props => {
+  const {title, subtitle} = props;
+
+  const subtitleSection = subtitle ? <div className={style.subtitle}>{subtitle}</div> : null;
+
+  return (
+    <div>
+      <div className={style.title}>{title}</div>
+      {subtitleSection}
+    </div>
+  );
 };
 
 Title.propTypes = {
-  children: PropTypes.node
+  title: PropTypes.string,
+  subtitle: PropTypes.string
 };
 export default Title;

--- a/packages/@coorpacademy-components/src/atom/title/style.css
+++ b/packages/@coorpacademy-components/src/atom/title/style.css
@@ -4,8 +4,8 @@
 .title {
     font-family: Gilroy;
     font-style: normal;
-    font-weight: 600;
-    font-size: 42px;
+    font-weight: bold;
+    font-size: 32px;
     line-height: 52px;
     color: cm_black;
 }
@@ -14,7 +14,8 @@
     margin: 8px 0 0;
     font-family: Gilroy;
     font-style: normal;
-    font-weight: 400;
+    font-weight: normal;
     font-size: 18px;
     line-height: 24px;
+    color: cm_black;
 }

--- a/packages/@coorpacademy-components/src/atom/title/style.css
+++ b/packages/@coorpacademy-components/src/atom/title/style.css
@@ -1,0 +1,20 @@
+@value colors: "../../variables/colors.css";
+@value cm_black from colors;
+
+.title {
+    font-family: Gilroy;
+    font-style: normal;
+    font-weight: 600;
+    font-size: 42px;
+    line-height: 52px;
+    color: cm_black;
+}
+
+.subtitle {
+    margin: 8px 0 0;
+    font-family: Gilroy;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 24px;
+}

--- a/packages/@coorpacademy-components/src/atom/title/test/fixtures/fixture.js
+++ b/packages/@coorpacademy-components/src/atom/title/test/fixtures/fixture.js
@@ -1,3 +1,6 @@
 export default {
-  children: 'foo'
+  props: {
+    title: 'Hello Marianna!',
+    subtitle: 'Welcome to the coorpmanager dashboard'
+  }
 };

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/style.css
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/style.css
@@ -1,5 +1,6 @@
 @value colors: "../../variables/colors.css";
-@value dark from colors;
+@value cm_black from colors;
+@value medium from colors;
 
 .wrapper {
   width: 100%;
@@ -21,20 +22,22 @@
 }
 
 .title h3 {
-  font-family: 'Open Sans';
-  font-size: 17px;
-  font-weight: 700;
-  color: dark;
-  margin: 0;
+  font-family: 'Gilroy';
+  font-size: 18px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  color: cm_black;
 }
 
 .title h4 {
-  font-family: 'Open Sans';
-  font-size: 13px;
+  font-family: 'Gilroy';
+  font-size: 14px;
   font-weight: 400;
-  font-style: italic;
-  color: dark;
-  margin: 5px 0;
+  font-style: normal;
+  line-height: 20px;
+  color: medium;
+  margin: 8px 0;
 }
 
 .field {

--- a/packages/@coorpacademy-components/src/organism/brand-form/index.js
+++ b/packages/@coorpacademy-components/src/organism/brand-form/index.js
@@ -36,7 +36,7 @@ function BrandForm(props, context) {
 
   const brandGroups = groups.map((group, index) => {
     return (
-      <div className={style.group} key={index}>
+      <div key={index}>
         <BrandFormGroup {...group} />
       </div>
     );

--- a/packages/@coorpacademy-components/src/organism/brand-form/style.css
+++ b/packages/@coorpacademy-components/src/organism/brand-form/style.css
@@ -15,7 +15,7 @@
 
 .backDesc {
   margin-left: 10px;
-  font-family: 'Open Sans';
+  font-family: 'Gilroy';
   font-size: 15px;
   font-weight: 700;
   color: dark;
@@ -24,15 +24,6 @@
 
 .backDesc:hover {
   color: brand;
-}
-
-.group {
-  border-bottom: 1px solid light;
-  margin-top: 50px;
-}
-
-.group:first-child {
-  margin-top: 0;
 }
 
 .buttons {
@@ -63,7 +54,7 @@
   padding: 10px;
   margin: 0;
   border-radius: 3px;
-  font-family: 'Open Sans';
+  font-family: 'Gilroy';
   font-size: 12px;
   width: 270px;
   background-color: white;

--- a/packages/@coorpacademy-components/src/template/cockpit/jw-uploader/index.js
+++ b/packages/@coorpacademy-components/src/template/cockpit/jw-uploader/index.js
@@ -4,7 +4,6 @@ import Button from '../../../atom/button';
 import Input from '../../../atom/input-text';
 import InputReadonly from '../../../atom/input-readonly';
 import VideoUpload from '../../../atom/video-upload';
-import Title from '../../../atom/title';
 import style from './style.css';
 
 const JwVideoUploader = ({
@@ -19,7 +18,7 @@ const JwVideoUploader = ({
   return (
     <div className={style.container}>
       <div className={style.wrapper}>
-        <Title>Jw Video Upload</Title>
+        <h1>Jw Video Upload</h1>
         <Input placeholder={placeholder} onChange={onInputTextChange} value={inputTextValue} />
         <VideoUpload
           title="Video Preview"

--- a/packages/@coorpacademy-components/src/variables/colors.css
+++ b/packages/@coorpacademy-components/src/variables/colors.css
@@ -5,7 +5,7 @@
 @value primaryAdd4: #015798;
 @value xtraLightGrey: #FAFAFA;
 @value light: #ECEFF1;
-@value medium: #9999A8;
+@value medium: #90A4AE;
 @value dark: #546E7A;
 @value grey: #607D8B;
 @value lightMediumGray: #CFD8DC;

--- a/packages/@coorpacademy-components/src/variables/colors.css
+++ b/packages/@coorpacademy-components/src/variables/colors.css
@@ -5,7 +5,7 @@
 @value primaryAdd4: #015798;
 @value xtraLightGrey: #FAFAFA;
 @value light: #ECEFF1;
-@value medium: #90A4AE;
+@value medium: #9999A8;
 @value dark: #546E7A;
 @value grey: #607D8B;
 @value lightMediumGray: #CFD8DC;
@@ -26,7 +26,7 @@
 @value shadow: rgba(0, 0, 0, 0.06);
 @value transparentRed: rgba(247, 63, 82, 0.1);
 @value battle_bg: #111026;
-@value cm_black: #111117;
+@value cm_black: #1D1D2B;
 @value cm_blue: #0061FF;
 @value cm_darkBlue: #0051d6;
 @value cm_grey: #515161;


### PR DESCRIPTION
**Detailed purpose of the PR**

This PR format groups on setup form to the style on coorpmanager.
Colors were also updated based on Figma specifications cc @wernerdurand 

**Result and observation**

BEFORE 
<img width="1182" alt="Capture d’écran 2021-10-04 à 10 47 49" src="https://user-images.githubusercontent.com/7602475/135821380-a46b3ab7-def1-491d-9871-3ad3d07ece23.png">

AFTER
<img width="1180" alt="Capture d’écran 2021-10-04 à 10 48 01" src="https://user-images.githubusercontent.com/7602475/135821403-336a2491-5713-4f17-8bd3-3e2bdcab3d56.png">

No more line to separate groups and new font used on title and subtitle of groups.

It also introduces the update of the Title component

<img width="482" alt="Capture d’écran 2021-10-04 à 10 49 25" src="https://user-images.githubusercontent.com/7602475/135821572-efb2897b-b251-4989-80d6-ae9575116b24.png">

**Testing Strategy**

- Already covered by tests
- Manual testing
