### PR TITLE
Wizard contents updates

### DIFF
--- a/packages/@coorpacademy-components/src/atom/content-badge/index.js
+++ b/packages/@coorpacademy-components/src/atom/content-badge/index.js
@@ -33,7 +33,8 @@ ContentBadge.propTypes = {
     'scorm',
     'video',
     'article',
-    'podcast'
+    'podcast',
+    'course'
   ]),
   label: PropTypes.string
 };

--- a/packages/@coorpacademy-components/src/atom/content-badge/index.js
+++ b/packages/@coorpacademy-components/src/atom/content-badge/index.js
@@ -15,7 +15,8 @@ const ContentBadge = props => {
         category === 'scorm' && style.scorm,
         category === 'video' && style.video,
         category === 'article' && style.article,
-        category === 'podcast' && style.podcast
+        category === 'podcast' && style.podcast,
+        category === 'course' && style.course
       )}
     >
       {label}

--- a/packages/@coorpacademy-components/src/atom/content-badge/style.css
+++ b/packages/@coorpacademy-components/src/atom/content-badge/style.css
@@ -6,6 +6,7 @@
 @value lightBlack from colors;
 @value cm_yellow_scorm from colors;
 @value cm_bleu_article from colors;
+@value cm_red_200 from colors;
 @value cm_red_video from colors;
 @value cm_violet_podcast from colors;
 
@@ -16,6 +17,11 @@
   font-size: 7px;
   font-style: normal;
   color: white;
