### PR TITLE
Qcm graphic update

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
@@ -9,18 +9,20 @@ const QCMImage = (props, context) => {
   const {answers} = props;
 
   const answersViews = answers.map((answer, key) => {
-    const {onClick, title, selected, image} = answer;
+    const {onClick, title, selected, image, ariaLabel} = answer;
 
     return (
       <div
         className={selected ? style.selected : style.answer}
         onClick={onClick}
         data-selected={selected}
+        data-name="answerGraphicWrapper"
         key={key}
       >
         <div
           className={style.imageWrapper}
           data-name="answerGraphic"
+          aria-label={ariaLabel || title}
           style={{
             backgroundImage: `url(${image})`
           }}
@@ -53,7 +55,8 @@ QCMImage.propTypes = {
       title: PropTypes.string,
       selected: PropTypes.bool,
       onClick: PropTypes.func,
-      image: PropTypes.string
+      image: PropTypes.string,
+      ariaLabel: PropTypes.string
     })
   )
 };

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
@@ -11,18 +11,12 @@ const QCMImage = (props, context) => {
 
   const answersViews = answers.map((answer, key) => {
     const {onClick, title, selected, image} = answer;
-    const {skin} = context;
 
-    const primarySkinColor = getOr('#00B0FF', 'common.primary', skin);
-    const selectedStyle = selected
-      ? {backgroundColor: primarySkinColor, borderColor: primarySkinColor}
-      : null;
     return (
       <div
         className={selected ? style.selected : style.answer}
         onClick={onClick}
         data-selected={selected}
-        style={selectedStyle}
         key={key}
       >
         <div
@@ -32,11 +26,13 @@ const QCMImage = (props, context) => {
             backgroundImage: `url(${image})`
           }}
         />
-        <div
-          className={classnames(style.titleWrapper, innerHTML)}
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{__html: title}}
-        />
+        <div className={style.titleWrapper}>
+          <div
+            className={classnames(style.title, innerHTML)}
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{__html: title}}
+          />
+        </div>
       </div>
     );
   });

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {getOr} from 'lodash/fp';
 import classnames from 'classnames';
 import Provider from '../../../atom/provider';
 import {innerHTML} from '../../../atom/label/style.css';

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
@@ -1,38 +1,59 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {getOr} from 'lodash/fp';
 import classnames from 'classnames';
 import Provider from '../../../atom/provider';
 import {innerHTML} from '../../../atom/label/style.css';
+import {getShadowBoxColorFromPrimary} from '../../../util/get-shadow-box-color-from-primary';
 import style from './style.css';
 
 const QCMImage = (props, context) => {
   const {answers} = props;
+  const {skin} = context;
+  const primarySkinColor = getOr('#00B0FF', 'common.primary', skin);
 
   const answersViews = answers.map((answer, key) => {
     const {onClick, title, selected, image, ariaLabel} = answer;
 
     return (
       <div
-        className={selected ? style.selected : style.answer}
         onClick={onClick}
         data-selected={selected}
-        data-name="answerGraphicWrapper"
+        data-name="answerGraphic"
+        style={{
+          ...(selected && {
+            boxShadow: `0 4px 16px ${getShadowBoxColorFromPrimary(primarySkinColor)}`
+          })
+        }}
+        className={selected ? style.selected : style.answer}
         key={key}
       >
         <div
-          className={style.imageWrapper}
-          data-name="answerGraphic"
-          aria-label={ariaLabel || title}
+          data-name="answerBackground"
           style={{
-            backgroundImage: `url(${image})`
+            backgroundColor: selected ? primarySkinColor : '#F4F4F5'
           }}
+          className={style.background}
         />
-        <div className={style.titleWrapper}>
+        <div data-name="answerContent" className={style.content}>
           <div
-            className={classnames(style.title, innerHTML)}
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{__html: title}}
+            className={style.imageWrapper}
+            data-name="answerImage"
+            aria-label={ariaLabel || title}
+            style={{
+              backgroundImage: `url(${image})`
+            }}
           />
+          <div data-name="answerText" className={style.titleWrapper}>
+            <div
+              className={classnames(style.title, innerHTML)}
+              style={{
+                ...(selected && {color: primarySkinColor})
+              }}
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{__html: title}}
+            />
+          </div>
         </div>
       </div>
     );

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
@@ -40,6 +40,7 @@
 
 .content {
   height: 100%;
+  width: 100%;
   position: relative;
 }
 
@@ -119,10 +120,11 @@
     overflow: hidden;
   }
 
