### PR TITLE
fix: should fix bug for previewing external content pdf on mobile

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/index.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/index.js
@@ -15,6 +15,8 @@ const iframeStyle = {
 
 function ExternalContentViewer(props) {
   const {url, backgroundImageUrl, contentType, mode = 'default'} = props;
+  const isPdf = url.includes('.pdf');
+  const googleViewer = `https://docs.google.com/viewerng/viewer?url=${url}&embedded=true`;
 
   return startsWith('audio', contentType) ? (
     <div className={podcastWrapperStyle[mode]}>
@@ -36,7 +38,7 @@ function ExternalContentViewer(props) {
     </div>
   ) : (
     <iframe
-      src={url}
+      src={isPdf ? googleViewer : url}
       frameBorder={0}
       className={iframeStyle[mode]}
       allowFullScreen


### PR DESCRIPTION
This is should fix it, but is it the best way? huh IDK.

I've tried lots of approaches like `<object>` or `<embed>` but none of them seem to work.

Something I'm scared of is if the url does not contain the file extension, in this case we'll face the bug still :/


![Simulator Screen Recording - iPhone 11 - 2021-10-04 at 13 41 46](https://user-images.githubusercontent.com/23306911/135845584-b2eecc98-2c19-4253-8d0e-95f827288747.gif)


