### PR TITLE
remove bold to feedback description

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/feedback/style.css
+++ b/packages/@coorpacademy-components/src/molecule/feedback/style.css
@@ -40,7 +40,6 @@
   margin-right: 32px;
   font-family: 'Open Sans';
   font-size: 13px;
-  font-weight: bold;
   letter-spacing: -0.1px;
   text-align: left;
   color: dark;


### PR DESCRIPTION
 https://app.prodpad.com/ideas/4033/canvas
**IDEA 4033 - Enlever le bold par défaut dans les feedbacks adaptives**
Aujourd'hui, le texte des feedbacks plateforme (en fin d'adaptive notamment) est en gras par défaut.
Serait-il possible d'enlever le "bold" par défaut pour ces feedbacks plateforme ?
Cela permettrait de mieux mettre en forme les textes de feedback d'adaptive qui sont parfois un peu longs.
Merci :)

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
