### PR TITLE
changed position type of summary + added max height

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/wizard-summary/style.css
+++ b/packages/@coorpacademy-components/src/molecule/wizard-summary/style.css
@@ -26,6 +26,7 @@
   bottom: 0px;
   display: flex;
   flex-direction: column;
+  max-height: 586px;
 }
 
 .summary {

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/style.css
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/style.css
@@ -30,14 +30,12 @@
 
 .stickySection {
   box-sizing: border-box;
-  position: fixed;
+  position: relative;
   z-index: 1;
-  bottom: 0;
-  right: 64px;
   width: 320px;
-  height: 82%;
+  height: 100%;
+  max-height: 646px;
   border-radius: 7px;
-  height: 86%;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
https://trello.com/c/bYJ52Pi0/578-fix-broken-notification-permenente-ui-ux
- fix summary CSS
before: 

<img width="1440" alt="before" src="https://user-images.githubusercontent.com/94372828/150384951-7ddb49a2-7814-4a27-835f-b3dac53a461c.png">

after:

<img width="1440" alt="after" src="https://user-images.githubusercontent.com/94372828/150384989-07f0edbe-3b71-471b-b016-0d89b10f4a49.png">


**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
