### PR TITLE
remove tolower when fuzzyMatching is activated for template text ques…

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
+++ b/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
@@ -66,15 +66,19 @@ function isTextCorrect(
   const allowedAnswers = _allowedAnswers.map(trim);
   const fm = new FuzzyMatching(allowedAnswers);
   const maxTypos = _maxTypos === 0 ? _maxTypos : _maxTypos || config.maxTypos;
-  const answer = toLower(answerWithCase);
 
   if (noFuzzy) {
-    return some(allowedAnswer => toLower(allowedAnswer) === answer, allowedAnswers);
+    return some(allowedAnswer => allowedAnswer === answerWithCase, allowedAnswers);
   }
+
+  const answerWithoutCase = toLower(answerWithCase);
   return (
-    checkFuzzyAnswer(maxTypos, fm, answer) ||
+    checkFuzzyAnswer(maxTypos, fm, answerWithoutCase) ||
     (maxTypos !== 0 &&
-      some(allowedAnswer => containsAnswer(config, toLower(allowedAnswer), answer), allowedAnswers))
+      some(
+        allowedAnswer => containsAnswer(config, toLower(allowedAnswer), answerWithoutCase),
+        allowedAnswers
+      ))
   );
 }
 
@@ -113,7 +117,7 @@ function matchAnswerForTemplate(
       isTextCorrect(
         config,
         [allowedAnswer[index]],
-        toLower(answer),
+        answer,
         get(['content', 'choices', `${index}`, 'type'], question) === 'text'
           ? question.content.maxTypos
           : 0,

--- a/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
+++ b/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
@@ -135,18 +135,18 @@ function matchAnswerForUnorderedItems(
   allowedAnswers: AcceptedAnswers,
   givenAnswer: Answer
 ): Array<Array<PartialCorrection>> {
-  const lowerGivenAnswer = map(toLower, givenAnswer);
+  // const lowerGivenAnswer = map(toLower, givenAnswer);
 
   return allowedAnswers.map((allowedAnswer): Array<PartialCorrection> => {
-    const lowerAllowedAnswer = map(toLower, allowedAnswer);
+    // const lowerAllowedAnswer = map(toLower, allowedAnswer);
     const givenAnswersMap = map(
       answer => ({
         answer,
-        isCorrect: includes(toLower(answer), lowerAllowedAnswer)
+        isCorrect: includes(answer, allowedAnswer)
       }),
       givenAnswer
     );
-    if (lowerAllowedAnswer.some(answer => !includes(answer, lowerGivenAnswer))) {
+    if (allowedAnswer.some(answer => !includes(answer, givenAnswer))) {
       return givenAnswersMap.concat([{answer: undefined, isCorrect: false}]);
     }
     return givenAnswersMap;
@@ -161,7 +161,7 @@ function matchAnswerForOrderedItems(
     return map(([givenAnswerPart, allowedAnswerPart]): PartialCorrection => {
       return {
         answer: givenAnswerPart,
-        isCorrect: toLower(givenAnswerPart) === toLower(allowedAnswerPart)
+        isCorrect: givenAnswerPart === allowedAnswerPart
       };
     }, zip(givenAnswer, allowedAnswer));
   }, allowedAnswers);

--- a/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
+++ b/packages/@coorpacademy-progression-engine/src/check-answer-correctness.js
@@ -73,7 +73,7 @@ function isTextCorrect(
 
   const answerWithoutCase = toLower(answerWithCase);
   return (
-    checkFuzzyAnswer(maxTypos, fm, answerWithoutCase) ||
+    checkFuzzyAnswer(maxTypos, fm, answerWithCase) ||
     (maxTypos !== 0 &&
       some(
         allowedAnswer => containsAnswer(config, toLower(allowedAnswer), answerWithoutCase),
@@ -135,10 +135,7 @@ function matchAnswerForUnorderedItems(
   allowedAnswers: AcceptedAnswers,
   givenAnswer: Answer
 ): Array<Array<PartialCorrection>> {
-  // const lowerGivenAnswer = map(toLower, givenAnswer);
-
   return allowedAnswers.map((allowedAnswer): Array<PartialCorrection> => {
-    // const lowerAllowedAnswer = map(toLower, allowedAnswer);
     const givenAnswersMap = map(
       answer => ({
         answer,

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-drag.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-drag.js
@@ -20,7 +20,7 @@ function createQuestion(matchOrder: boolean, answers: AcceptedAnswers): QCMDragQ
   };
 }
 
-[true, false].forEach((bool: boolean) => {
+[true].forEach((bool: boolean) => {
   test(`should return true when the given answer is in the accepted answers (matchOrder=${bool.toString()})`, t => {
     const question = createQuestion(bool, [
       ['answer1', 'answer3'],
@@ -33,10 +33,10 @@ function createQuestion(matchOrder: boolean, answers: AcceptedAnswers): QCMDragQ
     assertCorrect(t, config, question, ['answer1', 'answer4']);
   });
 
-  test(`should return true even when the given answer does not have the same case as the accepted answers (matchOrder=${bool.toString()})`, t => {
+  test(`should return false when the given answer does not have the same case as the accepted answers (matchOrder=${bool.toString()})`, t => {
     const question = createQuestion(bool, [['answer2']]);
 
-    assertCorrect(t, config, question, ['ANSWER2']);
+    assertIncorrect(t, config, question, ['ANSWER2'], [false]);
   });
 
   test(`should return false when the given answer is not in the accepted answers (matchOrder=${bool.toString()})`, t => {

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-drag.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-drag.js
@@ -20,7 +20,7 @@ function createQuestion(matchOrder: boolean, answers: AcceptedAnswers): QCMDragQ
   };
 }
 
-[true].forEach((bool: boolean) => {
+[true, false].forEach((bool: boolean) => {
   test(`should return true when the given answer is in the accepted answers (matchOrder=${bool.toString()})`, t => {
     const question = createQuestion(bool, [
       ['answer1', 'answer3'],

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-graphic.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm-graphic.js
@@ -33,10 +33,10 @@ test('should return true when the given answer is in the accepted answers', t =>
   assertCorrect(t, config, question, ['answer1', 'answer4']);
 });
 
-test('should return true even when the given answer does not have the same case as the accepted answers', t => {
+test('should return false when the given answer does not have the same case as the accepted answers', t => {
   const question = createQuestion([['answer2']]);
 
-  assertCorrect(t, config, question, ['ANSWER2']);
+  assertIncorrect(t, config, question, ['ANSWER2'], [false]);
 });
 
 test('should return true when the given answer is in the accepted answers but values are in a different order', t => {

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.qcm.js
@@ -32,10 +32,10 @@ test('should return true when the given answer is in the accepted answers', t =>
   assertCorrect(t, config, question, ['answer1', 'answer4']);
 });
 
-test('should return true even when the given answer does not have the same case as the accepted answers', t => {
+test('should return false when the given answer does not have the same case as the accepted answers', t => {
   const question = createQuestion([['answer2']]);
 
-  assertCorrect(t, config, question, ['ANSWER2']);
+  assertIncorrect(t, config, question, ['ANSWER2'], [false]);
 });
 
 test('should return true when the given answer is in the accepted answers but values are in a different order', t => {

--- a/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.template.js
+++ b/packages/@coorpacademy-progression-engine/src/test/check-answer-correctness.template.js
@@ -152,6 +152,7 @@ test('should allow additional characters on the sides of text inputs', t => {
   const question = createQuestion([['parachute']], ['text']);
 
   assertCorrect(t, config, question, ['parachute']);
+  assertCorrect(t, config, question, ['Parachute']);
   assertCorrect(t, config, question, ['parachuté']);
   assertCorrect(t, config, question, ['parachuteZZZZZ']);
   assertCorrect(t, config, question, ['ZZZZZparachute']);
@@ -166,8 +167,8 @@ test('should not allow typos or additional characters for select inputs', t => {
   const question = createQuestion([['parachute']], ['select']);
 
   assertCorrect(t, config, question, ['parachute']);
-  assertCorrect(t, config, question, ['parachUTe']);
-  assertCorrect(t, config, question, ['PARACHUTE']);
+  assertIncorrect(t, config, question, ['Parachute'], [false]);
+  assertIncorrect(t, config, question, ['PARACHUTE'], [false]);
   assertIncorrect(t, config, question, ['parachOte'], [false]);
   assertIncorrect(t, config, question, ['parachuteZ'], [false]);
   assertIncorrect(t, config, question, ['Zparachute'], [false]);


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

Correction to remove toLower case when its not needed. Only keep it in fuzzyMatching cases ( template text question)
Other type of question do not required user to type in anything so answer and expected answer have to match ( cockpit answer selection oblige)
<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [x] Unit testing
