### PR TITLE
Fix button effect

### DIFF
--- a/packages/@coorpacademy-components/src/atom/button-link-icon-only/index.js
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon-only/index.js
@@ -28,13 +28,15 @@ const ButtonLinkIconOnly = props => {
     'data-name': dataName,
     'aria-label': ariaLabel,
     link,
-    onClick
+    onClick,
+    type
   } = props;
   const contentView = getButtonContent(icon);
   const styleButton = classnames(
     size === 'default' ? style.default : style.small,
     link && style.link,
-    disabled && style.disabled
+    disabled && style.disabled,
+    type === 'bulletPoint' && style.bulletPoint
   );
 
   if (link) {
@@ -77,7 +79,8 @@ ButtonLinkIconOnly.propTypes = {
     download: PropTypes.bool,
     target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top'])
   }),
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  type: PropTypes.oneOf(['bulletPoint'])
 };
 
 export default ButtonLinkIconOnly;

--- a/packages/@coorpacademy-components/src/atom/button-link-icon-only/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon-only/style.css
@@ -62,3 +62,13 @@
   width: 12px;
   height: 12px;
 }
+
+.bulletPoint {
+  position: relative;
+  cursor: pointer;
+ }
+
+/* Recover - unset pointer-events  */
+.bulletPoint:focus { pointer-events: none; }
+.bulletPoint:not(:focus) { pointer-events: auto; }
+

--- a/packages/@coorpacademy-components/src/atom/button-link/test/on-click.js
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/on-click.js
@@ -1,0 +1,24 @@
+import browserEnv from 'browser-env';
+import test from 'ava';
+import React from 'react';
+import {mount, configure} from 'enzyme';
+import {identity} from 'lodash/fp';
+import Adapter from 'enzyme-adapter-react-16';
+import ButtonLink from '..';
+import defaultFixture from './fixtures/button-dangerous-no-icon';
+
+browserEnv();
+configure({adapter: new Adapter()});
+const translate = identity;
+
+test('should handle onClick event', t => {
+  t.plan(3);
+  const props = {...defaultFixture.props, onClick: () => t.pass()};
+  const wrapper = mount(<ButtonLink {...props} />, {
+    context: {translate}
+  });
+  const button = wrapper.find('[data-name="default-button"]');
+  t.true(button.exists());
+  button.first().simulate('click', {});
+  t.pass();
+});

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/index.js
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/index.js
@@ -24,12 +24,13 @@ const BulletPointMenuButton = props => {
     'data-name': 'bullet-point-button',
     icon: 'bullet-point',
     onClick: handleOnClick,
+    type: 'bulletPoint',
     disabled
   };
 
   return (
     <div className={style.bulletPointWrapper} data-name="bullet-point-wrapper">
-      <ButtonLinkIconOnly {...bulletPointButtonProps} className={style.bulletPointButton} />
+      <ButtonLinkIconOnly {...bulletPointButtonProps} />
       {menu}
     </div>
   );

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/style.css
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/style.css
@@ -27,14 +27,14 @@
 }
 
 /* Fade-in - Fade-out */
-.bulletPointButton,button + .bulletPointMenu {
+button + .bulletPointMenu {
   max-height: 0;
   /* fade out combo */
   visibility: hidden;
   opacity:0;
   transition:visibility 0.5s ease,opacity 0.5s ease;
 }
-.bulletPointButton,button:focus + .bulletPointMenu {
+button:focus + .bulletPointMenu {
   /* fade in combo */
   max-height: max-content;
   visibility:visible;

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/style.css
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/style.css
@@ -10,11 +10,6 @@
   position: relative;
 }
 
-.bulletPointButton {
-  position: relative;
-  cursor: pointer;
- }
-
 .bulletPointMenu {
   min-width: 80px;
   /* positioning */
@@ -39,14 +34,9 @@
   opacity:0;
   transition:visibility 0.5s ease,opacity 0.5s ease;
 }
-
 .bulletPointButton,button:focus + .bulletPointMenu {
   /* fade in combo */
   max-height: max-content;
   visibility:visible;
   opacity:1;
 }
-
-/* Recover - unset pointer-events  */
-.bulletPointButton,button:focus { pointer-events: none; }
-.bulletPointButton,button:not(:focus) { pointer-events: auto; }


### PR DESCRIPTION
Using the class `.button` in css file impact other components, cuz storyBook put all the css in only one file...

 in this case the button are impacted by this two lines 

`.bulletPointButton,button:not(:focus) { pointer-events: auto; }`
`.bulletPointButton,button:focus { pointer-events: none; }`

and because of that the onclick event doesn't work anymore

Solution : is to avoid using html tags as names for  css classes or to apply style directly on the tags classes


**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
