### PR TITLE
Use quickaccess cards in brand form group

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
@@ -18,7 +18,6 @@ import InputDoublestep from '../../atom/input-doublestep';
 import ImageUpload from '../../atom/image-upload';
 import SetupSlider from '../setup-slider';
 import SetupSections from '../setup-sections';
-import QuickAccessCard from '../quick-access-card';
 import style from './style.css';
 
 const buildInput = field => {
@@ -99,10 +98,6 @@ BrandFormGroup.propTypes = {
       PropTypes.shape({
         ...Autocomplete.propTypes,
         type: PropTypes.oneOf(['autoComplete'])
-      }),
-      PropTypes.shape({
-        ...QuickAccessCard.propTypes,
-        type: PropTypes.oneOf(['quickAccessCard'])
       }),
       PropTypes.shape({
         ...InputColor.propTypes,

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
@@ -18,6 +18,7 @@ import InputDoublestep from '../../atom/input-doublestep';
 import ImageUpload from '../../atom/image-upload';
 import SetupSlider from '../setup-slider';
 import SetupSections from '../setup-sections';
+import QuickAccessCard from '../quick-access-card';
 import style from './style.css';
 
 const buildInput = field => {
@@ -98,6 +99,10 @@ BrandFormGroup.propTypes = {
       PropTypes.shape({
         ...Autocomplete.propTypes,
         type: PropTypes.oneOf(['autoComplete'])
+      }),
+      PropTypes.shape({
+        ...QuickAccessCard.propTypes,
+        type: PropTypes.oneOf(['quickAccessCard'])
       }),
       PropTypes.shape({
         ...InputColor.propTypes,

--- a/packages/@coorpacademy-components/src/molecule/quick-access-card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-card/style.css
@@ -5,6 +5,7 @@
   width: 268px;
   height: 281px;
   cursor: pointer;
+  position: relative;
 }
 
 .content {

--- a/packages/@coorpacademy-components/src/molecule/quick-access-card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-card/style.css
@@ -14,6 +14,7 @@
   height: 100%;
   width: 100%;
   border-radius: 8px;
+  transition: all 0.5s linear;
 }
 
 .content:hover {

--- a/packages/@coorpacademy-components/src/molecule/quick-access-card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-card/style.css
@@ -1,9 +1,11 @@
 @value colors: "../../variables/colors.css";
+@value breakpoints: "../../variables/breakpoints.css";
 @value white from colors;
+@value tablet from breakpoints;
 
 .quickAccess {
-  width: 268px;
-  height: 281px;
+  width: 260px;
+  height: 273px;
   cursor: pointer;
   position: relative;
 }
@@ -101,4 +103,18 @@
   padding-left: 8px;
   width: 20px;
   height: 20px;
+}
+
+@media tablet {
+  .quickAccess {
+    width: 360.5px;
+  }
+
+  .description {
+    max-width: 313px;
+  }
+
+  .iconGotoWrapper {
+    left: 301px;
+  }
 }

--- a/packages/@coorpacademy-components/src/molecule/quick-access-card/test/fixtures/manage-email.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-card/test/fixtures/manage-email.js
@@ -1,8 +1,0 @@
-export default {
-  props: {
-    title: 'Manage email',
-    description: 'Manage all the settings for your emails',
-    feature: 'manage_email',
-    onClick: () => console.log('click everywhere')
-  }
-};

--- a/packages/@coorpacademy-components/src/molecule/quick-access-card/test/fixtures/massive-battle.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-card/test/fixtures/massive-battle.js
@@ -1,0 +1,8 @@
+export default {
+  props: {
+    title: 'Massive battle',
+    description: 'To engage your users senda "Massive Battle" to several of them',
+    feature: 'massive_battle',
+    onClick: () => console.log('click everywhere')
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/index.js
@@ -16,7 +16,7 @@ const QuickAccessCardGrid = props => {
 
   const cards = map(cardProps => {
     return (
-      <div>
+      <div className={style.card}>
         <QuickAccessCard {...cardProps} />
       </div>
     );

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/index.js
@@ -5,7 +5,7 @@ import QuickAccessCard from '../quick-access-card';
 import Loader from '../../atom/loader';
 import style from './style.css';
 
-const QuickAccessCardGrid = props => {
+const QuickAccessCardGroup = props => {
   const {list = [], loading = false} = props;
 
   const loader = loading ? (
@@ -30,9 +30,9 @@ const QuickAccessCardGrid = props => {
   );
 };
 
-QuickAccessCardGrid.propTypes = {
+QuickAccessCardGroup.propTypes = {
   list: PropTypes.arrayOf(PropTypes.shape(QuickAccessCard.propTypes)),
   loading: PropTypes.bool
 };
 
-export default QuickAccessCardGrid;
+export default QuickAccessCardGroup;

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {map} from 'lodash/fp';
+import {map, slice} from 'lodash/fp';
 import QuickAccessCard from '../quick-access-card';
 import Loader from '../../atom/loader';
 import style from './style.css';
@@ -20,7 +20,7 @@ const QuickAccessCardGrid = props => {
         <QuickAccessCard {...cardProps} />
       </div>
     );
-  }, list);
+  }, slice(0, 4, list));
 
   return (
     <div className={style.default}>

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/index.js
@@ -16,7 +16,7 @@ const QuickAccessCardGroup = props => {
 
   const cards = map(cardProps => {
     return (
-      <div className={style.card}>
+      <div className={style.card} key={`card-${cardProps.feature}`}>
         <QuickAccessCard {...cardProps} />
       </div>
     );

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/index.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {map} from 'lodash/fp';
+import QuickAccessCard from '../quick-access-card';
+import Loader from '../../atom/loader';
+import style from './style.css';
+
+const QuickAccessCardGrid = props => {
+  const {list = [], loading = false} = props;
+
+  const loader = loading ? (
+    <div className={style.loader}>
+      <Loader />
+    </div>
+  ) : null;
+
+  const cards = map(cardProps => {
+    return (
+      <div>
+        <QuickAccessCard {...cardProps} />
+      </div>
+    );
+  }, list);
+
+  return (
+    <div className={style.default}>
+      {cards}
+      {loader}
+    </div>
+  );
+};
+
+QuickAccessCardGrid.propTypes = {
+  list: PropTypes.arrayOf(PropTypes.shape(QuickAccessCard.propTypes)),
+  loading: PropTypes.bool
+};
+
+export default QuickAccessCardGrid;

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/style.css
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/style.css
@@ -5,5 +5,13 @@
 }
 
 .default {
-  
+  width: 100%;
+  display: flex;
+  overflow-y: inherit;
+  align-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.card {
+  margin-right: 16px;
 }

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/style.css
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/style.css
@@ -1,0 +1,9 @@
+.loader {
+  position: relative;
+  height: 100px;
+  width: 100%;
+}
+
+.default {
+  
+}

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/style.css
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/style.css
@@ -1,3 +1,6 @@
+@value breakpoints: "../../variables/breakpoints.css";
+@value tablet from breakpoints;
+
 .loader {
   position: relative;
   height: 100px;
@@ -14,4 +17,10 @@
 
 .card {
   margin-right: 16px;
+}
+
+@media tablet {
+  .card {
+    margin-top: 16px;
+  }
 }

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/test/fixtures/default.js
@@ -1,12 +1,18 @@
 import cockpit from '../../../quick-access-card/test/fixtures/default';
 import analytics from '../../../quick-access-card/test/fixtures/analytics';
 import lookAndFeel from '../../../quick-access-card/test/fixtures/look-and-feel';
-import email from '../../../quick-access-card/test/fixtures/manage-email';
+import massiveBattle from '../../../quick-access-card/test/fixtures/massive-battle';
 import uploadUsers from '../../../quick-access-card/test/fixtures/upload-users';
 
 export default {
   props: {
-    list: [cockpit.props, analytics.props, lookAndFeel.props, email.props, uploadUsers.props],
+    list: [
+      cockpit.props,
+      analytics.props,
+      lookAndFeel.props,
+      massiveBattle.props,
+      uploadUsers.props
+    ],
     loading: false
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/test/fixtures/default.js
@@ -1,0 +1,11 @@
+import cockpit from '../../../quick-access-card/test/fixtures/default';
+import analytics from '../../../quick-access-card/test/fixtures/analytics';
+import lookAndFeel from '../../../quick-access-card/test/fixtures/look-and-feel';
+import email from '../../../quick-access-card/test/fixtures/manage-email';
+
+export default {
+  props: {
+    list: [cockpit.props, analytics.props, lookAndFeel.props, email.props],
+    loading: false
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/test/fixtures/default.js
@@ -2,10 +2,11 @@ import cockpit from '../../../quick-access-card/test/fixtures/default';
 import analytics from '../../../quick-access-card/test/fixtures/analytics';
 import lookAndFeel from '../../../quick-access-card/test/fixtures/look-and-feel';
 import email from '../../../quick-access-card/test/fixtures/manage-email';
+import uploadUsers from '../../../quick-access-card/test/fixtures/upload-users';
 
 export default {
   props: {
-    list: [cockpit.props, analytics.props, lookAndFeel.props, email.props],
+    list: [cockpit.props, analytics.props, lookAndFeel.props, email.props, uploadUsers.props],
     loading: false
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/test/fixtures/loading.js
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-cards-group/test/fixtures/loading.js
@@ -1,0 +1,6 @@
+export default {
+  props: {
+    list: [],
+    loading: true
+  }
+};

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
@@ -195,7 +195,7 @@ BrandUpdate.propTypes = {
     PropTypes.shape({
       ...BrandDashboard.propTypes,
       key: PropTypes.string,
-      type: PropTypes.oneOf(['dashoard'])
+      type: PropTypes.oneOf(['home'])
     })
   ]),
   details: PropTypes.shape({

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/home.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/home.js
@@ -6,7 +6,7 @@ const {props} = Default;
 export default {
   props: defaultsDeep(props, {
     content: {
-      type: 'dashoard',
+      type: 'home',
       text: 'Welcome to coorpmanager'
     }
   })

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -559,7 +559,7 @@ import MoleculeQuestionsTemplateFixtureMultiple from '../src/molecule/questions/
 import MoleculeQuickAccessCardFixtureAnalytics from '../src/molecule/quick-access-card/test/fixtures/analytics';
 import MoleculeQuickAccessCardFixtureDefault from '../src/molecule/quick-access-card/test/fixtures/default';
 import MoleculeQuickAccessCardFixtureLookAndFeel from '../src/molecule/quick-access-card/test/fixtures/look-and-feel';
-import MoleculeQuickAccessCardFixtureManageEmail from '../src/molecule/quick-access-card/test/fixtures/manage-email';
+import MoleculeQuickAccessCardFixtureMassiveBattle from '../src/molecule/quick-access-card/test/fixtures/massive-battle';
 import MoleculeQuickAccessCardFixtureUploadUsers from '../src/molecule/quick-access-card/test/fixtures/upload-users';
 import MoleculeQuickAccessCardsGroupFixtureDefault from '../src/molecule/quick-access-cards-group/test/fixtures/default';
 import MoleculeQuickAccessCardsGroupFixtureLoading from '../src/molecule/quick-access-cards-group/test/fixtures/loading';
@@ -1684,7 +1684,7 @@ export const fixtures = {
       Analytics: MoleculeQuickAccessCardFixtureAnalytics,
       Default: MoleculeQuickAccessCardFixtureDefault,
       LookAndFeel: MoleculeQuickAccessCardFixtureLookAndFeel,
-      ManageEmail: MoleculeQuickAccessCardFixtureManageEmail,
+      MassiveBattle: MoleculeQuickAccessCardFixtureMassiveBattle,
       UploadUsers: MoleculeQuickAccessCardFixtureUploadUsers
     },
     MoleculeQuickAccessCardsGroup: {

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -98,6 +98,7 @@ import MoleculeQuestionsQcmGraphic from './../src/molecule/questions/qcm-graphic
 import MoleculeQuestionsQuestionRange from './../src/molecule/questions/question-range';
 import MoleculeQuestionsTemplate from './../src/molecule/questions/template';
 import MoleculeQuickAccessCard from './../src/molecule/quick-access-card';
+import MoleculeQuickAccessCardsGroup from './../src/molecule/quick-access-cards-group';
 import MoleculeResourcePlayer from './../src/molecule/resource-player';
 import MoleculeScopeContent from './../src/molecule/scope-content';
 import MoleculeScopeTabs from './../src/molecule/scope-tabs';
@@ -560,6 +561,8 @@ import MoleculeQuickAccessCardFixtureDefault from '../src/molecule/quick-access-
 import MoleculeQuickAccessCardFixtureLookAndFeel from '../src/molecule/quick-access-card/test/fixtures/look-and-feel';
 import MoleculeQuickAccessCardFixtureManageEmail from '../src/molecule/quick-access-card/test/fixtures/manage-email';
 import MoleculeQuickAccessCardFixtureUploadUsers from '../src/molecule/quick-access-card/test/fixtures/upload-users';
+import MoleculeQuickAccessCardsGroupFixtureDefault from '../src/molecule/quick-access-cards-group/test/fixtures/default';
+import MoleculeQuickAccessCardsGroupFixtureLoading from '../src/molecule/quick-access-cards-group/test/fixtures/loading';
 import MoleculeResourcePlayerFixtureAudio from '../src/molecule/resource-player/test/fixtures/audio';
 import MoleculeResourcePlayerFixtureImage from '../src/molecule/resource-player/test/fixtures/image';
 import MoleculeResourcePlayerFixtureJwplayerWithOverlay from '../src/molecule/resource-player/test/fixtures/jwplayer-with-overlay';
@@ -1046,6 +1049,7 @@ export const components = {
     MoleculeProductCard,
     MoleculeProgressBar,
     MoleculeQuickAccessCard,
+    MoleculeQuickAccessCardsGroup,
     MoleculeResourcePlayer,
     MoleculeScopeContent,
     MoleculeScopeTabs,
@@ -1682,6 +1686,10 @@ export const fixtures = {
       LookAndFeel: MoleculeQuickAccessCardFixtureLookAndFeel,
       ManageEmail: MoleculeQuickAccessCardFixtureManageEmail,
       UploadUsers: MoleculeQuickAccessCardFixtureUploadUsers
+    },
+    MoleculeQuickAccessCardsGroup: {
+      Default: MoleculeQuickAccessCardsGroupFixtureDefault,
+      Loading: MoleculeQuickAccessCardsGroupFixtureLoading
     },
     MoleculeResourcePlayer: {
       Audio: MoleculeResourcePlayerFixtureAudio,


### PR DESCRIPTION
https://trello.com/c/MtaV5hNB/2315-quick-access-page-dashboard-coorpamanger

**Detailed purpose of the PR**

This PR uses the new quickaccess card and add its to the brand-form-group.
It also adds the responsive behavior

**Result and observation**

![Kapture 2021-10-07 at 16 49 58](https://user-images.githubusercontent.com/7602475/136409418-e81f16d9-2474-4578-8cea-a88e818f4de0.gif)

**Testing Strategy**

- Already covered by tests
- Manual testing
- Unit testing
