### PR TITLE
Review add init step for review

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
@@ -23,7 +23,7 @@ import type {
   Answer,
   AnswerRecord,
   AvailableContent,
-  ChapterContent,
+  ContentContainer,
   Config,
   Content,
   Slide,
@@ -40,7 +40,7 @@ const getContentRef: State => string = get('content.ref');
 const hasRemainingLifeRequests = (state: State): boolean => state.remainingLifeRequests > 0;
 const stepIsAlreadyExtraLife = (state: State): boolean => getContentRef(state) === 'extraLife';
 
-const hasRulesToApply = (chapterContent: ChapterContent | null): boolean => {
+const hasRulesToApply = (chapterContent: ContentContainer | null): boolean => {
   return !!(
     chapterContent &&
     Array.isArray(chapterContent.rules) &&
@@ -64,8 +64,8 @@ export type PartialExtraLifeAcceptedAction = {
 type PartialAction = PartialAnswerActionWithIsCorrect | PartialExtraLifeAcceptedAction | null;
 
 type ChapterContentSelection = {
-  currentChapterContent: ChapterContent | null,
-  nextChapterContent: ChapterContent | null,
+  currentChapterContent: ContentContainer | null,
+  nextChapterContent: ContentContainer | null,
   temporaryNextContent: Content
 };
 
@@ -84,11 +84,11 @@ export const nextSlidePool = (
   }
   const lastSlideRef = pipe(get('slides'), last)(state);
   const _currentIndex: number = findIndex(
-    ({slides}: ChapterContent): boolean => !!find({_id: lastSlideRef}, slides),
+    ({slides}: ContentContainer): boolean => !!find({_id: lastSlideRef}, slides),
     availableContent
   );
   const currentIndex = _currentIndex !== -1 ? _currentIndex : 0;
-  const currentChapterPool: ChapterContent | null = availableContent[currentIndex] || null;
+  const currentChapterPool: ContentContainer | null = availableContent[currentIndex] || null;
 
   const currentChapterSlideIds = pipe(get('slides'), map('_id'))(currentChapterPool || []);
   const slidesAnsweredForThisChapter = intersection(state.slides, currentChapterSlideIds);
@@ -171,7 +171,7 @@ type Result = {
 
 const computeNextSlide = (
   config: Config,
-  chapterContent: ChapterContent,
+  chapterContent: ContentContainer,
   state: State | null
 ): Content => {
   const remainingSlides = filter(

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
@@ -261,7 +261,7 @@ const extendPartialAction = (action: PartialAction, state: State | null): Action
   }
 };
 
-const computeNextStep = (
+export const computeNextStep = (
   config: Config,
   _state: State | null,
   availableContent: AvailableContent,
@@ -357,4 +357,22 @@ const computeNextStep = (
   return null;
 };
 
-export default computeNextStep;
+export const computeNextStepForReview = (
+  config: Config,
+  _state: State | null,
+  availableContent: AvailableContent
+): Result => {
+  const nextSlide = get(['0', 'slides', '0'], availableContent);
+  if (!nextSlide) {
+    return null;
+  }
+
+  return {
+    nextContent: {
+      type: 'slide',
+      ref: nextSlide._id
+    },
+    instructions: null,
+    isCorrect: false
+  };
+};

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/index.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/index.js
@@ -17,6 +17,7 @@ import type {
 import checkAnswer from '../check-answer';
 import {
   computeNextStep,
+  computeNextStepForReview,
   type PartialAnswerActionWithIsCorrect,
   type PartialExtraLifeAcceptedAction
 } from './compute-next-step';
@@ -77,7 +78,7 @@ export const computeInitialStepForReview = (
   };
 
   if (isEmpty(availableContent)) return defaultSuccess;
-  const initialStep = computeNextStep(config, null, availableContent, null);
+  const initialStep = computeNextStepForReview(config, null, availableContent);
   if (!initialStep) return defaultSuccess;
   const {instructions, nextContent} = initialStep;
 

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/index.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/index.js
@@ -15,7 +15,8 @@ import type {
   Slide
 } from '../types';
 import checkAnswer from '../check-answer';
-import computeNextStep, {
+import {
+  computeNextStep,
   type PartialAnswerActionWithIsCorrect,
   type PartialExtraLifeAcceptedAction
 } from './compute-next-step';
@@ -51,6 +52,35 @@ export const computeInitialStep = (
   }
 
   const {nextContent, instructions} = initialStep;
+  return {
+    type: 'move',
+    payload: {
+      instructions,
+      nextContent
+    }
+  };
+};
+
+export const computeInitialStepForReview = (
+  config: Config,
+  availableContent: AvailableContent = []
+): MoveAction => {
+  const defaultSuccess = {
+    type: 'move',
+    payload: {
+      nextContent: {
+        type: 'success',
+        ref: 'successExitNode'
+      },
+      instructions: null
+    }
+  };
+
+  if (isEmpty(availableContent)) return defaultSuccess;
+  const initialStep = computeNextStep(config, null, availableContent, null);
+  if (!initialStep) return defaultSuccess;
+  const {instructions, nextContent} = initialStep;
+
   return {
     type: 'move',
     payload: {

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-initial-step-for-review.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-initial-step-for-review.js
@@ -17,7 +17,7 @@ const availableContent: AvailableContent = [
 ];
 
 test('should return successExitNode if availableContent is empty', t => {
-  t.deepEqual(computeInitialStepForReview(config, []), {
+  t.deepEqual(computeInitialStepForReview(config), {
     type: 'move',
     payload: {
       nextContent: {

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-initial-step-for-review.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-initial-step-for-review.js
@@ -1,0 +1,62 @@
+// @flow
+import test from 'ava';
+import {head} from 'lodash/fp';
+import {getConfig} from '../../config';
+import type {AvailableContent, Config} from '../../types';
+import {computeInitialStepForReview} from '..';
+import allSlides from './fixtures/slides';
+
+const config: Config = getConfig({ref: 'review', version: '1'});
+
+const availableContent: AvailableContent = [
+  {
+    ref: 'skill_41BBqFKoS',
+    slides: [head(allSlides)],
+    rules: null
+  }
+];
+
+test('should return successExitNode if availableContent is empty', t => {
+  t.deepEqual(computeInitialStepForReview(config, []), {
+    type: 'move',
+    payload: {
+      nextContent: {
+        type: 'success',
+        ref: 'successExitNode'
+      },
+      instructions: null
+    }
+  });
+});
+
+test('should return a success exitNode if there are no slides in all chapters', t => {
+  const action = computeInitialStepForReview(config, [{ref: '1.A1', slides: [], rules: null}]);
+  if (!action) {
+    throw new Error('action should not be falsy');
+  }
+  t.deepEqual(action, {
+    type: 'move',
+    payload: {
+      instructions: null,
+      nextContent: {
+        type: 'success',
+        ref: 'successExitNode'
+      }
+    }
+  });
+});
+
+test('should create an initial action from the availableContent', t => {
+  const action = computeInitialStepForReview(config, availableContent);
+
+  t.deepEqual(action, {
+    type: 'move',
+    payload: {
+      instructions: null,
+      nextContent: {
+        type: 'slide',
+        ref: '1.A1.1'
+      }
+    }
+  });
+});

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.js
@@ -4,7 +4,8 @@ import {filter, concat} from 'lodash/fp';
 
 import {getConfig} from '../../config';
 import type {AvailableContent, Config, State} from '../../types';
-import computeNextStep, {
+import {
+  computeNextStep,
   nextSlidePool,
   computeNextStepForNewChapter,
   prepareStateToSwitchChapters

--- a/packages/@coorpacademy-progression-engine/src/config/index.js
+++ b/packages/@coorpacademy-progression-engine/src/config/index.js
@@ -4,10 +4,12 @@ import type {Config, Engine, Progression} from '../types';
 import microlearning from './microlearning';
 import learner from './learner';
 import externalConfig from './external';
+import review from './review';
 
 const engineConfigurations = {
   microlearning,
   learner,
+  review,
   external: externalConfig
 };
 

--- a/packages/@coorpacademy-progression-engine/src/create-progression/index.js
+++ b/packages/@coorpacademy-progression-engine/src/create-progression/index.js
@@ -1,7 +1,31 @@
 // @flow
 import {getConfig} from '../config';
-import type {AvailableContent, GenericContent, Progression, Engine, EngineConfig} from '../types';
-import {computeInitialStep} from '../compute-next-step';
+import type {
+  Action,
+  AvailableContent,
+  Config,
+  GenericContent,
+  Progression,
+  Engine,
+  EngineConfig
+} from '../types';
+import {computeInitialStep, computeInitialStepForReview} from '../compute-next-step';
+
+const getActions = (
+  engine: Engine,
+  config: Config,
+  availableContent: AvailableContent
+): Array<Action> => {
+  if (engine.ref === 'external') {
+    return [];
+  }
+
+  if (engine.ref === 'review') {
+    return [computeInitialStepForReview(config, availableContent)];
+  }
+
+  return [computeInitialStep(config, availableContent)];
+};
 
 const createProgression = (
   engine: Engine,
@@ -13,6 +37,7 @@ const createProgression = (
     ...getConfig({ref: engine.ref, version: engine.version || 'latest'}),
     ...engineOptions
   };
+
   return {
     engine: {
       ...engine,
@@ -20,7 +45,7 @@ const createProgression = (
     },
     content,
     engineOptions,
-    actions: engine.ref === 'external' ? [] : [computeInitialStep(config, availableContent)]
+    actions: getActions(engine, config, availableContent)
   };
 };
 

--- a/packages/@coorpacademy-progression-engine/src/create-progression/test/index.js
+++ b/packages/@coorpacademy-progression-engine/src/create-progression/test/index.js
@@ -107,6 +107,41 @@ test('should create a new progression for external engine', t => {
   });
 });
 
+test('should create a new progression for review engine', t => {
+  const engine: Engine = {
+    ref: 'review',
+    version: 'latest'
+  };
+  const content: GenericContent = {
+    ref: 'skill_41BBqFKoS',
+    type: 'skill'
+  };
+  const engineOptions: EngineConfig = {
+    version: '1'
+  };
+  const progression = createProgression(engine, content, engineOptions, availableContentWithRules);
+  if (!progression) {
+    throw new Error('progression should not be falsy');
+  }
+  t.deepEqual(progression, {
+    engine: {ref: 'review', version: '1'},
+    content: {ref: 'skill_41BBqFKoS', type: 'skill'},
+    engineOptions: {version: '1'},
+    actions: [
+      {
+        type: 'move',
+        payload: {
+          nextContent: {
+            type: 'slide',
+            ref: '1.A1.1'
+          },
+          instructions: null
+        }
+      }
+    ]
+  });
+});
+
 test('should create a new progression with a custom version of the engine', t => {
   const engine: Engine = {
     ref: 'learner',

--- a/packages/@coorpacademy-progression-engine/src/types.js
+++ b/packages/@coorpacademy-progression-engine/src/types.js
@@ -408,10 +408,10 @@ export type Slide = {|
   lessons: Array<Lesson>
 |};
 
-export type ChapterContent = {|
+export type ContentContainer = {|
   ref: string,
   slides: Array<Slide>,
   rules: Array<ChapterRule> | null
 |};
 
-export type AvailableContent = Array<ChapterContent>;
+export type AvailableContent = Array<ContentContainer>;

--- a/packages/@coorpacademy-progression-engine/src/types.js
+++ b/packages/@coorpacademy-progression-engine/src/types.js
@@ -46,6 +46,7 @@ export type AUDIO = 'audio';
 export type SCORM = 'scorm';
 export type ARTICLE = 'article';
 export type PODCAST = 'podcast';
+export type SKILL = 'skill';
 export type ContentType =
   | DISCIPLINE
   | CHAPTER
@@ -60,7 +61,8 @@ export type ContentType =
   | VIDEO
   | SCORM
   | PODCAST
-  | ARTICLE;
+  | ARTICLE
+  | SKILL;
 
 export type LessonType = VIDEO | PDF | IMG;
 


### PR DESCRIPTION
https://trello.com/c/TCjT1J7z/2642-orprogression-engine-add-initstepforreview-function

**Detailed purpose of the PR**

This PR adds the `computeInitialStepForReview` function that allow `createProgression` to build the initialAction move for a progression of type review.

Also, the name used for the type of `AvailableContent`, that is an Array of `ChapterContent` was changed for a more generic one `ContentContainer`

```js
{
  ref: string,
  slides: Array<Slide>,
  rules: Array<ChapterRule> | null
}
```

This type is gonna be used also for review mode. `ref` would be the skill ref and slides is gonna be an array of one slide.

**Result and observation**

A new progression of type review is created with its initial step.
The compute of the `actions` property on the `createProgression` function was refactored to handle the review engine.

**Testing Strategy**

- Already covered by tests
- Unit testing
