### PR TITLE
Use css-modules to compose classes

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/audio/index.js
+++ b/packages/@coorpacademy-components/src/molecule/audio/index.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {NovaCompositionCoorpacademyMicrophone as PodcastIcon} from '@coorpacademy/nova-icons';
 import Provider from '../../atom/provider';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './style.css';
 
 class Audio extends React.Component {
@@ -54,7 +53,7 @@ class Audio extends React.Component {
         <PodcastIcon color={white} className={style.icon} />
         {description ? (
           <div
-            className={classnames(style.description, innerHTML)}
+            className={classnames(style.description, style.innerHTML)}
             data-name="audioDescription"
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{__html: description}}

--- a/packages/@coorpacademy-components/src/molecule/audio/style.css
+++ b/packages/@coorpacademy-components/src/molecule/audio/style.css
@@ -52,3 +52,7 @@
   margin: 24px 5px 0 5px;
   z-index: 1;
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/molecule/battle-request/index.js
+++ b/packages/@coorpacademy-components/src/molecule/battle-request/index.js
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 import Link from '../../atom/link';
 import Provider from '../../atom/provider';
 import Avatar from '../../atom/avatar';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './style.css';
 
 const BattleRequest = (props, context) => {
@@ -38,7 +37,7 @@ const BattleRequest = (props, context) => {
         </div>
         <div className={style.discipline}>
           <div
-            className={classnames(style.disciplineName, innerHTML)}
+            className={classnames(style.disciplineName, style.innerHTML)}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{__html: discipline}}
           />

--- a/packages/@coorpacademy-components/src/molecule/battle-request/style.css
+++ b/packages/@coorpacademy-components/src/molecule/battle-request/style.css
@@ -125,3 +125,7 @@
     font-size: 13px;
   }
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/molecule/card-content/index.js
+++ b/packages/@coorpacademy-components/src/molecule/card-content/index.js
@@ -10,7 +10,6 @@ import {
 import {isExternalContent, EXTERNAL_CONTENT_ICONS} from '../../util/external-content';
 import Provider from '../../atom/provider';
 import ContentBadge from '../../atom/content-badge';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './style.css';
 
 export const MODES = {
@@ -69,7 +68,7 @@ const CardTitle = ({title, empty, courseContent}) => {
     <div
       className={classnames(
         style.title,
-        innerHTML,
+        style.innerHTML,
         courseContent ? style.lightTitle : style.darkTitle,
         empty ? style.empty : null
       )}

--- a/packages/@coorpacademy-components/src/molecule/card-content/style.css
+++ b/packages/@coorpacademy-components/src/molecule/card-content/style.css
@@ -272,3 +272,7 @@
   composes: progressWrapper;
   opacity: 0;
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/molecule/discipline-header/index.js
+++ b/packages/@coorpacademy-components/src/molecule/discipline-header/index.js
@@ -5,7 +5,6 @@ import getOr from 'lodash/fp/getOr';
 import classnames from 'classnames';
 import VideoPlayer from '../video-player';
 import Picture from '../../atom/picture';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './style.css';
 
 const Preview = ({image, video}) => {
@@ -78,13 +77,13 @@ class DisciplineHeader extends React.Component {
         <div className={style.courseWrapper}>
           <div
             data-name="title"
-            className={classnames(style.title, innerHTML)}
+            className={classnames(style.title, style.innerHTML)}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{__html: title}}
           />
           <div className={fullDisplay ? style.desc : style.shortDesc}>
             <div
-              className={innerHTML}
+              className={style.innerHTML}
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{__html: description}}
               ref={this.setHandle}

--- a/packages/@coorpacademy-components/src/molecule/discipline-header/style.css
+++ b/packages/@coorpacademy-components/src/molecule/discipline-header/style.css
@@ -107,3 +107,7 @@
     padding-left: 0;
   }
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/molecule/feedback/index.js
+++ b/packages/@coorpacademy-components/src/molecule/feedback/index.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {pipe, get, extend} from 'lodash/fp';
 import classnames from 'classnames';
-
-import {innerHTML} from '../../atom/label/style.css';
 import ResourcePlayer, {TYPE_IMAGE, TYPE_VIDEO, TYPE_PDF, TYPE_AUDIO} from '../resource-player';
 import style from './style.css';
 
@@ -19,14 +17,14 @@ const Feedback = (props, context) => {
     (resource || title || description ? (
       <div className={style.feedback} data-name="feedback">
         <div
-          className={classnames(style.title, innerHTML)}
+          className={classnames(style.title, style.innerHTML)}
           data-name="title"
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{__html: title}}
         />
         <div className={style.descWrapper}>
           <div
-            className={classnames(style.description, innerHTML)}
+            className={classnames(style.description, style.innerHTML)}
             data-name="description"
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{__html: description}}
@@ -36,7 +34,7 @@ const Feedback = (props, context) => {
               <ResourcePlayer className={style.resourcePlayer} resource={resource} />
               <div
                 data-name="mediaDescription"
-                className={classnames(style.mediaDescription, innerHTML)}
+                className={classnames(style.mediaDescription, style.innerHTML)}
                 // eslint-disable-next-line react/no-danger
                 dangerouslySetInnerHTML={{__html: mediaDescription}}
               />

--- a/packages/@coorpacademy-components/src/molecule/feedback/style.css
+++ b/packages/@coorpacademy-components/src/molecule/feedback/style.css
@@ -91,3 +91,7 @@
     margin-bottom: 8px;
   }
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/molecule/module-card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/module-card/index.js
@@ -4,7 +4,6 @@ import {getOr} from 'lodash/fp';
 import classnames from 'classnames';
 import ModuleBubble from '../module-bubble';
 import Provider from '../../atom/provider';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './style.css';
 
 function ModuleCard(props, context) {
@@ -15,7 +14,7 @@ function ModuleCard(props, context) {
   return (
     <div className={style.default} data-name="module-card" onClick={onClick}>
       <div
-        className={classnames(style.title, innerHTML)}
+        className={classnames(style.title, style.innerHTML)}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{__html: label}}
       />

--- a/packages/@coorpacademy-components/src/molecule/module-card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/module-card/style.css
@@ -63,3 +63,7 @@
     margin-left: 10px;
   }
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/molecule/news/index.js
+++ b/packages/@coorpacademy-components/src/molecule/news/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Cta from '../../atom/cta';
 import Link from '../../atom/link';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './style.css';
 
 const News = (props, context) => {
@@ -25,7 +24,7 @@ const News = (props, context) => {
         <Link
           href={cta.href}
           title={title}
-          className={classnames(style.title, innerHTML)}
+          className={classnames(style.title, style.innerHTML)}
           target={cta.target}
           data-name="news-title"
           // eslint-disable-next-line react/no-danger

--- a/packages/@coorpacademy-components/src/molecule/news/style.css
+++ b/packages/@coorpacademy-components/src/molecule/news/style.css
@@ -173,3 +173,7 @@
     height: 100%;
   }
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/molecule/pdf/index.js
+++ b/packages/@coorpacademy-components/src/molecule/pdf/index.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import {NovaLineFilesOfficeFileOfficePdf as PDFIcon} from '@coorpacademy/nova-icons';
 import Link from '../../atom/link';
 import Provider from '../../atom/provider';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './style.css';
 
 const PDF = (props, context) => {
@@ -24,7 +23,7 @@ const PDF = (props, context) => {
     >
       <PDFIcon color={white} className={style.pdfIcon} />
       <div
-        className={classnames(style.pdfDescription, innerHTML)}
+        className={classnames(style.pdfDescription, style.innerHTML)}
         data-name="pdfDescription"
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{__html: description}}

--- a/packages/@coorpacademy-components/src/molecule/pdf/style.css
+++ b/packages/@coorpacademy-components/src/molecule/pdf/style.css
@@ -96,3 +96,7 @@
 .openPDFButton:active {
   transform: scale(0.95);
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/molecule/scope-content/index.js
+++ b/packages/@coorpacademy-components/src/molecule/scope-content/index.js
@@ -5,7 +5,6 @@ import Button from '../../atom/button';
 import Provider from '../../atom/provider';
 import Discussion from '../../organism/discussion';
 import ResourceBrowser from '../../organism/resource-browser';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './style.css';
 
 const ScopeContent = (props, context) => {
@@ -62,7 +61,7 @@ const ScopeContent = (props, context) => {
         <div className={style.infos}>
           <div className={style.title}>
             <div
-              className={innerHTML}
+              className={style.innerHTML}
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{__html: title}}
             />

--- a/packages/@coorpacademy-components/src/molecule/scope-content/style.css
+++ b/packages/@coorpacademy-components/src/molecule/scope-content/style.css
@@ -174,3 +174,7 @@
   border-right: solid 1px light;
   border-bottom: 1px solid light;
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/organism/sidebar/index.js
+++ b/packages/@coorpacademy-components/src/organism/sidebar/index.js
@@ -9,7 +9,6 @@ import Provider from '../../atom/provider';
 import Select from '../../atom/select';
 import Cta from '../../atom/cta';
 import SelectMultiple from '../../molecule/select-multiple';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './style.css';
 
 const NEUTRAL_COLOR = '#607D8B';
@@ -109,7 +108,12 @@ export const LinkItem = ({
     [onClick]
   );
 
-  const classNames = classnames(style.linkItem, innerHTML, {[style.uppercase]: uppercase}, styles);
+  const classNames = classnames(
+    style.linkItem,
+    style.innerHTML,
+    {[style.uppercase]: uppercase},
+    styles
+  );
   const borderStyle = {borderLeftColor: selected ? color : null};
 
   return (

--- a/packages/@coorpacademy-components/src/organism/sidebar/style.css
+++ b/packages/@coorpacademy-components/src/organism/sidebar/style.css
@@ -111,3 +111,7 @@
 .linkItem:hover .icon {
   color: cm_grey_700;
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/template/activity/index.js
+++ b/packages/@coorpacademy-components/src/template/activity/index.js
@@ -6,7 +6,6 @@ import Provider from '../../atom/provider';
 import Button from '../../atom/button';
 import Select from '../../atom/select';
 import Loader from '../../atom/loader';
-import {innerHTML} from '../../atom/label/style.css';
 import ProgressionItem from './progression-item';
 import EngineStars from './engine-stars';
 import StarsSummary from './stars-summary';
@@ -106,7 +105,7 @@ class Progression extends React.Component {
         <p className={style.recommendationSection}>
           <span>{recommendation.subtitle} </span>
           <span
-            className={classnames(style.course, innerHTML)}
+            className={classnames(style.course, style.innerHTML)}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{__html: recommendation.courseTitle}}
           />

--- a/packages/@coorpacademy-components/src/template/activity/progression-item.css
+++ b/packages/@coorpacademy-components/src/template/activity/progression-item.css
@@ -167,3 +167,7 @@
     font-size: 13px;
   }
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/template/activity/progression-item.js
+++ b/packages/@coorpacademy-components/src/template/activity/progression-item.js
@@ -18,7 +18,6 @@ import {
 import Provider from '../../atom/provider';
 import ProgressBar from '../../molecule/progress-bar';
 import Link from '../../atom/link';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './progression-item.css';
 
 const ICONS = {
@@ -87,7 +86,7 @@ const ProgressionItem = (props, context) => {
         <IconType className={style.iconType} color={dark} />
         <div data-name="activityLabel" className={style.label} title={label}>
           <div
-            className={innerHTML}
+            className={style.innerHTML}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{__html: label}}
           />

--- a/packages/@coorpacademy-components/src/template/activity/style.css
+++ b/packages/@coorpacademy-components/src/template/activity/style.css
@@ -153,3 +153,8 @@
     margin: 10px 10px 0;
   }
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}
+

--- a/packages/@coorpacademy-components/src/template/app-player/popin-correction/test/index.js
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-correction/test/index.js
@@ -9,9 +9,18 @@ import correctClosed from './fixtures/correct-closed';
 browserEnv();
 configure({adapter: new Adapter()});
 
-test.cb('should open with transition', t => {
-  const props = {onOpen: t.end, ...correctClosed.props};
-  const context = {skin: {}};
+test('should open with transition', async t => {
+  t.plan(1);
+  await new Promise(resolve => {
+    const props = {
+      onOpen: () => {
+        t.pass();
+        resolve();
+      },
+      ...correctClosed.props
+    };
+    const context = {skin: {}};
 
-  shallow(<PopinCorrection {...props} />, context);
+    shallow(<PopinCorrection {...props} />, context);
+  });
 });

--- a/packages/@coorpacademy-components/src/template/battle-requests/index.js
+++ b/packages/@coorpacademy-components/src/template/battle-requests/index.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import Provider from '../../atom/provider';
 import CardWithButton from '../../molecule/card-with-button';
 import Avatar from '../../atom/avatar';
-import {innerHTML} from '../../atom/label/style.css';
 import style from './style.css';
 
 const Battles = (props, context) => {
@@ -36,7 +35,7 @@ const Battles = (props, context) => {
                   <Avatar url={battle.urlAvatar} />
                 </div>
                 <div
-                  className={classnames(style.wrapper, innerHTML)}
+                  className={classnames(style.wrapper, style.innerHTML)}
                   // eslint-disable-next-line react/no-danger
                   dangerouslySetInnerHTML={{__html: challengeLabel}}
                 />

--- a/packages/@coorpacademy-components/src/template/battle-requests/style.css
+++ b/packages/@coorpacademy-components/src/template/battle-requests/style.css
@@ -72,3 +72,7 @@
   justify-content: center;
   align-items: center;
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}

--- a/packages/@coorpacademy-components/src/template/external-course/index.js
+++ b/packages/@coorpacademy-components/src/template/external-course/index.js
@@ -8,7 +8,6 @@ import {EXTERNAL_CONTENT_ICONS} from '../../util/external-content';
 import Provider from '../../atom/provider';
 import Loader from '../../atom/loader';
 import Button from '../../atom/button';
-import {innerHTML} from '../../atom/label/style.css';
 import ExternalContentViewer from '../../molecule/external-content-viewer';
 import style from './style.css';
 
@@ -132,7 +131,7 @@ class ExternalCourse extends React.Component {
           <IconType className={style.iconHeader} />
         </div>
         <span
-          className={innerHTML}
+          className={style.innerHTML}
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{__html: name}}
         />

--- a/packages/@coorpacademy-components/src/template/external-course/style.css
+++ b/packages/@coorpacademy-components/src/template/external-course/style.css
@@ -139,3 +139,7 @@
     display: none;
   }
 }
+
+.innerHTML {
+  composes: innerHTML from '../../atom/label/style.css'
+}


### PR DESCRIPTION
Resolve warnings from https://github.com/CoorpAcademy/coorpacademy-lambda/tree/master/teams 's webpack build.
``` 
WARNING in ./node_modules/@coorpacademy/components/es/molecule/audio/index.js 65:47-56
export 'innerHTML' (imported as 'innerHTML') was not found in '../../atom/label/style.css' (possible exports: default)
```