### PR TITLE
Fix css for buttons, removes bullet point menu interference

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/index.js
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/index.js
@@ -29,7 +29,7 @@ const BulletPointMenuButton = props => {
 
   return (
     <div className={style.bulletPointWrapper} data-name="bullet-point-wrapper">
-      <ButtonLinkIconOnly {...bulletPointButtonProps} className={style.bulletPointButton} />
+      <ButtonLinkIconOnly {...bulletPointButtonProps} />
       {menu}
     </div>
   );

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/style.css
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/style.css
@@ -10,7 +10,7 @@
   position: relative;
 }
 
-.bulletPointWrapper [data-name="bullet-point-button"] {
+.bulletPointWrapper > button {
   position: relative;
   cursor: pointer;
  }
@@ -52,5 +52,5 @@ button:focus + .bulletPointMenu {
   Recover - unset pointer-events,
   to be able to click on the button when the menu is open to close it
 */
-[data-name="bullet-point-button"]:focus { pointer-events: none; }
-[data-name="bullet-point-button"]:not(:focus) { pointer-events: auto; }
+.bulletPointWrapper > button:focus { pointer-events: none; }
+.bulletPointWrapper > button:not(:focus) { pointer-events: auto; }

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/style.css
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/style.css
@@ -10,7 +10,7 @@
   position: relative;
 }
 
-.bulletPointButton {
+.bulletPointWrapper [data-name="bullet-point-button"] {
   position: relative;
   cursor: pointer;
  }
@@ -31,8 +31,8 @@
   background-color: cm_grey_100;
 }
 
-/* Fade-in - Fade-out */
-.bulletPointButton,button + .bulletPointMenu {
+/* Fade-in - Fade-out, does target button class but bulletPointMenu only */
+button + .bulletPointMenu {
   max-height: 0;
   /* fade out combo */
   visibility: hidden;
@@ -40,13 +40,17 @@
   transition:visibility 0.5s ease,opacity 0.5s ease;
 }
 
-.bulletPointButton,button:focus + .bulletPointMenu {
+/* Does target button class but bulletPointMenu only */
+button:focus + .bulletPointMenu {
   /* fade in combo */
   max-height: max-content;
   visibility:visible;
   opacity:1;
 }
 
-/* Recover - unset pointer-events  */
-.bulletPointButton,button:focus { pointer-events: none; }
-.bulletPointButton,button:not(:focus) { pointer-events: auto; }
+/* 
+  Recover - unset pointer-events,
+  to be able to click on the button when the menu is open to close it
+*/
+[data-name="bullet-point-button"]:focus { pointer-events: none; }
+[data-name="bullet-point-button"]:not(:focus) { pointer-events: auto; }


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
Using the class .button in css file impact other components, storyBook puts all the css in only one file so they become impacted by the pointer events modif.

Adds further explanations for the css.
<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
