### PR TITLE
Review correction popin

### DIFF
--- a/packages/@coorpacademy-components/src/atom/button-link/index.js
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.js
@@ -36,10 +36,13 @@ const ButtonLink = props => {
     'data-name': dataName,
     'aria-label': ariaLabel,
     link,
-    onClick
+    onClick,
+    className,
+    customStyle
   } = props;
   const contentView = getButtonContent(icon, label);
   const styleButton = classnames(
+    className,
     style.button,
     type === 'primary' && style.primary,
     type === 'secondary' && style.secondary,
@@ -56,6 +59,7 @@ const ButtonLink = props => {
     return (
       <Link
         {...link}
+        style={customStyle}
         className={styleButton}
         data-name={dataName}
         aria-label={ariaLabel || label}
@@ -72,6 +76,7 @@ const ButtonLink = props => {
       aria-label={ariaLabel || label}
       title={ariaLabel || label}
       data-name={dataName}
+      style={customStyle}
       className={styleButton}
       onClick={handleOnClick}
     >
@@ -95,7 +100,9 @@ ButtonLink.propTypes = {
     download: PropTypes.bool,
     target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top'])
   }),
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+  customStyle: PropTypes.shape({})
 };
 
 export default ButtonLink;

--- a/packages/@coorpacademy-components/src/atom/button-link/index.js
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.js
@@ -1,6 +1,6 @@
 import React, {useCallback} from 'react';
 import PropTypes from 'prop-types';
-import {getOr, keys} from 'lodash/fp';
+import {getOr, keys, noop} from 'lodash/fp';
 import classnames from 'classnames';
 import Link from '../link';
 import {ICONS} from '../../util/button-icons';
@@ -36,7 +36,7 @@ const ButtonLink = props => {
     'data-name': dataName,
     'aria-label': ariaLabel,
     link,
-    onClick,
+    onClick = noop,
     className,
     customStyle
   } = props;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -12,18 +12,22 @@ const ReviewCorrectionPopin = (props, context) => {
     <div className={style.wrapper}>
       <div className={classnames(style.popin, type === 'right' ? style.right : style.wrong)}>
         <div className={style.iconCircle} />
-        <div className={style.result}>{resultLabel}</div>
-        <div className={style.information}>
-          <span className={style.label}>{information.label}</span>
-          <span className={style.message}>{information.message}</span>
+        <div className={style.result} aria-label="result">
+          <span aria-label={resultLabel}>{resultLabel}</span>
+        </div>
+        <div className={style.information} aria-label="answer-information">
+          <span className={style.label} aria-label={information.label}>
+            {information.label}
+          </span>
+          <span className={style.message} aria-label={information.message}>
+            {information.message}
+          </span>
         </div>
         {cta}
       </div>
     </div>
   );
 };
-
-// TODO RESET ET RECOMMIT
 
 ReviewCorrectionPopin.propTypes = {
   type: PropTypes.oneOf(['right', 'wrong']),

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -1,15 +1,19 @@
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import getOr from 'lodash/fp/getOr';
 import {
   NovaCompositionCoorpacademyCheck as RightIcon,
   NovaSolidStatusClose as WrongIcon
 } from '@coorpacademy/nova-icons';
+import Provider from '../../atom/provider';
 import ButtonLink from '../../atom/button-link';
 import style from './style.css';
 
 const ReviewCorrectionPopin = (props, context) => {
   const {information, resultLabel, type, next} = props;
+  const {skin} = context;
+  const primaryColor = getOr('#00B0FF', 'common.primary', skin);
 
   const nextQuestionButtonProps = {
     ...next,
@@ -19,8 +23,8 @@ const ReviewCorrectionPopin = (props, context) => {
     ...next,
     type: 'secondary'
   };
-
-  const cta = type === 'wrong' ? (<div className={style.klf}>
+  
+  const cta = type === 'wrong' ? (<div className={style.klfContainer}>
     <ButtonLink {...klfButtonProps} />
   </div>) : null;
 
@@ -51,8 +55,8 @@ const ReviewCorrectionPopin = (props, context) => {
         </div>
         <div className={type === 'right' ? style.actions : style.actionsWrong}>
           {cta}
-          <div className={style.nextQuestion}>
-            <ButtonLink {...nextQuestionButtonProps} />
+          <div className={style.nextQuestionContainer}>
+            <ButtonLink {...nextQuestionButtonProps} className={style.nextQuestionButton}/>
           </div>
         </div>
       </div>
@@ -71,6 +75,10 @@ ReviewCorrectionPopin.propTypes = {
     label: PropTypes.string,
     onClick: PropTypes.func
   })
+};
+
+ReviewCorrectionPopin.contextTypes = {
+  skin: Provider.childContextTypes.skin
 };
 
 export default ReviewCorrectionPopin;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import {
+  NovaCompositionCoorpacademyCheck as RightIcon,
+  NovaSolidStatusClose as WrongIcon
+} from '@coorpacademy/nova-icons';
 import ButtonLink from '../../atom/button-link';
 import style from './style.css';
 
@@ -13,10 +17,18 @@ const ReviewCorrectionPopin = (props, context) => {
     type: 'primary'
   };
 
+  const ICONS = {
+    right: RightIcon,
+    wrong: WrongIcon
+  };
+  const Icon = ICONS[type];
+
   return (
     <div className={style.wrapper}>
       <div className={classnames(style.popin, type === 'right' ? style.right : style.wrong)}>
-        <div className={style.iconCircle} />
+        <div className={style.iconCircle}>
+          <Icon className={type === 'right' ? style.iconRight : style.iconWrong}/>
+        </div>
         <div className={style.result}>
           <div className={style.resultLabel} aria-label="result">
             <span aria-label={resultLabel}>{resultLabel}</span>

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -16,7 +16,7 @@ const buildKlfButton = klf => {
       type: 'key'
     },
     type: 'primary',
-    onClick: () => {} // TODO: on mobile it should show the tooltip
+    onClick: () => {}
   };
 
   return (
@@ -71,7 +71,7 @@ const ReviewCorrectionPopin = props => {
         <div className={type === 'right' ? style.actions : style.actionsWrong}>
           {cta}
           <div className={style.nextQuestionContainer}>
-            <ButtonLink {...nextQuestionButtonProps} className={style.nextQuestionButton}/>
+            <ButtonLink {...nextQuestionButtonProps} className={style.nextQuestionButton} />
           </div>
         </div>
       </div>

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -58,7 +58,7 @@ const ReviewCorrectionPopin = props => {
             <span aria-label={resultLabel}>{resultLabel}</span>
           </div>
         </div>
-        <div className={type === 'right' ? style.rightFeedbackSection : style.wrongFeedbackSection}>
+        <div className={style.feedbackSection}>
           <div className={style.information} aria-label="answer-information">
             <span className={style.label} aria-label={information.label}>
               {information.label}

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -11,11 +11,18 @@ import style from './style.css';
 const ReviewCorrectionPopin = (props, context) => {
   const {information, resultLabel, type, next} = props;
 
-  const cta = null;
-  const buttonProps = {
+  const nextQuestionButtonProps = {
     ...next,
     type: 'primary'
   };
+  const klfButtonProps = {
+    ...next,
+    type: 'secondary'
+  };
+
+  const cta = type === 'wrong' ? (<div className={style.klf}>
+    <ButtonLink {...klfButtonProps} />
+  </div>) : null;
 
   const ICONS = {
     right: RightIcon,
@@ -45,7 +52,7 @@ const ReviewCorrectionPopin = (props, context) => {
         <div className={style.actions}>
           {cta}
           <div className={style.nextQuestion}>
-            <ButtonLink {...buttonProps} />
+            <ButtonLink {...nextQuestionButtonProps} />
           </div>
         </div>
       </div>

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -36,7 +36,7 @@ const ReviewCorrectionPopin = (props, context) => {
         <div className={style.iconCircle}>
           <Icon className={type === 'right' ? style.iconRight : style.iconWrong}/>
         </div>
-        <div className={style.result}>
+        <div className={type === 'right' ? style.rightResult : style.wrongResult}>
           <div className={style.resultLabel} aria-label="result">
             <span aria-label={resultLabel}>{resultLabel}</span>
           </div>
@@ -49,7 +49,7 @@ const ReviewCorrectionPopin = (props, context) => {
             </span>
           </div>
         </div>
-        <div className={style.actions}>
+        <div className={type === 'right' ? style.actions : style.actionsWrong}>
           {cta}
           <div className={style.nextQuestion}>
             <ButtonLink {...nextQuestionButtonProps} />

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import style from './style.css';
+
+const ReviewCorrectionPopin = (props, context) => {
+  const {information, type} = props;
+  return (
+    <div className={style.wrapper}>
+      <div className={classnames(style.popin, type === 'right' ? style.right : style.wrong)}>
+        <span>{information.label}</span>
+        <span>{information.message}</span>
+      </div>
+    </div>
+  );
+};
+
+ReviewCorrectionPopin.propTypes = {
+  type: PropTypes.oneOf(['right', 'wrong']),
+  resultLabel: PropTypes.string,
+  information: PropTypes.shape({
+    label: PropTypes.string,
+    message: PropTypes.string
+  }),
+  next: PropTypes.shape({
+    label: PropTypes.string,
+    onClick: PropTypes.func
+  })
+};

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -8,13 +8,7 @@ import {
 import ButtonLink from '../../atom/button-link';
 import style from './style.css';
 
-const ReviewCorrectionPopin = props => {
-  const {information, resultLabel, type, klf, next} = props;
-
-  const nextQuestionButtonProps = {
-    ...next,
-    type: 'primary'
-  };
+const buildKlfButton = klf => {
   const klfButtonProps = {
     ...klf,
     icon: {
@@ -23,10 +17,28 @@ const ReviewCorrectionPopin = props => {
     },
     type: 'primary'
   };
-  
-  const cta = type === 'wrong' ? (<div className={style.klfContainer}>
-    <ButtonLink {...klfButtonProps} className={style.klfButton} />
-  </div>) : null;
+
+  return (
+    <div className={style.klfContainer}>
+      <div className={style.klfButtonContainer}>
+        <ButtonLink {...klfButtonProps} className={style.klfButton} />
+      </div>
+      <div className={style.toolTip}>
+        <div className={style.tooltipText}>{klf.tooltip}</div>
+      </div>
+    </div>
+  );
+};
+
+const ReviewCorrectionPopin = props => {
+  const {information, resultLabel, type, klf, next} = props;
+
+  const nextQuestionButtonProps = {
+    ...next,
+    type: 'primary'
+  };
+
+  const cta = type === 'wrong' ? buildKlfButton(klf) : null;
 
   const ICONS = {
     right: RightIcon,

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -1,29 +1,41 @@
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import ButtonLink from '../../atom/button-link';
 import style from './style.css';
 
 const ReviewCorrectionPopin = (props, context) => {
-  const {information, resultLabel, type} = props;
+  const {information, resultLabel, type, next} = props;
 
   const cta = null;
+  const buttonProps = {
+    ...next,
+    type: 'primary'
+  };
 
   return (
     <div className={style.wrapper}>
       <div className={classnames(style.popin, type === 'right' ? style.right : style.wrong)}>
         <div className={style.iconCircle} />
-        <div className={style.result} aria-label="result">
-          <span aria-label={resultLabel}>{resultLabel}</span>
+        <div className={style.result}>
+          <div className={style.resultLabel} aria-label="result">
+            <span aria-label={resultLabel}>{resultLabel}</span>
+          </div>
+          <div className={style.information} aria-label="answer-information">
+            <span className={style.label} aria-label={information.label}>
+              {information.label}
+            </span>
+            <span className={style.message} aria-label={information.message}>
+              {information.message}
+            </span>
+          </div>
         </div>
-        <div className={style.information} aria-label="answer-information">
-          <span className={style.label} aria-label={information.label}>
-            {information.label}
-          </span>
-          <span className={style.message} aria-label={information.message}>
-            {information.message}
-          </span>
+        <div className={style.actions}>
+          {cta}
+          <div className={style.nextQuestion}>
+            <ButtonLink {...buttonProps} />
+          </div>
         </div>
-        {cta}
       </div>
     </div>
   );

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -58,7 +58,7 @@ const ReviewCorrectionPopin = props => {
             <span aria-label={resultLabel}>{resultLabel}</span>
           </div>
         </div>
-        <div className={type === 'right' ? style.rightMiddleSection : style.wrongMiddleSection}>
+        <div className={type === 'right' ? style.rightFeedbackSection : style.wrongFeedbackSection}>
           <div className={style.information} aria-label="answer-information">
             <span className={style.label} aria-label={information.label}>
               {information.label}

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -15,7 +15,8 @@ const buildKlfButton = klf => {
       position: 'left',
       type: 'key'
     },
-    type: 'primary'
+    type: 'primary',
+    onClick: () => {} // TODO: on mobile it should show the tooltip
   };
 
   return (
@@ -49,13 +50,15 @@ const ReviewCorrectionPopin = props => {
   return (
     <div className={style.wrapper}>
       <div className={classnames(style.popin, type === 'right' ? style.right : style.wrong)}>
-        <div className={style.iconCircle}>
-          <Icon className={type === 'right' ? style.iconRight : style.iconWrong}/>
-        </div>
-        <div className={type === 'right' ? style.rightResult : style.wrongResult}>
+        <div className={style.correctionSection}>
+          <div className={style.iconCircle}>
+            <Icon className={type === 'right' ? style.iconRight : style.iconWrong}/>
+          </div>
           <div className={style.resultLabel} aria-label="result">
             <span aria-label={resultLabel}>{resultLabel}</span>
           </div>
+        </div>
+        <div className={type === 'right' ? style.rightMiddleSection : style.wrongMiddleSection}>
           <div className={style.information} aria-label="answer-information">
             <span className={style.label} aria-label={information.label}>
               {information.label}

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -52,7 +52,7 @@ const ReviewCorrectionPopin = props => {
       <div className={classnames(style.popin, type === 'right' ? style.right : style.wrong)}>
         <div className={style.correctionSection}>
           <div className={style.iconCircle}>
-            <Icon className={type === 'right' ? style.iconRight : style.iconWrong}/>
+            <Icon className={type === 'right' ? style.iconRight : style.iconWrong} />
           </div>
           <div className={style.resultLabel} aria-label="result">
             <span aria-label={resultLabel}>{resultLabel}</span>

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -27,3 +27,5 @@ ReviewCorrectionPopin.propTypes = {
     onClick: PropTypes.func
   })
 };
+
+export default ReviewCorrectionPopin;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -15,8 +15,7 @@ const buildKlfButton = klf => {
       position: 'left',
       type: 'key'
     },
-    type: 'primary',
-    onClick: () => {}
+    type: 'primary'
   };
 
   return (

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -4,16 +4,26 @@ import PropTypes from 'prop-types';
 import style from './style.css';
 
 const ReviewCorrectionPopin = (props, context) => {
-  const {information, type} = props;
+  const {information, resultLabel, type} = props;
+
+  const cta = null;
+
   return (
     <div className={style.wrapper}>
       <div className={classnames(style.popin, type === 'right' ? style.right : style.wrong)}>
-        <span>{information.label}</span>
-        <span>{information.message}</span>
+        <div className={style.iconCircle} />
+        <div className={style.result}>{resultLabel}</div>
+        <div className={style.information}>
+          <span className={style.label}>{information.label}</span>
+          <span className={style.message}>{information.message}</span>
+        </div>
+        {cta}
       </div>
     </div>
   );
 };
+
+// TODO RESET ET RECOMMIT
 
 ReviewCorrectionPopin.propTypes = {
   type: PropTypes.oneOf(['right', 'wrong']),

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -1,31 +1,31 @@
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import getOr from 'lodash/fp/getOr';
 import {
   NovaCompositionCoorpacademyCheck as RightIcon,
   NovaSolidStatusClose as WrongIcon
 } from '@coorpacademy/nova-icons';
-import Provider from '../../atom/provider';
 import ButtonLink from '../../atom/button-link';
 import style from './style.css';
 
-const ReviewCorrectionPopin = (props, context) => {
-  const {information, resultLabel, type, next} = props;
-  const {skin} = context;
-  const primaryColor = getOr('#00B0FF', 'common.primary', skin);
+const ReviewCorrectionPopin = props => {
+  const {information, resultLabel, type, klf, next} = props;
 
   const nextQuestionButtonProps = {
     ...next,
     type: 'primary'
   };
   const klfButtonProps = {
-    ...next,
-    type: 'secondary'
+    ...klf,
+    icon: {
+      position: 'left',
+      type: 'key'
+    },
+    type: 'primary'
   };
   
   const cta = type === 'wrong' ? (<div className={style.klfContainer}>
-    <ButtonLink {...klfButtonProps} />
+    <ButtonLink {...klfButtonProps} className={style.klfButton} />
   </div>) : null;
 
   const ICONS = {
@@ -74,11 +74,11 @@ ReviewCorrectionPopin.propTypes = {
   next: PropTypes.shape({
     label: PropTypes.string,
     onClick: PropTypes.func
+  }),
+  klf: PropTypes.shape({
+    label: PropTypes.string,
+    onClick: PropTypes.func
   })
-};
-
-ReviewCorrectionPopin.contextTypes = {
-  skin: Provider.childContextTypes.skin
 };
 
 export default ReviewCorrectionPopin;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -251,6 +251,10 @@
     flex-direction: column;
   }
 
+  .popin > div {
+    min-width: auto;
+  }
+
   .correctionSection {
     width: 77%;
     justify-content: center;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -32,6 +32,14 @@
   box-shadow: 0px 0px 68px rgba(239, 72, 74, 0.4);
 }
 
+.result {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: left;
+  width: 64%;
+}
+
 .iconCircle {
   width: 60px;
   height: 60px;
@@ -40,7 +48,7 @@
   border-radius: 60px;
 }
 
-.result {
+.resultLabel {
   margin-left: 12px;
   width: 114px;
   font-weight: 900;
@@ -72,4 +80,15 @@
 .information .message {
   display: block;
   margin-top: 4px;
+}
+
+.actions {
+  width: 30%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.nextQuestion {
+  width: 138px;
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -48,6 +48,22 @@
   border-radius: 60px;
 }
 
+.icon {
+  width: 32px;
+  height: 32px;
+  margin: 14px;
+}
+
+.iconRight {
+  composes: icon;
+  color: cm_positive_100;
+}
+
+.iconWrong {
+  composes: icon;
+  color: cm_negative_100;
+}
+
 .resultLabel {
   margin-left: 12px;
   width: 114px;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -65,16 +65,19 @@
 
 .iconCircle {
   width: 52px;
+  min-width: 52px;
   height: 52px;
+  min-height: 52px;
   background: white;
   opacity: 0.7;
   border-radius: 50%;
+  box-sizing: border-box;
 }
 
 .icon {
   width: 24px;
   height: 24px;
-  margin: 14px;
+  padding: 14px 0 0 14px;
 }
 
 .iconRight {

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -47,7 +47,7 @@
 
 .result {
   display: flex;
-  margin-left: 23px;
+  margin: 0 23px;
   flex-direction: row;
   align-items: center;
   justify-content: left;
@@ -89,10 +89,12 @@
 
 .resultLabel {
   margin-left: 12px;
-  width: 114px;
   font-weight: 900;
   font-size: 24px;
   line-height: 24px;
+  hyphens: auto;
+  -ms-word-break: break-all;
+  word-break: break-all;
 }
 
 .information {
@@ -140,7 +142,7 @@
   width: 273px;
   border-radius: 15px;
   background-color: white;
-  right: 220px;
+  right: 17.5%;
   top: -64px;
 }
 
@@ -173,6 +175,8 @@
 
 .klfContainer {
   overflow: visible;
+  width: calc(55% - 16px);
+  margin-right: 16px;
 }
 
 .klfButtonContainer:hover ~ .toolTip {
@@ -186,7 +190,7 @@
 }
 
 .klfButtonContainer {
-  width: 191px;
+  width: 100%;
   margin-right: 16px;
 }
 
@@ -200,7 +204,11 @@
 }
 
 .nextQuestionContainer {
-  width: 138px;
+  width: 100%;
+}
+
+.actionsWrong .nextQuestionContainer {
+  width: 45%;
 }
 
 .nextQuestionButton {
@@ -222,19 +230,27 @@
   }  
 
   .rightMiddleSection {
-    width: 100%;
+    width: 73%;
   }
 
   .wrongMiddleSection {
     width: 100%;
+  }
+
+  .actions {
+    width: 20%;
   }
 }
 
 @media mobile {
   .popin {
     width: 100%;
-    height: 100%;
+    height: auto;
     padding: 32px;
     flex-direction: column;
+  }
+
+  .resultLabel {
+    display: block;
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -37,6 +37,15 @@
   flex-direction: row;
   align-items: center;
   justify-content: left;
+}
+
+.rightResult {
+  composes: result;
+  width: 77%;
+}
+
+.wrongResult {
+  composes: result;
   width: 64%;
 }
 
@@ -99,10 +108,15 @@
 }
 
 .actions {
-  width: 30%;
+  width: 20%;
   display: flex;
   align-items: center;
   justify-content: flex-end;
+}
+
+.actionsWrong {
+  composes: actions;
+  width: 34%;
 }
 
 .klf {

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -126,7 +126,12 @@
 }
 
 .klfButton {
-  
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.klfButton:hover {
+  background: linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)), rgba(255, 255, 255, 0.1)
 }
 
 .nextQuestionContainer {
@@ -134,6 +139,10 @@
 }
 
 .nextQuestionButton {
-  background-color: white;
+  background: white;
   color: cm_primary_blue;
+}
+
+.nextQuestionButton:hover {
+  background: linear-gradient(0deg, rgba(0, 0, 0, 0.07), rgba(0, 0, 0, 0.07)), #FFFFFF;
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -55,16 +55,6 @@
   flex: 1 1 100%;
 }
 
-.rightFeedbackSection {
-  composes: feedbackSection;
-  flex: 1 1 100%;
-}
-
-.wrongFeedbackSection {
-  composes: feedbackSection;
-  flex: 1 1 100%;
-}
-
 .iconCircle {
   width: 52px;
   min-width: 52px;
@@ -239,14 +229,6 @@
     min-width: 60px;
   }  
 
-  .rightFeedbackSection {
-    width: 73%;
-  }
-
-  .wrongFeedbackSection {
-    width: 46%;
-  }
-
   .actions {
     width: 25%;
   }
@@ -269,22 +251,18 @@
     flex-direction: column;
   }
 
-  .resultLabel {
-    display: block;
-  }
-
   .correctionSection {
     width: 77%;
     justify-content: center;
     margin-bottom: 32px;
   }
 
-  .rightFeedbackSection {
-    width: 100%;
+  .resultLabel {
+    display: block;
   }
 
-  .wrongFeedbackSection {
-    width: 100%;
+  .feedbackSection {
+    margin: 0;
   }
 
   .information .message {

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -257,14 +257,13 @@
   }
 
   .correctionSection {
-    /*width: 77%; sans cette partie on a l'icon qui n'est pas centré */
     justify-content: center;
     margin-bottom: 32px;
   }
 
   .resultLabel {
     display: block;
-    text-align: center;
+    text-align: left;
     width: calc(100% - 52px);
   }
 

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -3,6 +3,7 @@
 @value cm_positive_100 from colors;
 @value cm_negative_100 from colors;
 @value cm_primary_blue from colors;
+@value cm_blue_900 from colors;
 
 .wrapper {
   width: 100%;
@@ -120,7 +121,60 @@
   width: 34%;
 }
 
+.toolTip {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.8s;
+  position: absolute;
+  width: 273px;
+  border-radius: 15px;
+  background-color: white;
+  right: calc(16%);
+  top: -64px;
+}
+
+.toolTip::before {
+  content: '';
+  display: inline-block;
+  visibility: hidden;
+  opacity: 0;
+  width: 15px;
+  height: 15px;
+  transform: rotate(-45deg);
+  transition: opacity 0.8s;
+  background-color: white;
+  position: inherit;
+  bottom: -7px;
+  left: 129px;
+}
+
+.tooltipText {
+  display: inline-block;
+  margin: 16px;
+  border-radius: 3px;
+  word-wrap: break-word;
+  color: cm_blue_900;
+  max-width: 241px;
+  overflow: hidden;
+  text-align: center;
+  font-size: 16px;
+}
+
 .klfContainer {
+  overflow: visible;
+}
+
+.klfButtonContainer:hover ~ .toolTip {
+  visibility: visible;
+  opacity: 1;
+}
+
+.klfButtonContainer:hover ~ .toolTip::before {
+  visibility: visible;
+  opacity: 1;
+}
+
+.klfButtonContainer {
   width: 191px;
   margin-right: 16px;
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -5,18 +5,29 @@
 
 .wrapper {
   width: 100%;
+  height: 134px;
   font-family: Gilroy;
+  color: white;
+  display: flex;
+  justify-content: center;
+  overflow: visible;
 }
 
 .popin {
-  width: calc(100% - 80 px);
+  width: calc(100% - 80px);
+  padding: 40px;
+  border-radius: 16px;
   display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .right {
   background-color: cm_positive_100;
+  box-shadow: 0px 0px 68px rgba(53, 204, 127, 0.4);
 }
 
 .wrong {
   background-color: cm_negative_100;
+  box-shadow: 0px 0px 68px rgba(239, 72, 74, 0.4);
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -97,7 +97,7 @@
   line-height: 24px;
   hyphens: auto;
   -ms-word-break: break-word;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .information {
@@ -118,6 +118,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  hyphens: auto;
+  -ms-word-break: break-word;
 }
 
 .information .message {

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -1,0 +1,22 @@
+@value colors: "../../variables/colors.css";
+@value white from colors;
+@value cm_positive_100 from colors;
+@value cm_negative_100 from colors;
+
+.wrapper {
+  width: 100%;
+  font-family: Gilroy;
+}
+
+.popin {
+  width: calc(100% - 80 px);
+  display: flex;
+}
+
+.right {
+  background-color: cm_positive_100;
+}
+
+.wrong {
+  background-color: cm_negative_100;
+}

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -68,7 +68,7 @@
   height: 52px;
   background: white;
   opacity: 0.7;
-  border-radius: 50px;
+  border-radius: 50%;
 }
 
 .icon {
@@ -93,7 +93,7 @@
   font-size: 24px;
   line-height: 24px;
   hyphens: auto;
-  -ms-word-break: break-all;
+  -ms-word-break: break-word;
   word-break: break-all;
 }
 
@@ -234,11 +234,20 @@
   }
 
   .wrongMiddleSection {
-    width: 100%;
+    width: 46%;
   }
 
   .actions {
-    width: 20%;
+    width: 25%;
+  }
+
+  .actionsWrong {
+    width: 47%;
+  }
+
+  .toolTip {
+    width: 250px;
+    right: 25%;
   }
 }
 

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -2,6 +2,7 @@
 @value white from colors;
 @value cm_positive_100 from colors;
 @value cm_negative_100 from colors;
+@value cm_primary_blue from colors;
 
 .wrapper {
   width: 100%;
@@ -119,11 +120,20 @@
   width: 34%;
 }
 
-.klf {
+.klfContainer {
   width: 191px;
   margin-right: 16px;
 }
 
-.nextQuestion {
+.klfButton {
+  
+}
+
+.nextQuestionContainer {
   width: 138px;
+}
+
+.nextQuestionButton {
+  background-color: white;
+  color: cm_primary_blue;
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -253,8 +253,7 @@
 
   .popin > div {
     min-width: auto;
-    width: 100%; 
-    border: 1px solid white;
+    width: 100%;
   }
 
   .correctionSection {
@@ -297,6 +296,7 @@
   .klfContainer {
     width: 100%;
     margin: 0 0 8px 0;
+    position: relative;
   }
 
   .klfButtonContainer {
@@ -304,7 +304,13 @@
   }
 
   .toolTip {
-    width: 250px;
-    right: 5%;
+    width: 106%;
+    right: -3%;
+    top: auto;
+    bottom: 52px;
+  }
+
+  .tooltipText {
+    max-width: none;
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -1,4 +1,6 @@
 @value colors: "../../variables/colors.css";
+@value breakpoints: "../../variables/breakpoints.css";
+@value mobile from breakpoints;
 @value white from colors;
 @value cm_positive_100 from colors;
 @value cm_negative_100 from colors;
@@ -34,6 +36,13 @@
   box-shadow: 0px 0px 68px rgba(239, 72, 74, 0.4);
 }
 
+.correctionSection {
+  width: 187px;
+  display: flex;
+  align-content: center;
+  align-items: center;
+}
+
 .result {
   display: flex;
   flex-direction: row;
@@ -41,14 +50,14 @@
   justify-content: left;
 }
 
-.rightResult {
+.rightMiddleSection {
   composes: result;
-  width: 77%;
+  width: calc(100% - 325px);
 }
 
-.wrongResult {
+.wrongMiddleSection {
   composes: result;
-  width: 64%;
+  width: calc(100% - 555px);
 }
 
 .iconCircle {
@@ -110,7 +119,7 @@
 }
 
 .actions {
-  width: 20%;
+  width: 138px;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -118,7 +127,7 @@
 
 .actionsWrong {
   composes: actions;
-  width: 34%;
+  width: 345px;
 }
 
 .toolTip {
@@ -199,4 +208,13 @@
 
 .nextQuestionButton:hover {
   background: linear-gradient(0deg, rgba(0, 0, 0, 0.07), rgba(0, 0, 0, 0.07)), #FFFFFF;
+}
+
+@media mobile {
+  .popin {
+    width: 100%;
+    height: 100%;
+    padding: 32px;
+    flex-direction: column;
+  }
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -31,3 +31,39 @@
   background-color: cm_negative_100;
   box-shadow: 0px 0px 68px rgba(239, 72, 74, 0.4);
 }
+
+.iconCircle {
+  width: 60px;
+  height: 60px;
+  background: white;
+  border-radius: 60px;
+}
+
+.information {
+  display: flex;
+  flex-direction: column;
+}
+
+.information .label {
+  width: 140px;
+  height: 25px;
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 56px;
+  font-style: normal;
+  font-weight: 900;
+  font-size: 14px;
+  line-height: 17px;
+  display: block;
+}
+
+.information .message {
+  display: block;
+}
+
+.result {
+  width: 114px;
+  font-weight: 900;
+  font-size: 24px;
+  line-height: 24px;
+}

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -30,12 +30,12 @@
 
 .right {
   background-color: cm_positive_100;
-  box-shadow: 0px 0px 68px rgba(53, 204, 127, 0.4);
+  box-shadow: 0px 0px 68px rgba(cm_positive_100, 0.4);
 }
 
 .wrong {
   background-color: cm_negative_100;
-  box-shadow: 0px 0px 68px rgba(239, 72, 74, 0.4);
+  box-shadow: 0px 0px 68px rgba(cm_negative_100, 0.4);
 }
 
 .correctionSection {

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -105,6 +105,11 @@
   justify-content: flex-end;
 }
 
+.klf {
+  width: 191px;
+  margin-right: 16px;
+}
+
 .nextQuestion {
   width: 138px;
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -246,27 +246,34 @@
 @media mobile {
   .popin {
     width: 100%;
-    height: auto;
+    min-height: 100px;
     padding: 32px;
     flex-direction: column;
   }
 
   .popin > div {
     min-width: auto;
+    width: 100%; 
+    border: 1px solid white;
   }
 
   .correctionSection {
-    width: 77%;
+    /*width: 77%; sans cette partie on a l'icon qui n'est pas centré */
     justify-content: center;
     margin-bottom: 32px;
   }
 
   .resultLabel {
     display: block;
+    text-align: center;
+    width: calc(100% - 52px);
   }
 
   .feedbackSection {
     margin: 0;
+    width: 100%;
+    min-height: 100px;
+    display: block;
   }
 
   .information .message {

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -1,5 +1,6 @@
 @value colors: "../../variables/colors.css";
 @value breakpoints: "../../variables/breakpoints.css";
+@value tablet from breakpoints;
 @value mobile from breakpoints;
 @value white from colors;
 @value cm_positive_100 from colors;
@@ -38,7 +39,7 @@
 }
 
 .correctionSection {
-  width: 187px;
+  width: 17%;
   display: flex;
   align-content: center;
   align-items: center;
@@ -46,6 +47,7 @@
 
 .result {
   display: flex;
+  margin-left: 23px;
   flex-direction: row;
   align-items: center;
   justify-content: left;
@@ -53,12 +55,12 @@
 
 .rightMiddleSection {
   composes: result;
-  width: calc(100% - 325px);
+  width: 70%;
 }
 
 .wrongMiddleSection {
   composes: result;
-  width: calc(100% - 555px);
+  width: 51%;
 }
 
 .iconCircle {
@@ -96,7 +98,6 @@
 .information {
   display: flex;
   flex-direction: column;
-  margin-left: 23px;
 }
 
 .information .label {
@@ -120,7 +121,7 @@
 }
 
 .actions {
-  width: 138px;
+  width: 13%;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -128,7 +129,7 @@
 
 .actionsWrong {
   composes: actions;
-  width: 345px;
+  width: 32%;
 }
 
 .toolTip {
@@ -209,6 +210,24 @@
 
 .nextQuestionButton:hover {
   background: linear-gradient(0deg, rgba(0, 0, 0, 0.07), rgba(0, 0, 0, 0.07)), #FFFFFF;
+}
+
+@media tablet {
+  .resultLabel {
+    display: none;
+  }
+
+  .correctionSection {
+    width: auto;
+  }  
+
+  .rightMiddleSection {
+    width: 100%;
+  }
+
+  .wrongMiddleSection {
+    width: 100%;
+  }
 }
 
 @media mobile {

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -249,6 +249,7 @@
     min-height: 100px;
     padding: 32px;
     flex-direction: column;
+    display: block;
   }
 
   .popin > div {
@@ -270,7 +271,6 @@
   .feedbackSection {
     margin: 0;
     width: 100%;
-    min-height: 100px;
     display: block;
   }
 

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -46,7 +46,7 @@
   align-items: center;
 }
 
-.result {
+.feedbackSection {
   display: flex;
   margin: 0 23px;
   flex-direction: row;
@@ -55,13 +55,13 @@
   flex: 1 1 100%;
 }
 
-.rightMiddleSection {
-  composes: result;
+.rightFeedbackSection {
+  composes: feedbackSection;
   flex: 1 1 100%;
 }
 
-.wrongMiddleSection {
-  composes: result;
+.wrongFeedbackSection {
+  composes: feedbackSection;
   flex: 1 1 100%;
 }
 
@@ -103,7 +103,7 @@
 }
 
 .information {
-  display: flex;
+  display: block;
   flex-direction: column;
 }
 
@@ -239,11 +239,11 @@
     min-width: 60px;
   }  
 
-  .rightMiddleSection {
+  .rightFeedbackSection {
     width: 73%;
   }
 
-  .wrongMiddleSection {
+  .wrongFeedbackSection {
     width: 46%;
   }
 
@@ -274,15 +274,21 @@
   }
 
   .correctionSection {
+    width: 77%;
+    justify-content: center;
+    margin-bottom: 32px;
+  }
+
+  .rightFeedbackSection {
     width: 100%;
   }
 
-  .rightMiddleSection {
+  .wrongFeedbackSection {
     width: 100%;
   }
 
-  .wrongMiddleSection {
-    width: 100%;
+  .information .message {
+    margin: 8px 0 32px 0;
   }
 
   .actions {
@@ -291,5 +297,25 @@
 
   .actionsWrong {
     width: 100%;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .actionsWrong .nextQuestionContainer {
+    width: 100%;
+  }
+
+  .klfContainer {
+    width: 100%;
+    margin: 0 0 8px 0;
+  }
+
+  .klfButtonContainer {
+    margin: 0;
+  }
+
+  .toolTip {
+    width: 250px;
+    right: 5%;
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -36,12 +36,22 @@
   width: 60px;
   height: 60px;
   background: white;
+  opacity: 0.7;
   border-radius: 60px;
+}
+
+.result {
+  margin-left: 12px;
+  width: 114px;
+  font-weight: 900;
+  font-size: 24px;
+  line-height: 24px;
 }
 
 .information {
   display: flex;
   flex-direction: column;
+  margin-left: 23px;
 }
 
 .information .label {
@@ -54,16 +64,12 @@
   font-weight: 900;
   font-size: 14px;
   line-height: 17px;
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .information .message {
   display: block;
-}
-
-.result {
-  width: 114px;
-  font-weight: 900;
-  font-size: 24px;
-  line-height: 24px;
+  margin-top: 4px;
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -39,7 +39,8 @@
 }
 
 .correctionSection {
-  width: 17%;
+  flex: 0 1 auto;
+  min-width: 187px;
   display: flex;
   align-content: center;
   align-items: center;
@@ -51,16 +52,17 @@
   flex-direction: row;
   align-items: center;
   justify-content: left;
+  flex: 1 1 100%;
 }
 
 .rightMiddleSection {
   composes: result;
-  width: 70%;
+  flex: 1 1 100%;
 }
 
 .wrongMiddleSection {
   composes: result;
-  width: 51%;
+  flex: 1 1 100%;
 }
 
 .iconCircle {
@@ -120,6 +122,7 @@
   justify-content: center;
   hyphens: auto;
   -ms-word-break: break-word;
+  word-break: break-word;
 }
 
 .information .message {
@@ -128,7 +131,8 @@
 }
 
 .actions {
-  width: 13%;
+  flex: 0 1 auto;
+  min-width: 138px;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -136,7 +140,8 @@
 
 .actionsWrong {
   composes: actions;
-  width: 32%;
+  min-width: 345px;
+  flex: 0 1 auto;
 }
 
 .toolTip {
@@ -231,7 +236,7 @@
   }
 
   .correctionSection {
-    width: auto;
+    min-width: 60px;
   }  
 
   .rightMiddleSection {
@@ -266,5 +271,25 @@
 
   .resultLabel {
     display: block;
+  }
+
+  .correctionSection {
+    width: 100%;
+  }
+
+  .rightMiddleSection {
+    width: 100%;
+  }
+
+  .wrongMiddleSection {
+    width: 100%;
+  }
+
+  .actions {
+    width: 100%;
+  }
+
+  .actionsWrong {
+    width: 100%;
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -9,16 +9,17 @@
 
 .wrapper {
   width: 100%;
-  height: 134px;
+  height: auto;
   font-family: Gilroy;
   color: white;
   display: flex;
   justify-content: center;
   overflow: visible;
+  padding: 0px;
 }
 
 .popin {
-  width: calc(100% - 80px);
+  width: 100%;
   padding: 40px;
   border-radius: 16px;
   display: flex;
@@ -61,16 +62,16 @@
 }
 
 .iconCircle {
-  width: 60px;
-  height: 60px;
+  width: 52px;
+  height: 52px;
   background: white;
   opacity: 0.7;
-  border-radius: 60px;
+  border-radius: 50px;
 }
 
 .icon {
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   margin: 14px;
 }
 
@@ -138,7 +139,7 @@
   width: 273px;
   border-radius: 15px;
   background-color: white;
-  right: calc(16%);
+  right: 220px;
   top: -64px;
 }
 

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/right.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/right.js
@@ -9,6 +9,8 @@ export default {
     },
     next: {
       label: 'Next Question',
+      'aria-label': 'next question button',
+      'data-name': 'next-question-button',
       onClick: () => console.log('Next Question')
     }
   }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/right.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/right.js
@@ -1,0 +1,15 @@
+export default {
+  props: {
+    type: 'right',
+    resultLabel: 'CORRECT ANSWER',
+    information: {
+      label: 'Key learning factor',
+      message:
+        '17 frustrated software engineers grappling with the complexities of software development.'
+    },
+    next: {
+      label: 'Next Question',
+      onClick: () => console.log('Next Question')
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/wrong.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/wrong.js
@@ -6,8 +6,8 @@ export default {
       label: 'Correct Answer',
       message: 'Corporate lawyers trying to understand software.'
     },
-    cta: {
-      label: 'Kery learning favor',
+    klf: {
+      label: 'Key learning factor',
       tooltip:
         '17 frustrated software engineers grappling with the complexities of software development.'
     },

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/wrong.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/wrong.js
@@ -1,0 +1,19 @@
+export default {
+  props: {
+    type: 'wrong',
+    resultLabel: 'WRONG ANSWER',
+    information: {
+      label: 'Correct Answer',
+      message: 'Corporate lawyers trying to understand software.'
+    },
+    cta: {
+      label: 'Kery learning favor',
+      tooltip:
+        '17 frustrated software engineers grappling with the complexities of software development.'
+    },
+    next: {
+      label: 'Next Question',
+      onClick: () => console.log('Next Question')
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/util/button-icons.js
+++ b/packages/@coorpacademy-components/src/util/button-icons.js
@@ -11,7 +11,8 @@ import {
   NovaSolidContentContentViewModule1 as ListIcon,
   NovaSolidLoginLogout1 as LogoutIcon,
   NovaSolidApplicationsWindowUpload3 as PublishIcon,
-  NovaSolidComputersSdCard as SaveIcon
+  NovaSolidComputersSdCard as SaveIcon,
+  NovaLineLoginKey1 as KlfIcon
 } from '@coorpacademy/nova-icons';
 
 export const ICONS = {
@@ -23,6 +24,7 @@ export const ICONS = {
   'chevron-right': ChevronRightIcon,
   close: CloseIcon,
   edit: EditIcon,
+  key: KlfIcon,
   list: ListIcon,
   logout: LogoutIcon,
   publish: PublishIcon,

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -118,6 +118,7 @@ import MoleculeQuestionsTemplate from './../src/molecule/questions/template';
 import MoleculeQuickAccessCard from './../src/molecule/quick-access-card';
 import MoleculeQuickAccessCardsGroup from './../src/molecule/quick-access-cards-group';
 import MoleculeResourcePlayer from './../src/molecule/resource-player';
+import MoleculeReviewCorrectionPopin from './../src/molecule/review-correction-popin';
 import MoleculeScopeContent from './../src/molecule/scope-content';
 import MoleculeScopeTabs from './../src/molecule/scope-tabs';
 import MoleculeSearchForm from './../src/molecule/search-form';
@@ -680,6 +681,8 @@ import MoleculeResourcePlayerFixturePdfWithOverlay from '../src/molecule/resourc
 import MoleculeResourcePlayerFixturePdf from '../src/molecule/resource-player/test/fixtures/pdf';
 import MoleculeResourcePlayerFixtureVimeoWithOverlay from '../src/molecule/resource-player/test/fixtures/vimeo-with-overlay';
 import MoleculeResourcePlayerFixtureVimeo from '../src/molecule/resource-player/test/fixtures/vimeo';
+import MoleculeReviewCorrectionPopinFixtureRight from '../src/molecule/review-correction-popin/test/fixtures/right';
+import MoleculeReviewCorrectionPopinFixtureWrong from '../src/molecule/review-correction-popin/test/fixtures/wrong';
 import MoleculeScopeContentFixtureArabic from '../src/molecule/scope-content/test/fixtures/arabic';
 import MoleculeScopeContentFixtureAudio from '../src/molecule/scope-content/test/fixtures/audio';
 import MoleculeScopeContentFixtureDefault from '../src/molecule/scope-content/test/fixtures/default';
@@ -1231,6 +1234,7 @@ export const components = {
     MoleculeQuickAccessCard,
     MoleculeQuickAccessCardsGroup,
     MoleculeResourcePlayer,
+    MoleculeReviewCorrectionPopin,
     MoleculeScopeContent,
     MoleculeScopeTabs,
     MoleculeSearchForm,
@@ -2006,6 +2010,10 @@ export const fixtures = {
       Pdf: MoleculeResourcePlayerFixturePdf,
       VimeoWithOverlay: MoleculeResourcePlayerFixtureVimeoWithOverlay,
       Vimeo: MoleculeResourcePlayerFixtureVimeo
+    },
+    MoleculeReviewCorrectionPopin: {
+      Right: MoleculeReviewCorrectionPopinFixtureRight,
+      Wrong: MoleculeReviewCorrectionPopinFixtureWrong
     },
     MoleculeScopeContent: {
       Arabic: MoleculeScopeContentFixtureArabic,


### PR DESCRIPTION
https://trello.com/c/6QnVgT2S/2496-or-composant-popin-r%C3%A9vision

**Detailed purpose of the PR**

This PR introduces the new component popin for review mode. It handles the right and wrong answer feedback in web, tablet and mobile format and IE11 compatibility.

There are some modifications related to the original designs on Figma. (see comments on Trello card, approved by @audric-coorp)

- On tablet mode, the "WRONG ANSWER" or "CORRECT ANSWER" disappears. 
- On mobile mode, the "WRONG ANSWER" or "CORRECT ANSWER" should be aligne to the left. 

**Result and observation**

### Right
![Kapture 2022-03-02 at 14 52 34](https://user-images.githubusercontent.com/7602475/156375136-8ea38c0d-0d9b-4368-8bd8-31496d612fbb.gif)

### Wrong
![Kapture 2022-03-02 at 14 50 50](https://user-images.githubusercontent.com/7602475/156374437-f5efc1a9-894a-48b9-85fb-a7a2f5ea6e3f.gif)

### IE 11
![Kapture 2022-03-02 at 15 31 06](https://user-images.githubusercontent.com/7602475/156381744-a4548ed3-03c2-4b19-a808-93738695076f.gif)

**Testing Strategy**

- Manual testing
