### PR TITLE
Fix footer last link

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-footer/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-footer/style.css
@@ -340,9 +340,8 @@
     width: 100%;
     height: 1px;
     position: absolute;
-    bottom: -15px;
     left: 0px;
-    border-bottom: solid 2em transparent;
+    border-bottom: solid 1em transparent;
     box-shadow: 0 1px 0 lightBlack;
   }
 }


### PR DESCRIPTION
https://coorpacademy.github.io/components/components/?path=/story/organismmoocfooter--default

En mode mobile, la partie inférieur du dernier lien de chaque groupe est incliquable.