### PR TITLE
CM Loader Tweaks

### DIFF
--- a/packages/@coorpacademy-components/src/organism/course-selection/index.js
+++ b/packages/@coorpacademy-components/src/organism/course-selection/index.js
@@ -7,8 +7,8 @@ import SelectMultiple from '../../molecule/select-multiple';
 import Card from '../../molecule/card';
 import style from './style.css';
 
-const buildResultView = (courses, coursesSelectionAriaLabel, emptyMessages) => {
-  if (isEmpty(courses)) {
+const buildResultView = (courses, coursesSelectionAriaLabel, emptyMessages, isLoading) => {
+  if (!isLoading && isEmpty(courses)) {
     return <EmptySearchResult {...emptyMessages} />;
   }
 
@@ -29,10 +29,11 @@ const CourseSelection = props => {
     contentTypeFilter,
     courses,
     emptyMessages,
+    isLoading = false,
     'courses-selection-aria-label': coursesSelectionAriaLabel
   } = props;
 
-  const resultView = buildResultView(courses, coursesSelectionAriaLabel, emptyMessages);
+  const resultView = buildResultView(courses, coursesSelectionAriaLabel, emptyMessages, isLoading);
 
   return (
     <div className={style.container}>
@@ -51,6 +52,7 @@ const CourseSelection = props => {
 
 CourseSelection.propTypes = {
   search: PropTypes.shape(Search.PropTypes),
+  isLoading: PropTypes.bool,
   contentTypeFilter: PropTypes.shape(SelectMultiple.PropTypes),
   courses: PropTypes.arrayOf(PropTypes.shape(Card.propTypes)),
   'courses-selection-aria-label': PropTypes.string,

--- a/packages/@coorpacademy-components/src/organism/course-selection/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/course-selection/test/fixtures/default.js
@@ -13,6 +13,7 @@ export default {
       description: 'Type to filter the courses',
       onChange: value => console.log(value)
     },
+    isLoading: false,
     contentTypeFilter: {
       type: 'selectMultiple',
       title: 'Content type',

--- a/packages/@coorpacademy-components/src/organism/search-and-chips-results/index.js
+++ b/packages/@coorpacademy-components/src/organism/search-and-chips-results/index.js
@@ -7,8 +7,8 @@ import ButtonLink from '../../atom/button-link';
 import Chips from '../../atom/chips';
 import style from './style.css';
 
-const buildResultView = (results, resultsAriaLabel, emptyMessages) => {
-  if (isEmpty(results)) {
+const buildResultView = (results, resultsAriaLabel, emptyMessages, isLoading) => {
+  if (!isLoading && isEmpty(results)) {
     return <EmptySearchResult {...emptyMessages} />;
   }
 
@@ -29,11 +29,12 @@ const SearchAndChipsResults = props => {
     selectAllButton,
     results,
     emptyMessages,
+    isLoading = false,
     'results-aria-label': resultsAriaLabel
   } = props;
 
   const {onClick, label, disabled = false, 'aria-label': ariaLabel} = selectAllButton;
-  const resultView = buildResultView(results, resultsAriaLabel, emptyMessages);
+  const resultView = buildResultView(results, resultsAriaLabel, emptyMessages, isLoading);
   const buttonProps = {
     type: 'secondary',
     label,
@@ -69,6 +70,7 @@ SearchAndChipsResults.propTypes = {
     disabled: PropTypes.bool,
     'aria-label': PropTypes.string
   }),
+  isLoading: PropTypes.bool,
   search: PropTypes.shape(Search.PropTypes),
   results: PropTypes.arrayOf(PropTypes.shape(Chips.propTypes)),
   'results-aria-label': PropTypes.string,

--- a/packages/@coorpacademy-components/src/organism/search-and-chips-results/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/search-and-chips-results/test/fixtures/default.js
@@ -4,6 +4,7 @@ export default {
       label: 'Select All',
       onClick: () => console.log('Select All')
     },
+    isLoading: false,
     search: {
       title: 'Search...',
       placeholder: 'Search...',

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/index.js
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/index.js
@@ -94,7 +94,7 @@ const buildActionZone = (previousStep, nextStep, side) => {
 const WizardContents = props => {
   const {isLoading, wizardHeader, steps, summary, content, nextStep, previousStep} = props;
   const headerView = buildHeader(wizardHeader, steps);
-  const formView = buildForm(content);
+  const formView = buildForm({...content, isLoading});
   const rightActionView = buildActionZone(previousStep, nextStep, 'right');
   const footerActionView = buildActionZone(previousStep, nextStep, 'footer');
 
@@ -102,7 +102,15 @@ const WizardContents = props => {
     <div className={style.container} data-name="custom-playlist-summary">
       <div className={style.leftSection}>
         {headerView}
-        <div className={style.form}>{isLoading ? <Loader theme="coorpmanager" /> : formView}</div>
+        <div className={style.form}>
+          {isLoading ? (
+            <div className={style.loader}>
+              <Loader theme="coorpmanager" />
+            </div>
+          ) : (
+            formView
+          )}
+        </div>
       </div>
       <div className={style.rightSection} data-name="summary-right-section">
         <div className={style.stickySection}>

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/style.css
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/style.css
@@ -42,6 +42,12 @@
   flex-direction: column;
 }
 
+.loader {
+  position: relative;
+  min-height: 50vh;
+  width: 100%;
+}
+
 .header {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
- Center the loader
- Only shows empty messages when it's not loading and courses/populations is empty

### Before
<img width="1092" alt="Capture d’écran 2022-01-19 à 15 56 49" src="https://user-images.githubusercontent.com/23306911/150156124-244b9940-725e-4e05-8e71-710ad15cf22a.png">


### After
<img width="1118" alt="Capture d’écran 2022-01-19 à 15 57 05" src="https://user-images.githubusercontent.com/23306911/150156020-ed40c3c8-1878-478e-9e45-b3e02edfb934.png">
