### PR TITLE
Add filter for content type on course-selection organism

### DIFF
--- a/packages/@coorpacademy-components/src/organism/course-selection/index.js
+++ b/packages/@coorpacademy-components/src/organism/course-selection/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {isEmpty} from 'lodash/fp';
 import EmptySearchResult from '../../atom/empty-search-result';
 import Search from '../../atom/input-search';
+import SelectMultiple from '../../molecule/select-multiple';
 import Card from '../../molecule/card';
 import style from './style.css';
 
@@ -25,6 +26,7 @@ const buildResultView = (courses, coursesSelectionAriaLabel, emptyMessages) => {
 const CourseSelection = props => {
   const {
     search,
+    contentTypeFilter,
     courses,
     emptyMessages,
     'courses-selection-aria-label': coursesSelectionAriaLabel
@@ -34,8 +36,13 @@ const CourseSelection = props => {
 
   return (
     <div className={style.container}>
-      <div className={style.search}>
-        <Search {...search} theme="coorpmanager" />
+      <div className={style.filters}>
+        <div className={style.search}>
+          <Search {...search} theme="coorpmanager" />
+        </div>
+        <div className={style.contentFilter}>
+          <SelectMultiple {...contentTypeFilter} />
+        </div>
       </div>
       <div className={style.cardsContainer}>{resultView}</div>
     </div>
@@ -44,6 +51,7 @@ const CourseSelection = props => {
 
 CourseSelection.propTypes = {
   search: PropTypes.shape(Search.PropTypes),
+  contentTypeFilter: PropTypes.shape(SelectMultiple.PropTypes),
   courses: PropTypes.arrayOf(PropTypes.shape(Card.propTypes)),
   'courses-selection-aria-label': PropTypes.string,
   emptyMessages: PropTypes.shape({

--- a/packages/@coorpacademy-components/src/organism/course-selection/style.css
+++ b/packages/@coorpacademy-components/src/organism/course-selection/style.css
@@ -7,9 +7,19 @@
   width: 100%;
 }
 
+.filters {
+  display: flex;
+}
+
 .search {
-  width: 42%;
+  width: 41%;
   min-width: 309px;
+}
+
+.contentFilter {
+  width: 24%;
+  min-width: 181px;
+  margin: 0 0 0 16px;
 }
 
 .cardsContainer {

--- a/packages/@coorpacademy-components/src/organism/course-selection/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/course-selection/test/fixtures/default.js
@@ -13,6 +13,37 @@ export default {
       description: 'Type to filter the courses',
       onChange: value => console.log(value)
     },
+    contentTypeFilter: {
+      type: 'selectMultiple',
+      title: 'Content type',
+      placeholder: 'Content type',
+      description: 'This filters the courses',
+      theme: 'coorpmanager',
+      size: 'default',
+      options: [
+        {
+          name: 'Course',
+          value: 'course',
+          selected: true
+        },
+        {
+          name: "5' learning",
+          value: 'chapter',
+          selected: false
+        },
+        {
+          name: 'Interactive slides',
+          value: 'scorm',
+          selected: false
+        },
+        {
+          name: 'Video',
+          value: 'video',
+          selected: false
+        }
+      ],
+      multiple: false
+    },
     'courses-selection-aria-label': 'Courses results',
     courses: [
       SelectedCard.props,


### PR DESCRIPTION
https://trello.com/c/PrWea3xN/536-ajouter-un-filtre-sur-cm-pour-display-type-de-contenu

**Detailed purpose of the PR**

Add a Multiselect organism to allow filter on contents on seletc-course organism for Playlist wizard

**Result and observation**

<img width="1168" alt="Capture d’écran 2022-01-11 à 09 25 44" src="https://user-images.githubusercontent.com/7602475/148960906-6d1aeefa-8971-4cbf-83fa-c05c51da4b60.png">

**Testing Strategy**

- Already covered by tests
- Manual testing