### PR TITLE
fix drag & drop component

### DIFF
--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
@@ -27,7 +27,9 @@ class DragAndDrop extends React.Component {
     modified: PropTypes.bool,
     children: PropTypes.func,
     onReset: PropTypes.func,
-    error: PropTypes.string
+    error: PropTypes.string,
+    buttonAriaLabel: PropTypes.string,
+    errorButtonLabel: PropTypes.string
   };
 
   constructor(props) {
@@ -65,7 +67,9 @@ class DragAndDrop extends React.Component {
       loading = false,
       modified = false,
       onReset = null,
-      error = ''
+      error = '',
+      buttonAriaLabel = '',
+      errorButtonLabel = ''
     } = this.props;
     const {dragging} = this.state;
 
@@ -124,7 +128,7 @@ class DragAndDrop extends React.Component {
     const buildButton = () => {
       const defaultButtonProps = {
         label: uploadLabel,
-        'aria-label': 'aria button',
+        'aria-label': buttonAriaLabel,
         'data-name': 'default-button',
         icon: {
           position: 'left',
@@ -134,7 +138,7 @@ class DragAndDrop extends React.Component {
       if (dragging) {
         return null;
       } else if (error) {
-        return <Button {...defaultButtonProps} label="Try again" icon={{}} />;
+        return <Button {...defaultButtonProps} label={errorButtonLabel} icon={{}} />;
       } else {
         return <Button {...defaultButtonProps} />;
       }

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/error.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/error.js
@@ -7,6 +7,6 @@ export default {
     ...props,
     error: 'The file is invalid',
     errorButtonLabel: 'Try again',
-    buttonAriaLabel: 'aria error label'
+    buttonAriaLabel: 'Aria label'
   }
 };

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/error.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/error.js
@@ -5,6 +5,8 @@ const {props} = defaultProps;
 export default {
   props: {
     ...props,
-    error: 'The file is invalid'
+    error: 'The file is invalid',
+    errorButtonLabel: 'Try again',
+    buttonAriaLabel: 'aria error label'
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/drag-and-drop-wrapper/index.js
+++ b/packages/@coorpacademy-components/src/molecule/drag-and-drop-wrapper/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {map} from 'lodash/fp';
-import DragAndDrop from '../../atom/drag-and-drop';
-import CheckboxWithTitle from '../../atom/checkbox-with-title';
+import ImageUpload from '../../atom/image-upload';
 import style from './style.css';
 
 const DragAndDropWrapper = props => {
@@ -11,7 +10,7 @@ const DragAndDropWrapper = props => {
   const dragAndDropList = map(dragAndDropProps => {
     return (
       <li className={style.dragAndDrop} key={`dragAndDrop-${dragAndDropProps.title}`}>
-        <DragAndDrop {...dragAndDropProps} />
+        <ImageUpload {...dragAndDropProps} />
       </li>
     );
   }, list);
@@ -26,8 +25,7 @@ const DragAndDropWrapper = props => {
 };
 
 DragAndDropWrapper.propTypes = {
-  list: PropTypes.arrayOf(PropTypes.shape(DragAndDrop.propTypes)),
-  checkBoxTitle: PropTypes.shape({...CheckboxWithTitle.propTypes}),
+  list: PropTypes.arrayOf(PropTypes.shape(ImageUpload.propTypes)),
   'data-name': PropTypes.string
 };
 

--- a/packages/@coorpacademy-components/src/molecule/drag-and-drop-wrapper/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/drag-and-drop-wrapper/test/fixtures/default.js
@@ -1,9 +1,7 @@
-import firstdDragAndDrop from '../../../../atom/drag-and-drop/test/fixtures/default';
-import checkBoxTitle from '../../../../atom/checkbox-with-title/test/fixtures/checked';
+import firstdDragAndDrop from '../../../../atom/image-upload/test/fixtures/default';
 
 export default {
   props: {
-    checkBoxTitle: {...checkBoxTitle.props, title: 'Create badge'},
     list: [{...firstdDragAndDrop.props, title: 'Add a badge'}]
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/drag-and-drop-wrapper/test/fixtures/two-drag-and-drops.js
+++ b/packages/@coorpacademy-components/src/molecule/drag-and-drop-wrapper/test/fixtures/two-drag-and-drops.js
@@ -1,13 +1,14 @@
 import firstdDragAndDrop from '../../../../atom/drag-and-drop/test/fixtures/default';
 import secondDragAndDrop from '../../../../atom/drag-and-drop/test/fixtures/clean-and-modified';
 import checkBoxTitle from '../../../../atom/checkbox-with-title/test/fixtures/checked';
+import dragAndDrop from '../../../../atom/image-upload/test/fixtures/default';
 
 export default {
   props: {
     checkBoxTitle: {...checkBoxTitle.props, title: 'Create diploma'},
     list: [
-      {...firstdDragAndDrop.props, title: 'Upload Company logo'},
-      {...secondDragAndDrop.props, title: 'Upload digital signature'}
+      {...dragAndDrop.props, ...firstdDragAndDrop.props, title: 'Upload Company logo'},
+      {...dragAndDrop.props, ...secondDragAndDrop.props, title: 'Upload digital signature'}
     ]
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/drag-and-drop-wrapper/test/fixtures/without-checkbox.js
+++ b/packages/@coorpacademy-components/src/molecule/drag-and-drop-wrapper/test/fixtures/without-checkbox.js
@@ -1,4 +1,4 @@
-import firstdDragAndDrop from '../../../../atom/drag-and-drop/test/fixtures/default';
+import firstdDragAndDrop from '../../../../atom/image-upload/test/fixtures/default';
 
 export default {
   props: {

--- a/packages/@coorpacademy-components/src/organism/brand-form/test/fixtures/wizard-certification.js
+++ b/packages/@coorpacademy-components/src/organism/brand-form/test/fixtures/wizard-certification.js
@@ -1,4 +1,4 @@
-import SetupSlider from '../../../../molecule/title-and-checkbox-wrapper/test/fixtures/drag-drop-without-title';
+import logoUpload from '../../../../molecule/title-and-checkbox-wrapper/test/fixtures/drag-drop-without-title';
 
 export default {
   props: {
@@ -60,7 +60,7 @@ export default {
               'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis fermentum sem ac fermentum luctus. Integer eu dui magna. Donec ut tristique dui. Vestibulum non accumsan tellus. Donec luctus erat vitae aliquet viverra. Mauris malesuada tortor quis viverra vestibulum. Nullam laoreet porta massa vitae porta.'
           },
           {
-            ...SetupSlider.props,
+            ...logoUpload.props,
             type: 'titleAndCheckBoxWrapper'
           }
         ]

--- a/packages/@coorpacademy-components/src/organism/rewards-form/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/rewards-form/test/fixtures/default.js
@@ -16,11 +16,11 @@ export default {
           childType: 'drag-and-drop-wrapper',
           title: 'Create badge'
         },
-        sectionTitle: {title: 'Create badge'}
+        checkboxWithTitle: {title: 'Create badge'}
       },
       {
         child: {...doubleDragAndDrop.props, childType: 'drag-and-drop-wrapper'},
-        sectionTitle: {title: 'Create diploma'}
+        checkboxWithTitle: {title: 'Create diploma'}
       }
     ]
   }


### PR DESCRIPTION
Fix drag & droop wrapper click, the component is not clickable after the new refacto, in this pr i wrappe it in the image upload component 

fix rewards page fixtures

![upload image](https://user-images.githubusercontent.com/58167920/160629849-86a111fa-4b41-489c-9fad-388f426de5c3.gif)

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
