### PR TITLE
Fix slides review template style for short desktop screens

### DIFF
--- a/packages/@coorpacademy-components/src/template/slides-review/style.css
+++ b/packages/@coorpacademy-components/src/template/slides-review/style.css
@@ -11,7 +11,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
   height: 100vh;
 }
 
@@ -32,12 +32,14 @@
 .congrats {
   width: 100%;
   height: 100%;
+  min-height: 832px;
   position: absolute;
 }
 
 .playerBackground {
   position: absolute;
   height: 100vh;
+  min-height: 832px;
   top: 0;
   left: 0;
 }


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- Fixes slides review template style for short desktop screens by adding a vertical sliding bar (&& height adjustments).

**Result and observation**

<img width="821" alt="Screenshot 2022-05-19 at 14 05 19" src="https://user-images.githubusercontent.com/33550261/169289427-79a84297-0c26-47ba-b15d-4b5df3703142.png">


- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
