### PR TITLE
Plug Congrats component into Slides Review Template

### DIFF
--- a/packages/@coorpacademy-components/src/atom/lottie-wrapper/index.js
+++ b/packages/@coorpacademy-components/src/atom/lottie-wrapper/index.js
@@ -47,18 +47,20 @@ export const fetchAndLoadAnimation = async (
 
   const animationData = await fetchResult.json();
 
-  const animation = _lottie.loadAnimation({
-    container: containerRef.current, // the dom element that will contain the animation
-    renderer: 'svg',
-    autoplay,
-    loop,
-    animationData,
-    rendererSettings: {
-      className: animationClassnames,
-      hideOnTransparent,
-      preserveAspectRatio: 'xMidYMid meet' // same options as a preserveAspectRatio prop
-    }
-  });
+  const animation =
+    _lottie.loadAnimation &&
+    _lottie.loadAnimation({
+      container: containerRef.current, // the dom element that will contain the animation
+      renderer: 'svg',
+      autoplay,
+      loop,
+      animationData,
+      rendererSettings: {
+        className: animationClassnames,
+        hideOnTransparent,
+        preserveAspectRatio: 'xMidYMid meet' // same options as a preserveAspectRatio prop
+      }
+    });
   return animation;
 };
 

--- a/packages/@coorpacademy-components/src/organism/review-congrats/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-congrats/index.js
@@ -6,10 +6,11 @@ import MoleculeReviewCardCongrats from '../../molecule/review-card-congrats';
 import style from './style.css';
 
 export const setScroll = container => () => {
-  container.current.scrollTo({
-    left: 1000,
-    behavior: 'smooth'
-  });
+  container.current?.scrollTo &&
+    container.current.scrollTo({
+      left: 1000,
+      behavior: 'smooth'
+    });
 };
 
 const ReviewCongrats = props => {

--- a/packages/@coorpacademy-components/src/organism/review-congrats/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-congrats/style.css
@@ -114,7 +114,6 @@
   top: 200px;
   user-select: none;
   animation: translateTitle 1.4s ease-out 0s forwards;
-  background-color: white;
 }
 
 .containerCards {

--- a/packages/@coorpacademy-components/src/organism/review-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-header/style.css
@@ -51,7 +51,7 @@
 .stepsWrapperAnimation {
   opacity: 0;
   transform: translate(-50%, -180%);
-  transition: opacity 0.5s ease-in-out 0.5s, transform 0.5s ease-in-out 0.5s;
+  transition: opacity 0.5s ease-in-out, transform 0.5s ease-in-out;
 }
 
 .iconButtonWrapper {

--- a/packages/@coorpacademy-components/src/template/slides-review/style.css
+++ b/packages/@coorpacademy-components/src/template/slides-review/style.css
@@ -29,10 +29,11 @@
   align-self: center;
 }
 
-/* .congrats {
+.congrats {
   width: 100%;
-  position: relative;
-} */
+  height: 100%;
+  position: absolute;
+}
 
 .playerBackground {
   position: absolute;

--- a/packages/@coorpacademy-components/src/template/slides-review/test/fixtures/failure.js
+++ b/packages/@coorpacademy-components/src/template/slides-review/test/fixtures/failure.js
@@ -1,4 +1,5 @@
 import headerProps from '../../../../organism/review-header/test/fixtures/no-answered-question';
+import congratsProps from '../../../../organism/review-congrats/test/fixtures/default';
 import AnswerQCMDrag from '../../../../molecule/answer/test/fixtures/qcm-drag';
 import AnswerQCMGraphic from '../../../../molecule/answer/test/fixtures/qcm-graphic';
 import {correctionPopinProps} from './success';
@@ -27,6 +28,7 @@ export default {
       question: 'Hey there! ......dramatic suspense..... ready to answer?',
       answer: qcmDrag
     },
-    correctionPopinProps
+    correctionPopinProps,
+    congratsProps: congratsProps.props
   }
 };

--- a/packages/@coorpacademy-components/src/template/slides-review/test/fixtures/success.js
+++ b/packages/@coorpacademy-components/src/template/slides-review/test/fixtures/success.js
@@ -1,4 +1,5 @@
 import headerProps from '../../../../organism/review-header/test/fixtures/no-answered-question';
+import congratsProps from '../../../../organism/review-congrats/test/fixtures/default';
 import AnswerQCMDrag from '../../../../molecule/answer/test/fixtures/qcm-drag';
 import AnswerQCMGraphic from '../../../../molecule/answer/test/fixtures/qcm-graphic';
 
@@ -45,6 +46,7 @@ export default {
       question: 'Hey there, .....suspense.... ready to select some answers?',
       answer: qcmDrag
     },
-    correctionPopinProps
+    correctionPopinProps,
+    congratsProps: congratsProps.props
   }
 };

--- a/packages/@coorpacademy-components/src/template/slides-review/test/slides-review.js
+++ b/packages/@coorpacademy-components/src/template/slides-review/test/slides-review.js
@@ -1,7 +1,7 @@
 import browserEnv from 'browser-env';
 import test from 'ava';
 import React from 'react';
-import {render, cleanup, fireEvent, act} from '@testing-library/react';
+import {render, fireEvent, act} from '@testing-library/react';
 import SlidesReview from '..';
 import AnswerQCMDrag from '../../../molecule/answer/test/fixtures/qcm-drag';
 import successFixture from './fixtures/success';
@@ -9,8 +9,6 @@ import failureFixture from './fixtures/failure';
 import failOnceOnLastSlideFixture from './fixtures/only-once-on-last-slide';
 
 browserEnv({pretendToBeVisual: true});
-
-test.after(cleanup);
 
 const elementExists = foundElements => foundElements && foundElements[0];
 

--- a/packages/@coorpacademy-components/src/template/slides-review/test/slides-review.js
+++ b/packages/@coorpacademy-components/src/template/slides-review/test/slides-review.js
@@ -8,9 +8,9 @@ import successFixture from './fixtures/success';
 import failureFixture from './fixtures/failure';
 import failOnceOnLastSlideFixture from './fixtures/only-once-on-last-slide';
 
-browserEnv();
+browserEnv({pretendToBeVisual: true});
 
-test.afterEach(cleanup);
+test.after(cleanup);
 
 const elementExists = foundElements => foundElements && foundElements[0];
 


### PR DESCRIPTION
Co-authored-by: EmelineLeduc <EmelineLeduc@users.noreply.github.com>

 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
This is the 2th iteration of the Slides Review Template, to plug the Review Congrats organism into the provided slot (which is shown after a complete review of the slides/ or an early exit).

- Plugs the Congrats Organism, updates styles, updates tests.


**Result and observation**

![Kapture 2022-05-13 at 10 56 10](https://user-images.githubusercontent.com/33550261/168248801-fe10d6d1-3977-430e-910e-aee2765d290a.gif)

![Kapture 2022-05-13 at 10 34 42](https://user-images.githubusercontent.com/33550261/168248758-c16f68da-6d76-47fa-b567-f2f40bc3acfd.gif)

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
