### PR TITLE
Micro fix - mozilla css specificity - fix full select (absolute) width

### DIFF
--- a/packages/@coorpacademy-components/src/atom/select/style.css
+++ b/packages/@coorpacademy-components/src/atom/select/style.css
@@ -496,7 +496,7 @@ div.player:hover span.selectSpan {
 
 /* mozilla specific styling */
 @supports (-moz-appearance:none) {
-  .player .selectWrapper select.selectBox {
+  .player label.selectWrapper select.selectBox {
     width: 100%;
   } 
 }


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- (still) Mozilla needs more class specificity if a vendor specific tag is used (even though it is only used as a support check) for letting select use the whole area for the drop-down (it doesn't reach 100% but a portion of the width)

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
