### PR TITLE
added position fixed to popin component

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
@@ -26,6 +26,7 @@
   box-sizing: border-box;
   overflow: hidden;
   display: flex;
+  position:fixed;
 }
 
 .popin {

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/published.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/published.js
@@ -3,7 +3,7 @@ import revisedItem from '../../../list-item/test/fixtures/revised';
 
 const propsRevised = revisedItem.props;
 
-const ids = ['1', '2', '3'];
+const ids = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'];
 const listePublishedItems = ids.map(id => {
   return {
     ...publishedItem.props,


### PR DESCRIPTION
https://trello.com/c/vDrJD9MX/550-correctif-background-mal-appliqu%C3%A9
- fixed background of popin in case of long list of custom playlists

![popin-background-fix](https://user-images.githubusercontent.com/94372828/150159686-aabb0d9f-0297-4c6a-a694-5ea16b6b4e98.gif)


**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
