### PR TITLE
[CM] Add error icon for vertical locales tabs

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/vertical-tabs/index.js
+++ b/packages/@coorpacademy-components/src/molecule/vertical-tabs/index.js
@@ -1,13 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import {NovaSolidStatusCheckCircle2 as CheckIcon} from '@coorpacademy/nova-icons';
-import {snakeCase} from 'lodash/fp';
+import {
+  NovaSolidStatusCheckCircle2 as CheckIcon,
+  NovaSolidStatusClose as ErrorIcon
+} from '@coorpacademy/nova-icons';
+import keys from 'lodash/fp/keys';
+import snakeCase from 'lodash/fp/snakeCase';
 import Link from '../../atom/link';
 import style from './style.css';
 
 const LeftIcons = {
-  BlueValidatedCircle: CheckIcon
+  BlueValidatedCircle: CheckIcon,
+  LocaleInError: ErrorIcon
 };
 
 const buildTab = (tab, index) => {
@@ -22,7 +27,9 @@ const buildTab = (tab, index) => {
       onClick={onClick}
     >
       <span className={style.title}>{title}</span>
-      {LeftIcon ? <LeftIcon className={style.leftIcon} /> : null}
+      {LeftIcon ? (
+        <LeftIcon className={leftIcon === 'LocaleInError' ? style.leftIconError : style.leftIcon} />
+      ) : null}
     </li>
   );
 };
@@ -38,12 +45,14 @@ const VerticalTabs = props => {
   );
 };
 
+const LeftIconValues = [...keys(LeftIcons), ''];
+
 VerticalTabs.propTypes = {
   tabs: PropTypes.arrayOf(
     PropTypes.shape({
       title: Link.propTypes.children,
       selected: PropTypes.bool,
-      leftIcon: PropTypes.string,
+      leftIcon: PropTypes.oneOf(LeftIconValues),
       onClick: PropTypes.func
     })
   ),

--- a/packages/@coorpacademy-components/src/molecule/vertical-tabs/style.css
+++ b/packages/@coorpacademy-components/src/molecule/vertical-tabs/style.css
@@ -5,6 +5,7 @@
 @value medium from colors;
 @value cm_blue_50 from colors;
 @value cm_primary_blue from colors;
+@value cm_negative_100 from colors;
 
 .wrapper {
   background-color: white;
@@ -50,6 +51,16 @@
   width: 20px;
   height: 15px;
   color: cm_primary_blue
+}
+
+.leftIconError {
+  background-color: cm_negative_100;
+  color: white;
+  border-radius: 50%;
+  padding: 2px;
+  width: 9px;
+  height: 9px;
+  margin-right: 3px;
 }
 
 .tab:hover {

--- a/packages/@coorpacademy-components/src/molecule/vertical-tabs/test/fixtures/with-multiple-errors.js
+++ b/packages/@coorpacademy-components/src/molecule/vertical-tabs/test/fixtures/with-multiple-errors.js
@@ -1,0 +1,49 @@
+export default {
+  props: {
+    tabs: [
+      {
+        title: '🇫🇷 French',
+        leftIcon: 'LocaleInError',
+        onClick: () => console.log('click'),
+        selected: false
+      },
+      {
+        title: '🇪🇸 Spanish',
+        leftIcon: 'BlueValidatedCircle',
+        onClick: () => console.log('click'),
+        selected: false
+      },
+      {
+        title: '🇮🇹 Italian',
+        leftIcon: 'LocaleInError',
+        onClick: () => console.log('click'),
+        selected: false
+      },
+      {
+        title: '🇩🇪 German',
+        leftIcon: '',
+        onClick: () => console.log('click'),
+        selected: false
+      },
+      {
+        title: '🇷🇺 Russian',
+        leftIcon: '',
+        onClick: () => console.log('click'),
+        selected: false
+      },
+      {
+        title: '🇵🇱 Polish',
+        leftIcon: 'BlueValidatedCircle',
+        onClick: () => console.log('click'),
+        selected: false
+      },
+      {
+        title: '🇹🇷 Turkish',
+        leftIcon: '',
+        onClick: () => console.log('click'),
+        selected: false
+      }
+    ],
+    'aria-label': 'Languages list'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/vertical-tabs/test/fixtures/with-selected-item.js
+++ b/packages/@coorpacademy-components/src/molecule/vertical-tabs/test/fixtures/with-selected-item.js
@@ -87,7 +87,7 @@ export default {
       },
       {
         title: '🇹🇷 Turkish',
-        leftIcon: '',
+        leftIcon: 'LocaleInError',
         onClick: () => console.log('click'),
         selected: false
       }

--- a/packages/@coorpacademy-components/src/organism/content-translation/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/content-translation/test/fixtures/default.js
@@ -1,8 +1,8 @@
-import vericalMenu from '../../../../molecule/vertical-tabs/test/fixtures/with-selected-item';
+import verticalMenu from '../../../../molecule/vertical-tabs/test/fixtures/with-selected-item';
 import inputText from '../../../../atom/input-text/test/fixtures/cm-default';
 import textArea from '../../../../atom/input-textarea/test/fixtures/cm-default';
 
-const languageTabs = vericalMenu.props.tabs;
+const languageTabs = verticalMenu.props.tabs;
 
 export default {
   props: {

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -729,6 +729,7 @@ import MoleculeTitledCheckboxFixtureNotChecked from '../src/molecule/titled-chec
 import MoleculeUnsubscribeFixtureDefault from '../src/molecule/unsubscribe/test/fixtures/default';
 import MoleculeUnsubscribeFixtureSubscribed from '../src/molecule/unsubscribe/test/fixtures/subscribed';
 import MoleculeVerticalTabsFixtureDefault from '../src/molecule/vertical-tabs/test/fixtures/default';
+import MoleculeVerticalTabsFixtureWithMultipleErrors from '../src/molecule/vertical-tabs/test/fixtures/with-multiple-errors';
 import MoleculeVerticalTabsFixtureWithSelectedItem from '../src/molecule/vertical-tabs/test/fixtures/with-selected-item';
 import MoleculeVideoIframeFixtureEmpty from '../src/molecule/video-iframe/test/fixtures/empty';
 import MoleculeVideoIframeFixtureH5P from '../src/molecule/video-iframe/test/fixtures/h5p';
@@ -2054,6 +2055,7 @@ export const fixtures = {
     },
     MoleculeVerticalTabs: {
       Default: MoleculeVerticalTabsFixtureDefault,
+      WithMultipleErrors: MoleculeVerticalTabsFixtureWithMultipleErrors,
       WithSelectedItem: MoleculeVerticalTabsFixtureWithSelectedItem
     },
     MoleculeVideoIframe: {


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
- adds error icon for vertical locales tabs

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
