### PR TITLE
2 lives for microlearning

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/config/microlearning.js
+++ b/packages/@coorpacademy-progression-engine/src/config/microlearning.js
@@ -27,6 +27,19 @@ const configurations: Array<Config> = [
     starsPerCorrectAnswer: 4,
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
+  },
+  {
+    version: '3',
+    lives: 2,
+    livesDisabled: true,
+    maxTypos: 2,
+    slidesToComplete: 4,
+    shuffleChoices: true,
+    answerBoundaryLimit: 5,
+    starsPerAskingClue: -1,
+    starsPerCorrectAnswer: 4,
+    starsPerResourceViewed: 4,
+    remainingLifeRequests: 1
   }
 ];
 


### PR DESCRIPTION
https://app.prodpad.com/ideas/3911/canvas

**IDEA 3911 - La Poste - Avoir 2 vies dispo pour les microlearnings**
Hello,
Suite aux retours de la phase de test, il a été remonté que les parcours sont trop difficiles à jouer dans l'ensemble avec uniquement une vie par chapitre. Il faudrait ajouter une vie aux microlearnings de manière à avoir 2 vies à dispo (+1 sur la consultation de la leçon).
Merci

https://institutgroupelaposte.coorpacademy.com/certifications


**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