-  .answer:hover {
-    background-color: white;
+  .content {
+    display: flex;
+    align-items: center;
   }
-
+  
   .answer:last-child {
     margin-bottom: 0;
   }
@@ -139,7 +141,7 @@
     white-space: wrap;
     overflow: hidden;
     padding: 0;
-    text-align: left;
+    justify-content: left;
     font-size: 15px;
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
@@ -2,8 +2,8 @@
 @value mobile from breakpoints;
 @value colors: "../../../variables/colors.css";
 @value white from colors;
-@value xtraLightGrey from colors;
-@value light from colors;
+@value cm_grey_75 from colors;
+@value cm_primary_blue from colors;
 @value black from colors;
 
 .wrapper {
@@ -17,14 +17,14 @@
 .answer {
   color: black;
   background-color: white;
-  border: 1px solid color(black lightness(85%));
-  border-radius: 3px;
   box-sizing: border-box;
   cursor: pointer;
   padding: 8px;
   width: 200px;
   min-height: 245px;
   margin: 0 4px 8px;
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.12);
+  border-radius: 16px;
 }
 
 .imageWrapper {
@@ -33,12 +33,21 @@
   align-items: center;
   height: 110px;
   margin-bottom: 16px;
-  background-size: contain;
+  background-size: cover;
   background-repeat: no-repeat;
   background-position: center center;
+  border-radius: 12px;
 }
 
 .titleWrapper {
+  display: flex;
+  height: calc(100% - 126px);
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.title {
   font-family: 'Gilroy';
   font-size: 17px;
   line-height: 20px;
@@ -49,18 +58,26 @@
 }
 
 .answer:hover {
-  background-color: xtraLightGrey;
+  background: cm_grey_75;
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.12);
 }
 
 .selected {
   composes: answer;
-  color: white;
+  background: rgba(0, 97, 255, 0.05);
+  box-shadow: 0px 4px 16px rgba(0, 97, 255, 0.2);
+  color: cm_primary_blue;
+}
+
+.selected:hover {
+  background: rgba(0, 97, 255, 0.1);
 }
 
 @media mobile {
   .wrapper {
     flex-direction: column;
-    align-items: stretch;
+    display: flex;
+    align-items: center;
     width: 100%;
     padding-bottom: 0;
   }
@@ -69,7 +86,7 @@
     display: flex;
     align-items: center;
     flex-flow: row nowrap;
-    width: 100%;
+    width: calc(100% - 45px);
     min-height: 82px;
     height: inherit;
     margin: 0 0 8px;

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
@@ -4,7 +4,7 @@
 @value white from colors;
 @value cm_grey_75 from colors;
 @value cm_primary_blue from colors;
-@value black from colors;
+@value cm_blue_900 from colors;
 
 .wrapper {
   display: flex;
@@ -15,7 +15,8 @@
 }
 
 .answer {
-  color: black;
+  position: relative;
+  color: cm_blue_900;
   background-color: white;
   box-sizing: border-box;
   cursor: pointer;
@@ -25,6 +26,20 @@
   margin: 0 4px 8px;
   box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.12);
   border-radius: 16px;
+}
+
+.background {
+  top: 0;
+  left: 0;
+  position: absolute;
+  border-radius: 16px;
+  height: 100%;
+  width: 100%;
+  transition: opacity 0.25s linear, background-color 0.25s linear;
+}
+
+.content {
+  height: 100%;
 }
 
 .imageWrapper {
@@ -62,15 +77,21 @@
   box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.12);
 }
 
