### PR TITLE
Remove loader from DOM

### DIFF
--- a/packages/@coorpacademy-components/src/template/app-player/popin-correction/index.js
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-correction/index.js
@@ -209,7 +209,7 @@ class PopinCorrection extends Component {
             {quitCta}
             <AssistanceLink {...assistanceLink} />
           </div>
-          <Loader className={isLoading ? style.activeLoader : style.inactiveLoader} />
+          {isLoading ? <Loader className={style.activeLoader} /> : null}
         </div>
       </div>
     );

--- a/packages/@coorpacademy-components/src/template/app-player/popin-correction/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-correction/style.css
@@ -104,10 +104,6 @@
   transition: opacity 0.3s;
 }
 
-.inactiveLoader {
-  opacity: 0;
-}
-
 /* Question -------------- */
 
 .question {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/509108/159963538-9d1bb937-389f-4785-a868-450a57b288a6.png)

Sur certaine résolution (celle utilisé dans les tests e2e), le loader était toujours présent dans le DOM et pouvait se placer devant le bouton `Quit` et empêcher le clic.