### PR TITLE
set visible text on mobile mode, update fixtures to allow see long text behaviour.

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
@@ -46,6 +46,7 @@ const QCMImage = (props, context) => {
           />
           <div data-name="answerText" className={style.titleWrapper}>
             <div
+              title={title}
               className={classnames(style.title, innerHTML)}
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{__html: title}}

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
@@ -144,10 +144,17 @@
   }
 
   .titleWrapper {
+    height: 100%;
+    width: 100%;
+    display: flex;
     white-space: wrap;
     overflow: hidden;
     padding: 0;
     justify-content: left;
     font-size: 15px;
+  }
+
+  .title {
+    text-align: left;
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
@@ -64,6 +64,11 @@
   width: 100%;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
+  hyphens: auto;
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
 }
 
 .title {

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/fixtures/default.js
@@ -9,7 +9,8 @@ export default {
           'https://images.unsplash.com/photo-1467890947394-8171244e5410?dpr=2&auto=format&fit=crop&w=1080&h=720&q=80&cs=tinysrgb&crop=&bg='
       },
       {
-        title: 'Lorem ipsum',
+        title:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sut labore et dolore magna aliqua.',
         onClick: () => {},
         selected: false,
         image:

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/fixtures/no-selected.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/fixtures/no-selected.js
@@ -9,7 +9,7 @@ export default {
           'https://images.unsplash.com/photo-1467890947394-8171244e5410?dpr=2&auto=format&fit=crop&w=1080&h=720&q=80&cs=tinysrgb&crop=&bg='
       },
       {
-        title: 'Lorem ipsum',
+        title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua tempor incididunt ut labore et dolore  tempor incididunt ut labore et dolore magna aliqua tempor incididunt ut labore et dolore.',
         onClick: () => {},
         selected: false,
         image:

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/fixtures/no-selected.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/fixtures/no-selected.js
@@ -9,7 +9,8 @@ export default {
           'https://images.unsplash.com/photo-1467890947394-8171244e5410?dpr=2&auto=format&fit=crop&w=1080&h=720&q=80&cs=tinysrgb&crop=&bg='
       },
       {
-        title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua tempor incididunt ut labore et dolore  tempor incididunt ut labore et dolore magna aliqua tempor incididunt ut labore et dolore.',
+        title:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua tempor incididunt ut labore et dolore  tempor incididunt ut labore et dolore magna aliqua tempor incididunt ut labore et dolore.',
         onClick: () => {},
         selected: false,
         image:

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/qcm-graphic.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/qcm-graphic.js
@@ -26,7 +26,10 @@ test('onClick should be reachable, should match given aria-label', t => {
 
   const answersImages = wrapper.find('[data-name="answerImage"]');
   t.true(answersImages.at(1).exists());
-  t.is(answersImages.at(1).props()['aria-label'], 'Lorem ipsum');
+  t.is(
+    answersImages.at(1).props()['aria-label'],
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sut labore et dolore magna aliqua.'
+  );
 
   const answers = wrapper.find('[data-name="answerGraphic"]');
   answers.at(1).simulate('click');

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm/style.css
@@ -48,6 +48,10 @@
 .answerText {
   position: relative;
   color: cm_blue_900;
+  hyphens: auto;
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
 }
 
 .selectedAnswer .answerText {


### PR DESCRIPTION
https://trello.com/c/RWBCFOE2/2480-re-design-composant-question-qcm-illustr%C3%A9

**Detailed purpose of the PR**

This PR fixes a problem of missing text on mobile mode. But also shows that, as asked by @wernerdurand, i.e. existing behaviour of QCM Graphic answer cards when answer text is very long has not changed.
This PR also handles the case when the word is so long that it should be broken.

**Result and observation**

### Long texte answers

**Before**

![Kapture 2022-02-16 at 16 29 30](https://user-images.githubusercontent.com/7602475/154299404-2b8b8daa-26cd-481d-9ca4-364d1b479ea9.gif)

**Now**
![Kapture 2022-02-16 at 17 28 56](https://user-images.githubusercontent.com/7602475/154311123-3ab77e58-a645-4796-82df-1a7247fb1fbf.gif)

### Long words in answers

**Before**

Desktop
![Capture d’écran 2022-02-16 à 17 31 56](https://user-images.githubusercontent.com/7602475/154311620-9720d333-4260-4243-8b75-9d4b6af91684.png)

Mobile
![Capture d’écran 2022-02-16 à 17 32 18](https://user-images.githubusercontent.com/7602475/154311631-a483c658-636e-4103-8a76-19d9bd62e4cd.png)

**Now**

Desktop
![Capture d’écran 2022-02-16 à 17 28 10](https://user-images.githubusercontent.com/7602475/154311783-a7ec6d8c-0dd4-4c21-b825-323dc80116d4.png)

Mobile
![Capture d’écran 2022-02-16 à 17 27 56](https://user-images.githubusercontent.com/7602475/154311824-7eb441c2-82e5-4be6-aab6-09f52e143305.png)

**Testing Strategy**

- Already covered by tests
- Manual testing
