### PR TITLE
Review popin fixes

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -59,9 +59,11 @@ const ReviewCorrectionPopin = props => {
         </div>
         <div className={style.feedbackSection}>
           <div className={style.information} aria-label="answer-information">
-            <span className={style.label} aria-label={information.label}>
-              {information.label}
-            </span>
+            <div className={style.labelContainer}>
+              <span className={style.label} aria-label={information.label}>
+                {information.label}
+              </span>
+            </div>
             <span className={style.message} aria-label={information.message}>
               {information.message}
             </span>

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -48,7 +48,7 @@
 
 .feedbackSection {
   display: flex;
-  margin: 0 48px;
+  margin: 0 48px 0 23px;
   flex-direction: row;
   align-items: center;
   justify-content: left;
@@ -100,7 +100,7 @@
 
 .labelContainer {
   width: fit-content;
-  height: 25px;
+  height: fit-content;
   padding: 4px 8px;
   background: rgba(255, 255, 255, 0.3);
   border-radius: 56px;
@@ -143,7 +143,7 @@
   opacity: 0;
   transition: opacity 0.8s;
   position: absolute;
-  width: 273px;
+  width: 25%;
   border-radius: 15px;
   background-color: white;
   right: 17.5%;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -143,11 +143,12 @@
   opacity: 0;
   transition: opacity 0.8s;
   position: absolute;
-  width: 25%;
+  width: 142%;
   border-radius: 15px;
   background-color: white;
-  right: 211px;
-  top: -64px;
+  right: 0px;
+  bottom: 55px;
+  filter: drop-shadow(0px 4px 16px rgba(0, 0, 0, 0.32));
 }
 
 .toolTip::before {
@@ -181,6 +182,7 @@
   overflow: visible;
   width: calc(55% - 16px);
   margin-right: 16px;
+  position: relative;
 }
 
 .klfButtonContainer:hover ~ .toolTip {
@@ -239,11 +241,6 @@
 
   .actionsWrong {
     width: 47%;
-  }
-
-  .toolTip {
-    width: 35%;
-    right: 211px;
   }
 }
 

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -146,7 +146,7 @@
   width: 25%;
   border-radius: 15px;
   background-color: white;
-  right: 17.5%;
+  right: 211px;
   top: -64px;
 }
 
@@ -162,7 +162,7 @@
   background-color: white;
   position: inherit;
   bottom: -7px;
-  left: 129px;
+  right: 10%;
 }
 
 .tooltipText {
@@ -242,8 +242,8 @@
   }
 
   .toolTip {
-    width: 250px;
-    right: 25%;
+    width: 35%;
+    right: 211px;
   }
 }
 
@@ -311,6 +311,10 @@
     right: -3%;
     top: auto;
     bottom: 52px;
+  }
+
+  .toolTip::before {
+    right: 50%
   }
 
   .tooltipText {

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -48,7 +48,7 @@
 
 .feedbackSection {
   display: flex;
-  margin: 0 23px;
+  margin: 0 48px;
   flex-direction: row;
   align-items: center;
   justify-content: left;
@@ -84,7 +84,7 @@
 
 .resultLabel {
   margin-left: 12px;
-  font-weight: 900;
+  font-weight: 600;
   font-size: 24px;
   line-height: 24px;
   hyphens: auto;
@@ -95,21 +95,25 @@
 .information {
   display: block;
   flex-direction: column;
+  width: 100%;
 }
 
-.information .label {
-  width: 140px;
+.labelContainer {
+  width: fit-content;
   height: 25px;
   padding: 4px 8px;
   background: rgba(255, 255, 255, 0.3);
   border-radius: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.label {
   font-style: normal;
   font-weight: 900;
   font-size: 14px;
   line-height: 17px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   hyphens: auto;
   -ms-word-break: break-word;
   word-break: break-word;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -104,9 +104,7 @@
   padding: 4px 8px;
   background: rgba(255, 255, 255, 0.3);
   border-radius: 56px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: table;
 }
 
 .label {


### PR DESCRIPTION
https://trello.com/c/6QnVgT2S/2496-or-composant-popin-r%C3%A9vision

**Detailed purpose of the PR**

This PR adds fixes after review.

- Label wrong/correct answer —> font weight 600
- Feedback section : 48px de margin right en desktop et tablet
- Label correct answer/key learning factor : doit s’adapter au contenu (surtout pour les trads)
- La tooltip du key learning factor (popin mauvaise réponse) n’est pas bien centré au dessus du bouton
- La tooltip doit avoir une drop shadow

**Result and observation**

### Chrome right
![Kapture 2022-03-08 at 10 57 13](https://user-images.githubusercontent.com/7602475/157213185-31fa02ef-f653-4bc0-a87a-67afa8c41669.gif)

### Chrome wrong
![Kapture 2022-03-08 at 10 59 23](https://user-images.githubusercontent.com/7602475/157213519-3b51b6b2-a3aa-4a31-bb49-5087f14fc3b8.gif)

### IE 11
![Kapture 2022-03-08 at 10 53 16](https://user-images.githubusercontent.com/7602475/157212556-f7f68e24-080a-427d-b9ef-9a8dde97eb0c.gif)

**Testing Strategy**

- Already covered by tests
- Manual testing
