### PR TITLE
Fix footer

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-footer/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-footer/style.css
@@ -137,7 +137,7 @@
   padding-top: 24px;
   display: flex;
   flex-wrap: nowrap;
-  list-style: non;
+  list-style: none;
 }
 
 .socialLink {


### PR DESCRIPTION
 Bonjour, 
Il y a un affichage de numéro "1.2.3.4.5" au niveau du footer des plateformes team (je ne sais pas pour celles grands comptes). 

<img width="347" alt="Capture d’écran 2022-01-31 à 18 57 44" src="https://user-images.githubusercontent.com/15608581/151847466-339cbdd5-360c-45a4-b235-f0426f5066e9.png">


**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
