### PR TITLE
fix image name

### DIFF
--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
@@ -21,7 +21,8 @@ class DragAndDrop extends React.Component {
     previewLabel: PropTypes.string,
     previewContent: PropTypes.shape({
       type: PropTypes.string,
-      src: PropTypes.string
+      src: PropTypes.string,
+      label: PropTypes.string
     }),
     loading: PropTypes.bool,
     modified: PropTypes.bool,
@@ -112,7 +113,9 @@ class DragAndDrop extends React.Component {
     const resetContent =
       previewContent && previewContent.src ? (
         <div className={style.resetUploadWrapper}>
-          <div className={style.resetSrcLabel}>{previewContent.src}</div>
+          <div className={style.resetSrcLabel}>
+            {previewContent.label ? previewContent.label : previewContent.src}
+          </div>
           {onReset ? (
             <Close
               data-name="reset-content-icon"

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/with-image.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/with-image.js
@@ -6,7 +6,8 @@ export default {
     previewLabel: 'File Preview',
     previewContent: {
       type: 'image',
-      src: 'https://static.coorpacademy.com/content/up/raw/logo_coorp-1491560495763.svg'
+      src: 'https://static.coorpacademy.com/content/up/raw/logo_coorp-1491560495763.svg',
+      label: 'coorp image'
     }
   }
 };

--- a/packages/@coorpacademy-components/src/organism/brand-form/index.js
+++ b/packages/@coorpacademy-components/src/organism/brand-form/index.js
@@ -118,7 +118,7 @@ function BrandForm(props, context) {
   return (
     <div>
       {backView}
-      <form onSubmit={handleSubmit} onReset={handleReset}>
+      <form onSubmit={handleSubmit} onReset={handleReset} className={style.form}>
         {brandGroups}
         {buttonSection}
       </form>

--- a/packages/@coorpacademy-components/src/organism/brand-form/style.css
+++ b/packages/@coorpacademy-components/src/organism/brand-form/style.css
@@ -12,6 +12,10 @@
   margin: 0 0 32px 0;
 }
 
+.form {
+  margin: 0 0 48px 0;
+}
+
 .group:last-child {
   margin: 0;
 }


### PR DESCRIPTION
in svg case the drage & drop fill name is wrong , so in this case we will use the name of the fille passed in props(label)

![image](https://user-images.githubusercontent.com/58167920/161712416-33026369-5fac-4bad-a1ac-9fd4212b7473.png)

![image](https://user-images.githubusercontent.com/58167920/161713172-551bdd05-e9ff-496f-b03e-076a25f7e765.png)


**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
