### PR TITLE
fix summary size and position

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/wizard-summary/style.css
+++ b/packages/@coorpacademy-components/src/molecule/wizard-summary/style.css
@@ -243,6 +243,6 @@ ul {
     transform: rotateZ(180deg);
   }
   .summarySections {
-    max-height: 250px;
+    max-height: 500px;
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/wizard-summary/style.css
+++ b/packages/@coorpacademy-components/src/molecule/wizard-summary/style.css
@@ -233,7 +233,7 @@ ul {
   }
 
   .checkbox:checked + .summary  {
-    height: 65%;
+    height: 70%;
     max-height: 1000px;
     padding: 12px 24px 12px 24px;
     box-shadow: 0 -6px 42px -14px rgba(0, 0, 0, 0.25);

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/style.css
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/style.css
@@ -37,7 +37,7 @@
   width: 320px;
   height: 82%;
   border-radius: 7px;
-  height: 80%;
+  height: 86%;
   display: flex;
   flex-direction: column;
 }

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/style.css
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/style.css
@@ -8,6 +8,7 @@
   align-items: stretch;
   justify-content: flex-start;
   flex-wrap: wrap;
+  height: 100%;
 }
 
 .leftSection {
@@ -24,6 +25,7 @@
   display: flex;
   flex-direction: column;
   flex: 0 1 320px;
+  height: 100%;
 }
 
 .stickySection {
@@ -32,7 +34,12 @@
   z-index: 1;
   bottom: 0;
   right: 64px;
-  width: 300px;
+  width: 320px;
+  height: 82%;
+  border-radius: 7px;
+  height: 80%;
+  display: flex;
+  flex-direction: column;
 }
 
 .header {
@@ -56,6 +63,9 @@
   width: 100%;
   position: relative;
   min-height: 500px;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
   justify-content: space-between;
 }
 
@@ -72,6 +82,7 @@
 
 .footer {
   width: 100%;
+  height: 100%;
   bottom: 0px;
   display: none;
   position: inherit;
@@ -93,6 +104,7 @@
     bottom: 10px;
     position: sticky;
     z-index: 1;
+    min-height: 600px;
   }
   .footer::before {
     content: '';
@@ -107,6 +119,7 @@
 
   .summaryFooter {
     width: 57%;
+    height: 100%;
   }
 
   .actionFooter {


### PR DESCRIPTION
[Ticket](https://trello.com/c/F0jVchrn/548-remont%C3%A9-le-summary-plus-haut-au-niveau-du-wizard-fil-darianne)
Fix the size and position of summary
Web: 
![image](https://user-images.githubusercontent.com/58167920/149780470-54551c62-d65f-4764-8517-b4ee5adcabc0.png)


Responsive 
![image](https://user-images.githubusercontent.com/58167920/149762156-2e4d6210-b163-4be9-8a5e-a9a82a6eff2a.png)


**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
