### PR TITLE
recalculate  tabs statets when props change

### DIFF
--- a/packages/@coorpacademy-components/src/organism/accordion/coorp-manager/index.js
+++ b/packages/@coorpacademy-components/src/organism/accordion/coorp-manager/index.js
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useMemo, useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {map, noop, findIndex} from 'lodash/fp';
 import Part from './part';
@@ -61,7 +61,10 @@ const Accordion = props => {
   const {tabProps, children, theme = 'default', onClick = noop} = props;
   const selectedIndex = findIndex(item => item.selected, tabProps);
 
-  const [openedTab, updateOpenedTab] = React.useState(selectedIndex);
+  const [openedTab, updateOpenedTab] = useState(selectedIndex);
+  useEffect(() => {
+    updateOpenedTab(selectedIndex);
+  }, [selectedIndex]);
 
   const tabs = map.convert({cap: false})((tab, index) => ({
     ...tab,


### PR DESCRIPTION
[ticket](https://trello.com/c/UFQ7Sv8Y/2342-lorsque-je-clique-sur-un-quickaccess-qui-redirige-vers-une-page-le-menu-de-gauche-souvre)
Should recalculate state when props change 
When we click on the quick access card the form change. but the menu doen't update , this pr wii fix that 

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
