### PR TITLE
Remove warning

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/course-section/style.css
+++ b/packages/@coorpacademy-components/src/molecule/course-section/style.css
@@ -10,7 +10,7 @@
     border-radius: 7px;
     display: flex;
     font-size: 14px;
-    justify-content: start;
+    justify-content: flex-start;
     margin-top: 8px;
     padding: 8px 16px;
     border-radius: 7px;


### PR DESCRIPTION
```
(13:5) start value has mixed support, consider using flex-start instead
 @ ./src/molecule/course-section/style.css 2:26-167 43:4-64:5 46:18-159
```