+.answer .background{
+  opacity: 0;
+}
+
 .selected {
   composes: answer;
-  background: rgba(0, 97, 255, 0.05);
-  box-shadow: 0px 4px 16px rgba(0, 97, 255, 0.2);
   color: cm_primary_blue;
 }
 
-.selected:hover {
-  background: rgba(0, 97, 255, 0.1);
+.selected .background{
+  opacity: 0.05;
+}
+
+.selected:hover .background{
+  opacity: 0.1;
 }
 
 @media mobile {

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
@@ -40,6 +40,7 @@
 
 .content {
   height: 100%;
+  position: relative;
 }
 
 .imageWrapper {
@@ -79,6 +80,10 @@
 
 .answer .background{
   opacity: 0;
+}
+
+.answer:hover .background{
+  opacity: 1;
 }
 
 .selected {

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/qcm-graphic.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/qcm-graphic.js
@@ -24,12 +24,27 @@ test('onClick should be reachable, should match given aria-label', t => {
     context: {translate}
   });
 
-  const answers = wrapper.find('[data-name="answerGraphic"]');
-  t.true(answers.at(1).exists());
-  t.is(answers.at(1).props()['aria-label'], 'Lorem ipsum');
+  const answersImages = wrapper.find('[data-name="answerImage"]');
+  t.true(answersImages.at(1).exists());
+  t.is(answersImages.at(1).props()['aria-label'], 'Lorem ipsum');
 
-  const answerWrappers = wrapper.find('[data-name="answerGraphicWrapper"]');
-  answerWrappers.at(1).simulate('click');
+  const answers = wrapper.find('[data-name="answerGraphic"]');
+  answers.at(1).simulate('click');
   t.true(answerWasClicked);
   t.pass();
+});
+
+test("should set: selected's background to Primary w/ alpha 5% && color to primary, unselected's no background && color to a nuance of primary", t => {
+  const wrapper = shallow(<QCMImage {...defaultFixture.props} />, {
+    context: {translate}
+  });
+  const answerBackgrounds = wrapper.find('[data-name="answerBackground"]');
+
+  const unselectedAnswer = answerBackgrounds.at(0);
+  t.true(unselectedAnswer.exists());
+  t.deepEqual(unselectedAnswer.props().style, {backgroundColor: '#F4F4F5'});
+
+  const selectedAnswer = answerBackgrounds.at(2);
+  t.true(selectedAnswer.exists());
+  t.deepEqual(selectedAnswer.props().style, {backgroundColor: '#00B0FF'});
 });

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/qcm-graphic.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/qcm-graphic.js
@@ -38,13 +38,21 @@ test("should set: selected's background to Primary w/ alpha 5% && color to prima
   const wrapper = shallow(<QCMImage {...defaultFixture.props} />, {
     context: {translate}
   });
-  const answerBackgrounds = wrapper.find('[data-name="answerBackground"]');
+  const answers = wrapper.find('[data-name="answerGraphic"]');
 
-  const unselectedAnswer = answerBackgrounds.at(0);
-  t.true(unselectedAnswer.exists());
-  t.deepEqual(unselectedAnswer.props().style, {backgroundColor: '#F4F4F5'});
+  const firstAnswer = answers.at(0);
+  t.true(firstAnswer.exists());
+  t.deepEqual(firstAnswer.props().style, {});
+  const unselectedBackgroundAnswer = firstAnswer.children().at(0);
+  t.true(unselectedBackgroundAnswer.exists());
+  t.deepEqual(unselectedBackgroundAnswer.props().style, {backgroundColor: '#F4F4F5'});
+  const firstAnswerText = firstAnswer.children().at(1).children().at(1).children().at(0);
+  t.true(firstAnswerText.exists());
 
-  const selectedAnswer = answerBackgrounds.at(2);
-  t.true(selectedAnswer.exists());
-  t.deepEqual(selectedAnswer.props().style, {backgroundColor: '#00B0FF'});
+  const thirdAnswer = answers.at(2);
+  t.true(thirdAnswer.exists());
+  t.deepEqual(thirdAnswer.props().style, {boxShadow: '0 4px 16px rgba(0, 122, 179, 0.25)'});
+  const selectedBackgroundAnswer = thirdAnswer.children().at(0);
+  t.true(selectedBackgroundAnswer.exists());
+  t.deepEqual(selectedBackgroundAnswer.props().style, {backgroundColor: '#00B0FF'});
 });

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/qcm-graphic.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/qcm-graphic.js
@@ -1,0 +1,35 @@
+import browserEnv from 'browser-env';
+import test from 'ava';
+import React from 'react';
+import {shallow, configure} from 'enzyme';
+import {identity} from 'lodash/fp';
+import Adapter from 'enzyme-adapter-react-16';
+import QCMImage from '..';
+import defaultFixture from './fixtures/default';
+
+browserEnv();
+configure({adapter: new Adapter()});
+const translate = identity;
+
+test('onClick should be reachable, should match given aria-label', t => {
+  let answerWasClicked = false;
+  defaultFixture.props.answers[1] = {
+    ...defaultFixture.props.answers[1],
+    onClick: () => {
+      answerWasClicked = true;
+    }
+  };
+
+  const wrapper = shallow(<QCMImage {...defaultFixture.props} />, {
+    context: {translate}
+  });
+
+  const answers = wrapper.find('[data-name="answerGraphic"]');
+  t.true(answers.at(1).exists());
+  t.is(answers.at(1).props()['aria-label'], 'Lorem ipsum');
+
+  const answerWrappers = wrapper.find('[data-name="answerGraphicWrapper"]');
+  answerWrappers.at(1).simulate('click');
+  t.true(answerWasClicked);
+  t.pass();
+});


### PR DESCRIPTION
https://trello.com/c/RWBCFOE2/2480-re-design-composant-question-qcm-illustr%C3%A9

**Detailed purpose of the PR**

This PRs restructure the QCMGraphic, adding a background div to handle color for selected cards based on brand's primary color.
It also groups the answer image and the answer text in a `content` div to have the expected rendering using `flex` property.

**Result and observation**

**Before web**
![Capture d’écran 2022-02-09 à 18 39 27](https://user-images.githubusercontent.com/7602475/153258427-7bf819fc-2122-4803-b027-6bedcf6e600c.png)

**Now**
![Capture d’écran 2022-02-09 à 18 39 50](https://user-images.githubusercontent.com/7602475/153258431-e2ff0870-ff6b-4745-af27-26d67ef8954e.png)

**Before mobile**
![Capture d’écran 2022-02-09 à 18 40 13](https://user-images.githubusercontent.com/7602475/153258434-410510c4-8f88-4f98-a5b5-edf775f7f6dd.png)

**Now**
![Capture d’écran 2022-02-09 à 18 40 26](https://user-images.githubusercontent.com/7602475/153258440-eec392a1-c2ae-4691-897b-b384733284e3.png)

**Hover behavior**
![Kapture 2022-02-09 at 18 31 14](https://user-images.githubusercontent.com/7602475/153257395-54511785-ad69-47f5-b891-e540a2ee9e6a.gif)

## Warning

The card dimensions were not modified (200x245), even if the figma specification indicates new dimensions (217x248), so the figma specs are not consistent with the expected version.

**Figma**
![Capture d’écran 2022-02-09 à 18 36 00](https://user-images.githubusercontent.com/7602475/153258642-a53efc2e-a7a4-4a7c-b8e7-ed84d3ef9663.png)

**Old version**
![Capture d’écran 2022-02-09 à 18 39 13](https://user-images.githubusercontent.com/7602475/153258643-f5c4cdf3-742f-4d53-a89a-316bd95b586a.png)


**New version**
![Capture d’écran 2022-02-09 à 18 35 04](https://user-images.githubusercontent.com/7602475/153258639-05e7cb1c-b088-47ad-87df-9efafa9e01e5.png)


**Testing Strategy**

- Already covered by tests
- Manual testing
- Unit testing