+}
+
+.course {
+  composes: level;
+  background-color: cm_red_200;
 }
 
 .base {

--- a/packages/@coorpacademy-components/src/atom/content-badge/test/fixtures/course.js
+++ b/packages/@coorpacademy-components/src/atom/content-badge/test/fixtures/course.js
@@ -1,0 +1,6 @@
+export default {
+  props: {
+    category: 'course',
+    label: 'Course'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/wizard-summary/index.js
+++ b/packages/@coorpacademy-components/src/molecule/wizard-summary/index.js
@@ -171,7 +171,8 @@ WizardSummary.propTypes = {
               'scorm',
               'video',
               'article',
-              'podcast'
+              'podcast',
+              'course'
             ]),
             title: PropTypes.string,
             label: PropTypes.string,

--- a/packages/@coorpacademy-components/src/molecule/wizard-summary/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/wizard-summary/test/fixtures/default.js
@@ -120,8 +120,8 @@ export default {
           {
             type: 'content',
             title: 'Cluedo: Meurtre sur Skill Island',
-            category: 'advanced',
-            label: 'Advanced',
+            category: 'course',
+            label: 'Course',
             author: 'Coorpacademy'
           },
           {

--- a/packages/@coorpacademy-components/src/organism/content-translation/index.js
+++ b/packages/@coorpacademy-components/src/organism/content-translation/index.js
@@ -7,8 +7,26 @@ import TextArea from '../../atom/input-textarea';
 import Button from '../../atom/button-link';
 import style from './style.css';
 
+const buildCtaButton = cta => {
+  if (!cta) {
+    return;
+  }
+
+  return (
+    <div className={classNames(style.button, style.binButton)}>
+      <Button
+        onClick={cta.handleOnclick}
+        type="text"
+        icon={{type: 'bin', position: 'left'}}
+        label={cta.label}
+      />
+    </div>
+  );
+};
+
 const PlayListTranslation = props => {
   const {languageTabs, inputText, textArea, cta, 'list-aria-label': listAriaLabel} = props;
+  const ctaButton = buildCtaButton(cta);
 
   const ariaLabel = {'aria-label': listAriaLabel};
   return (
@@ -21,14 +39,7 @@ const PlayListTranslation = props => {
         <div className={style.input}>
           <TextArea {...textArea} />
         </div>
-        <div className={classNames(style.button, cta.type === 'delete' && style.binButton)}>
-          <Button
-            onClick={cta.handleOnclick}
-            type={cta.type === 'delete' ? 'text' : 'primary'}
-            icon={{type: cta.type === 'delete' ? 'bin' : 'add', position: 'left'}}
-            label={cta.label}
-          />
-        </div>
+        {ctaButton}
       </div>
     </div>
   );
@@ -41,7 +52,7 @@ PlayListTranslation.propTypes = {
   cta: PropTypes.shape({
     label: PropTypes.string,
     handleOnclick: PropTypes.func,
-    type: PropTypes.oneOf(['delete', 'add'])
+    type: PropTypes.oneOf(['delete'])
   }),
   'list-aria-label': PropTypes.string
 };

--- a/packages/@coorpacademy-components/src/organism/content-translation/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/content-translation/test/fixtures/default.js
@@ -9,11 +9,6 @@ export default {
     languageTabs,
     inputText: {...inputText.props, theme: 'coorpmanager'},
     textArea: {...textArea.props, theme: 'coorpmanager'},
-    cta: {
-      label: 'Add translation',
-      type: 'add',
-      handleOnClick: () => {}
-    },
     'list-aria-label': 'Languages list'
   }
 };

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/index.js
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import getOr from 'lodash/fp/getOr';
 import PropTypes from 'prop-types';
 import ButtonLink from '../../atom/button-link';
 import ButtonLinkIconOnly from '../../atom/button-link-icon-only';
@@ -47,15 +48,27 @@ const buildForm = content => {
 };
 
 const buildButton = (type, step) => {
+  const ICONS = {
+    previous: {
+      position: 'left',
+      type: 'chevron-left'
+    },
+    next: {
+      position: 'right',
+      type: 'chevron-right'
+    },
+    publish: {
+      position: 'left',
+      type: 'publish'
+    }
+  };
+
   const {label, onClick} = step;
   const buttonProps = {
-    type: type === 'next' ? 'primary' : 'secondary',
+    type: type === 'previous' ? 'secondary' : 'primary',
     'aria-label': `${type} step button`,
     'data-name': `${type}-step-button`,
-    icon: {
-      position: type === 'next' ? 'right' : 'left',
-      type: type === 'next' ? 'chevron-right' : 'chevron-left'
-    },
+    icon: ICONS[type],
     label,
     onClick
   };
@@ -65,7 +78,8 @@ const buildButton = (type, step) => {
 
 const buildActionZone = (previousStep, nextStep) => {
   const previousButton = previousStep ? buildButton('previous', previousStep) : null;
-  const nextButton = nextStep ? buildButton('next', nextStep) : null;
+  const nextStepType = getOr('next', 'type', nextStep);
+  const nextButton = nextStep ? buildButton(nextStepType, nextStep) : null;
   return (
     <div className={style.actionZone}>
       <div className={style.button}>{previousButton}</div>
@@ -136,6 +150,7 @@ WizardContents.propTypes = {
     onClick: PropTypes.func
   }),
   nextStep: PropTypes.shape({
+    type: PropTypes.oneOf(['next', 'publish']),
     label: PropTypes.string,
     onClick: PropTypes.func
   })

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/test/fixtures/playlist-add-courses-create.js
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/test/fixtures/playlist-add-courses-create.js
@@ -37,7 +37,8 @@ export default {
       onClick: () => console.log('Previous Step')
     },
     nextStep: {
-      label: 'Next Step',
+      type: 'publish',
+      label: 'Publish',
       onClick: () => console.log('Next Step')
     }
   }

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/test/fixtures/playlist-general-settings-create.js
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/test/fixtures/playlist-general-settings-create.js
@@ -33,6 +33,7 @@ export default {
       type: 'form'
     },
     nextStep: {
+      type: 'next',
       label: 'Next step',
       onClick: () => console.log('Next Step')
     }

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/test/fixtures/playlist-populations-create.js
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/test/fixtures/playlist-populations-create.js
@@ -37,6 +37,7 @@ export default {
       onClick: () => console.log('Previous Step')
     },
     nextStep: {
+      type: 'next',
       label: 'Next Step',
       onClick: () => console.log('Next Step')
     }

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/test/fixtures/playlist-translate-edit.js
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/test/fixtures/playlist-translate-edit.js
@@ -37,6 +37,7 @@ export default {
       onClick: () => console.log('Previous Step')
     },
     nextStep: {
+      type: 'next',
       label: 'Next Step',
       onClick: () => console.log('Next Step')
     }

--- a/packages/@coorpacademy-components/src/util/button-icons.js
+++ b/packages/@coorpacademy-components/src/util/button-icons.js
@@ -8,9 +8,10 @@ import {
   NovaSolidStatusClose as CloseIcon,
   NovaSolidContentEditionPencilWrite as EditIcon,
   NovaCompositionCoorpacademyEye as EyeIcon,
-  NovaSolidComputersSdCard as SaveIcon,
   NovaSolidContentContentViewModule1 as ListIcon,
-  NovaSolidLoginLogout1 as LogoutIcon
+  NovaSolidLoginLogout1 as LogoutIcon,
+  NovaSolidApplicationsWindowUpload3 as PublishIcon,
+  NovaSolidComputersSdCard as SaveIcon
 } from '@coorpacademy/nova-icons';
 
 export const ICONS = {
@@ -24,6 +25,7 @@ export const ICONS = {
   edit: EditIcon,
   list: ListIcon,
   logout: LogoutIcon,
+  publish: PublishIcon,
   save: SaveIcon,
   see: EyeIcon
 };

--- a/packages/@coorpacademy-components/src/variables/colors.css
+++ b/packages/@coorpacademy-components/src/variables/colors.css
@@ -55,6 +55,7 @@
 @value cm_yellow_100: #ffc043;
 @value cm_yellow_200: #DB9200;
 @value cm_yellow_400: #bd7e00;
+@value cm_red_200: #FF4040;
 @value cm_red_video: #E8335E;
 @value cm_violet_podcast: #432ba7;
 @value cm_warning_50: rgba(255, 192, 67, 0.13);

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -237,6 +237,7 @@ import AtomContentBadgeFixtureAdvanced from '../src/atom/content-badge/test/fixt
 import AtomContentBadgeFixtureArticle from '../src/atom/content-badge/test/fixtures/article';
 import AtomContentBadgeFixtureChapter from '../src/atom/content-badge/test/fixtures/chapter';
 import AtomContentBadgeFixtureCoach from '../src/atom/content-badge/test/fixtures/coach';
+import AtomContentBadgeFixtureCourse from '../src/atom/content-badge/test/fixtures/course';
 import AtomContentBadgeFixtureDefault from '../src/atom/content-badge/test/fixtures/default';
 import AtomContentBadgeFixturePodcast from '../src/atom/content-badge/test/fixtures/podcast';
 import AtomContentBadgeFixtureScorm from '../src/atom/content-badge/test/fixtures/scorm';
@@ -1389,6 +1390,7 @@ export const fixtures = {
       Article: AtomContentBadgeFixtureArticle,
       Chapter: AtomContentBadgeFixtureChapter,
       Coach: AtomContentBadgeFixtureCoach,
+      Course: AtomContentBadgeFixtureCourse,
       Default: AtomContentBadgeFixtureDefault,
       Podcast: AtomContentBadgeFixturePodcast,
       Scorm: AtomContentBadgeFixtureScorm,


### PR DESCRIPTION
**Detailed purpose of the PR**

This PR updates the wizard contents components, adding missing features.

**Result and observation**

### Course content tag

<img width="132" alt="Capture d’écran 2021-12-10 à 07 24 26" src="https://user-images.githubusercontent.com/7602475/145573795-81386fa2-0b0c-4088-9bf5-61d8e2659830.png">

<img width="341" alt="Capture d’écran 2021-12-10 à 07 25 02" src="https://user-images.githubusercontent.com/7602475/145573829-aa54380a-576e-4f24-a0f3-a345e45b3288.png">

### Cleaning Add Translation button on translate organism

**Now**
<img width="615" alt="Capture d’écran 2021-12-10 à 07 26 46" src="https://user-images.githubusercontent.com/7602475/145574031-fd8df987-d674-4558-900f-1e72ba07ed3d.png">

**After**
<img width="614" alt="Capture d’écran 2021-12-10 à 07 26 59" src="https://user-images.githubusercontent.com/7602475/145574032-6e58d819-df31-4c23-8e00-6c23de7ff247.png">

### Adding publish button on wizard organism

<img width="1347" alt="Capture d’écran 2021-12-10 à 07 28 59" src="https://user-images.githubusercontent.com/7602475/145574259-e4339367-3f32-4c95-a7c7-5c66c7a19417.png">


**Testing Strategy**

- Already covered by tests
- Manual testing
- Unit testing
