### PR TITLE
close summary when click out side

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/wizard-summary/index.js
+++ b/packages/@coorpacademy-components/src/molecule/wizard-summary/index.js
@@ -147,7 +147,7 @@ const WizardSummary = props => {
       );
     }
     setChecked(!checked);
-  }, [checked, summaryElement]);
+  }, [checked]);
 
   return (
     <div className={style.container} ref={summaryElement}>

--- a/packages/@coorpacademy-components/src/molecule/wizard-summary/index.js
+++ b/packages/@coorpacademy-components/src/molecule/wizard-summary/index.js
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useMemo, useState, useCallback} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {uniqueId} from 'lodash/fp';
@@ -110,13 +110,43 @@ const BuildAction = ({action}) => {
   );
 };
 
+const checkOnClose = (checked, summaryElement, onCloseSummary, clickEvent) => {
+  if (checked) {
+    if (summaryElement && !summaryElement.contains(clickEvent.target)) {
+      onCloseSummary();
+    }
+  }
+};
+
 const WizardSummary = props => {
   const {title, sections, action, side} = props;
   const sectionsView = buildSections(sections);
   const idSwitch = uniqueId('open-summary-wizard');
+  const [summaryElement, setSummaryElement] = useState(null);
+  const [checked, setChecked] = useState(false);
+
+  const onCloseSummary = () => setChecked(false);
+  const handleOnChange = useCallback(() => {
+    if (!checked) {
+      document.addEventListener('click', clickEvent =>
+        checkOnClose(!checked, summaryElement, onCloseSummary, clickEvent)
+      );
+      document.addEventListener('touchstart', clickEvent =>
+        checkOnClose(!checked, summaryElement, onCloseSummary, clickEvent)
+      );
+    } else {
+      document.removeEventListener('click', clickEvent =>
+        checkOnClose(!checked, summaryElement, onCloseSummary, clickEvent)
+      );
+      document.removeEventListener('touchstart', clickEvent =>
+        checkOnClose(!checked, summaryElement, onCloseSummary, clickEvent)
+      );
+    }
+    setChecked(!checked);
+  }, [checked, summaryElement]);
 
   return (
-    <div className={style.container}>
+    <div className={style.container} ref={setSummaryElement}>
       <span className={style.desktopSummaryTitle} data-name={`summary-title-${side}`}>
         {title}
       </span>
@@ -127,6 +157,8 @@ const WizardSummary = props => {
         title={idSwitch}
         className={style.checkbox}
         data-name={`summary-checkbox-${side}`}
+        checked={checked}
+        onChange={handleOnChange}
       />
       <div className={style.summary}>
         <div className={style.tabletSummaryHeader}>

--- a/packages/@coorpacademy-components/src/molecule/wizard-summary/index.js
+++ b/packages/@coorpacademy-components/src/molecule/wizard-summary/index.js
@@ -1,4 +1,4 @@
-import React, {useMemo, useState, useCallback} from 'react';
+import React, {useMemo, useState, useCallback, useRef} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {uniqueId} from 'lodash/fp';
@@ -112,7 +112,11 @@ const BuildAction = ({action}) => {
 
 const checkOnClose = (checked, summaryElement, onCloseSummary, clickEvent) => {
   if (checked) {
-    if (summaryElement && !summaryElement.contains(clickEvent.target)) {
+    if (
+      summaryElement &&
+      summaryElement.current &&
+      !summaryElement.current.contains(clickEvent.target)
+    ) {
       onCloseSummary();
     }
   }
@@ -122,7 +126,7 @@ const WizardSummary = props => {
   const {title, sections, action, side} = props;
   const sectionsView = buildSections(sections);
   const idSwitch = uniqueId('open-summary-wizard');
-  const [summaryElement, setSummaryElement] = useState(null);
+  const summaryElement = useRef(null);
   const [checked, setChecked] = useState(false);
 
   const onCloseSummary = () => setChecked(false);
@@ -146,7 +150,7 @@ const WizardSummary = props => {
   }, [checked, summaryElement]);
 
   return (
-    <div className={style.container} ref={setSummaryElement}>
+    <div className={style.container} ref={summaryElement}>
       <span className={style.desktopSummaryTitle} data-name={`summary-title-${side}`}>
         {title}
       </span>


### PR DESCRIPTION
[Ticket](https://trello.com/c/oFmFIZiM/567-clic-outside-of-summary-should-close-it)

Click on input => open 
Click on summary => nothing to do 
Click out side => close summary
Click the input => open summary

![summary-click](https://user-images.githubusercontent.com/58167920/150158413-7347bb61-3723-4fe1-a283-cbda56629a9a.gif)


**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
