### PR TITLE
Refactor <Title /> atom component in order to be use on page or group form component

### DIFF
--- a/packages/@coorpacademy-components/src/atom/title/index.js
+++ b/packages/@coorpacademy-components/src/atom/title/index.js
@@ -3,13 +3,19 @@ import PropTypes from 'prop-types';
 import style from './style.css';
 
 const Title = props => {
-  const {title, subtitle} = props;
+  const {title, subtitle, type} = props;
 
-  const subtitleSection = subtitle ? <div className={style.subtitle}>{subtitle}</div> : null;
+  const subtitleSection = subtitle ? (
+    <div className={style.subtitle}>
+      <div className={style[type]}>{subtitle}</div>
+    </div>
+  ) : null;
 
   return (
     <div>
-      <div className={style.title}>{title}</div>
+      <div className={style.title}>
+        <div className={style[type]}>{title}</div>
+      </div>
       {subtitleSection}
     </div>
   );
@@ -17,6 +23,7 @@ const Title = props => {
 
 Title.propTypes = {
   title: PropTypes.string,
-  subtitle: PropTypes.string
+  subtitle: PropTypes.string,
+  type: PropTypes.oneOf(['page', 'form-group'])
 };
 export default Title;

--- a/packages/@coorpacademy-components/src/atom/title/style.css
+++ b/packages/@coorpacademy-components/src/atom/title/style.css
@@ -1,21 +1,39 @@
 @value colors: "../../variables/colors.css";
 @value cm_grey_700 from colors;
+@value cm_grey_400 from colors;
 
 .title {
     font-family: Gilroy;
     font-style: normal;
     font-weight: bold;
+    color: cm_grey_700;
+}
+
+.title .page {
     font-size: 32px;
     line-height: 52px;
-    color: cm_grey_700;
+}
+
+.title .form-group {
+    font-size: 18px;
 }
 
 .subtitle {
     margin: 8px 0 0;
     font-family: Gilroy;
-    font-style: normal;
+    font-style: normal;   
+}
+
+.subtitle .page {
     font-weight: normal;
     font-size: 18px;
     line-height: 24px;
     color: cm_grey_700;
+}
+
+.subtitle .form-group {
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 20px;
+    color: cm_grey_400;
 }

--- a/packages/@coorpacademy-components/src/atom/title/test/fixtures/form-group-title-without-subtitle.js
+++ b/packages/@coorpacademy-components/src/atom/title/test/fixtures/form-group-title-without-subtitle.js
@@ -1,0 +1,6 @@
+export default {
+  props: {
+    type: 'form-group',
+    title: 'Quickaccess'
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/title/test/fixtures/form-group-title.js
+++ b/packages/@coorpacademy-components/src/atom/title/test/fixtures/form-group-title.js
@@ -1,0 +1,7 @@
+export default {
+  props: {
+    type: 'form-group',
+    title: 'Roles',
+    subtitle: 'lorem ipsum dolor sit amet consectetur adipiscing elit'
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/title/test/fixtures/page-title.js
+++ b/packages/@coorpacademy-components/src/atom/title/test/fixtures/page-title.js
@@ -1,5 +1,6 @@
 export default {
   props: {
+    type: 'page',
     title: 'Hello Marianna!',
     subtitle: 'Welcome to the coorpmanager dashboard'
   }

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
@@ -18,6 +18,7 @@ import InputDoublestep from '../../atom/input-doublestep';
 import ImageUpload from '../../atom/image-upload';
 import SetupSlider from '../setup-slider';
 import SetupSections from '../setup-sections';
+import Title from '../../atom/title';
 import style from './style.css';
 
 const buildInput = field => {
@@ -80,9 +81,8 @@ const BrandFormGroup = props => {
 
   return (
     <div data-name={`brand_form_group_${snakeCase(title)}`} className={style.wrapper}>
-      <div className={style.title}>
-        {title ? <h3>{title}</h3> : null}
-        <h4>{subtitle}</h4>
+      <div className={style.titleWrapper}>
+        <Title title={title} subtitle={subtitle} type={'form-group'} />
       </div>
       <div className={fieldsLayout === 'grid' ? style.grid : null}>{fieldsList}</div>
     </div>

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/style.css
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/style.css
@@ -1,13 +1,9 @@
-@value colors: "../../variables/colors.css";
-@value cm_grey_700 from colors;
-@value medium from colors;
-
 .wrapper {
   width: 100%;
   padding-bottom: 50px;
 }
 
-.title {
+.titleWrapper {
   margin-top: 20px;
   margin-bottom: 20px;
 }
@@ -21,29 +17,9 @@
   margin-right: 20px;
 }
 
-.title h3 {
-  font-family: 'Gilroy';
-  font-size: 18px;
-  font-weight: bold;
-  font-stretch: normal;
-  font-style: normal;
-  color: cm_grey_700;
-}
-
-.title h4 {
-  font-family: 'Gilroy';
-  font-size: 14px;
-  font-weight: 400;
-  font-style: normal;
-  line-height: 20px;
-  color: medium;
-  margin: 8px 0;
-}
-
 .field {
   margin-bottom: 20px;
 }
-
 
 .field:last-child {
   margin-bottom: 0;

--- a/packages/@coorpacademy-components/src/variables/colors.css
+++ b/packages/@coorpacademy-components/src/variables/colors.css
@@ -32,6 +32,7 @@
 @value cm_grey_50: #FAFAFA;
 @value cm_grey_100: #EAEAEB;
 @value cm_grey_200: #d7d7da;
+@value cm_grey_400: #9999A8;
 @value cm_grey_500: #515161;
 @value cm_grey_700: #1D1D2B;
 @value cm_negative_200: #b81400;

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -326,7 +326,9 @@ import AtomSpinnerFixtureDefault from '../src/atom/spinner/test/fixtures/default
 import AtomTabFixtureDefault from '../src/atom/tab/test/fixtures/default';
 import AtomTabContentFixtureDefault from '../src/atom/tab-content/test/fixtures/default';
 import AtomTabContentFixtureHideContentBackground from '../src/atom/tab-content/test/fixtures/hide-content-background';
-import AtomTitleFixtureFixture from '../src/atom/title/test/fixtures/fixture';
+import AtomTitleFixtureFormGroupTitleWithoutSubtitle from '../src/atom/title/test/fixtures/form-group-title-without-subtitle';
+import AtomTitleFixtureFormGroupTitle from '../src/atom/title/test/fixtures/form-group-title';
+import AtomTitleFixturePageTitle from '../src/atom/title/test/fixtures/page-title';
 import AtomVideoUploadFixtureDesktop from '../src/atom/video-upload/test/fixtures/desktop';
 import AtomVideoUploadFixtureLoading from '../src/atom/video-upload/test/fixtures/loading';
 import AtomVideoUploadFixtureModified from '../src/atom/video-upload/test/fixtures/modified';
@@ -1399,7 +1401,9 @@ export const fixtures = {
       HideContentBackground: AtomTabContentFixtureHideContentBackground
     },
     AtomTitle: {
-      Fixture: AtomTitleFixtureFixture
+      FormGroupTitleWithoutSubtitle: AtomTitleFixtureFormGroupTitleWithoutSubtitle,
+      FormGroupTitle: AtomTitleFixtureFormGroupTitle,
+      PageTitle: AtomTitleFixturePageTitle
     },
     AtomVideoUpload: {
       Desktop: AtomVideoUploadFixtureDesktop,


### PR DESCRIPTION
**Detailed purpose of the PR**

Use title component on form section: centralizing title and subtitle elements.

**Result and observation**

### Components views

#### Title for page

<img width="632" alt="Capture d’écran 2021-10-08 à 12 06 45" src="https://user-images.githubusercontent.com/7602475/136538609-8dc5b78c-5b70-40de-924d-748e9579809e.png">

#### Title for form-group

<img width="439" alt="Capture d’écran 2021-10-08 à 12 06 31" src="https://user-images.githubusercontent.com/7602475/136538644-242f0e87-f7d2-4d58-8c6b-707ff5ba2e50.png">

#### result in form-group organism

<img width="1134" alt="Capture d’écran 2021-10-08 à 12 08 04" src="https://user-images.githubusercontent.com/7602475/136538686-5f86830e-55bd-4602-b1b3-b54a4a1ca9f9.png">

**Testing Strategy**

- Already covered by tests
- Manual testing
- Unit testing
