### PR TITLE
Swap QS params to avoid conflicts

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/external-content-viewer/index.js
+++ b/packages/@coorpacademy-components/src/molecule/external-content-viewer/index.js
@@ -16,7 +16,7 @@ const iframeStyle = {
 function ExternalContentViewer(props) {
   const {url, backgroundImageUrl, contentType, mode = 'default'} = props;
   const isPdf = url.includes('.pdf');
-  const googleViewer = `https://docs.google.com/viewerng/viewer?url=${url}&embedded=true`;
+  const googleViewer = `https://docs.google.com/viewerng/viewer?embedded=true&url=${url}`;
 
   return startsWith('audio', contentType) ? (
     <div className={podcastWrapperStyle[mode]}>


### PR DESCRIPTION
The url itself might contain params, so this avoids the conflicts with the google-viewer params