### PR TITLE
update next content for review

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
@@ -12,7 +12,6 @@ import {
   sortBy,
   isEqual,
   isEmpty,
-  sample,
   shuffle,
   includes,
   findIndex,
@@ -376,20 +375,12 @@ const getNextSlide = (
 const getNextPendingSlide = (
   currentSlide: string,
   oldPendingSlides: Array<string>,
-  newPendingSlide: []
+  newPendingSlide: Array<string>
 ): string | null => {
   if (isEmpty(newPendingSlide)) return null;
 
   const indexPendingSlide = findIndex(s => s === currentSlide, oldPendingSlides) + 1;
-  console.log('indexPendingSlide', indexPendingSlide);
-  const index = indexPendingSlide === oldPendingSlides.length
-      ? 0
-      : indexPendingSlide;
-  console.log(`
-  
-  index ${index} 
-  
-  `);
+  const index = indexPendingSlide === oldPendingSlides.length ? 0 : indexPendingSlide;
 
   return oldPendingSlides[index];
 };
@@ -403,15 +394,6 @@ export const computeNextStepForReview = (
   const action = extendPartialAction(partialAction, _state);
   const isCorrect = !!action && action.type === 'answer' && !!action.payload.isCorrect;
   const state = !_state || !action ? _state : updateState(config, _state, [action]);
-  console.log(`
-  
-  
-  _state: ${JSON.stringify(_state)}
-  
-  state: ${JSON.stringify(state)}
-  
-  
-  `);
 
   const correctAnswers = state ? filter(a => a.isCorrect, state.allAnswers) : [];
   if (correctAnswers.length === config.slidesToComplete) {
@@ -432,17 +414,13 @@ export const computeNextStepForReview = (
       return null;
     } else {
       // if there is no more slides, two scenarios are possible
-      const pendingSlides = get('pendingSlides', _state);
+
+      const pendingSlides = !_state ? [] : _state.pendingSlides;
       const pendingSlide = getNextPendingSlide(
         state.nextContent.ref,
         pendingSlides,
         state.pendingSlides
       );
-      console.log(`
-      
-      pendingSlide ${pendingSlide}
-      
-      `);
 
       // all other questions have been already right answered, so we close the progression
       if (!pendingSlide) {

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
@@ -373,6 +373,27 @@ const getNextSlide = (
   return null;
 };
 
+const getNextPendingSlide = (
+  currentSlide: string,
+  oldPendingSlides: Array<string>,
+  newPendingSlide: []
+): string | null => {
+  if (isEmpty(newPendingSlide)) return null;
+
+  const indexPendingSlide = findIndex(s => s === currentSlide, oldPendingSlides) + 1;
+  console.log('indexPendingSlide', indexPendingSlide);
+  const index = indexPendingSlide === oldPendingSlides.length
+      ? 0
+      : indexPendingSlide;
+  console.log(`
+  
+  index ${index} 
+  
+  `);
+
+  return oldPendingSlides[index];
+};
+
 export const computeNextStepForReview = (
   config: Config,
   _state: State | null,
@@ -382,6 +403,15 @@ export const computeNextStepForReview = (
   const action = extendPartialAction(partialAction, _state);
   const isCorrect = !!action && action.type === 'answer' && !!action.payload.isCorrect;
   const state = !_state || !action ? _state : updateState(config, _state, [action]);
+  console.log(`
+  
+  
+  _state: ${JSON.stringify(_state)}
+  
+  state: ${JSON.stringify(state)}
+  
+  
+  `);
 
   const correctAnswers = state ? filter(a => a.isCorrect, state.allAnswers) : [];
   if (correctAnswers.length === config.slidesToComplete) {
@@ -402,7 +432,18 @@ export const computeNextStepForReview = (
       return null;
     } else {
       // if there is no more slides, two scenarios are possible
-      const pendingSlide = sample(state.pendingSlides);
+      const pendingSlides = get('pendingSlides', _state);
+      const pendingSlide = getNextPendingSlide(
+        state.nextContent.ref,
+        pendingSlides,
+        state.pendingSlides
+      );
+      console.log(`
+      
+      pendingSlide ${pendingSlide}
+      
+      `);
+
       // all other questions have been already right answered, so we close the progression
       if (!pendingSlide) {
         return null;

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
@@ -365,9 +365,9 @@ const getNextSlide = (
 ): Slide | null => {
   if (!state) return get(['0', 'slides', '0'], availableContent);
 
-  const current = get('step.current', state) - 1;
-  if (current < config.slidesToComplete) {
-    return get(['0', 'slides', `${current}`], availableContent);
+  const current = get('step.current', state);
+  if (current <= config.slidesToComplete) {
+    return get(['0', 'slides', '1'], availableContent);
   }
 
   return null;

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
@@ -16,8 +16,7 @@ import {
   shuffle,
   includes,
   findIndex,
-  intersection,
-  toString as _toString
+  intersection
 } from 'lodash/fp';
 
 import type {

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-initial-step-for-review.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-initial-step-for-review.js
@@ -1,6 +1,5 @@
 // @flow
 import test from 'ava';
-import {head} from 'lodash/fp';
 import {getConfig} from '../../config';
 import type {AvailableContent, Config} from '../../types';
 import {computeInitialStepForReview} from '..';
@@ -11,7 +10,7 @@ const config: Config = getConfig({ref: 'review', version: '1'});
 const availableContent: AvailableContent = [
   {
     ref: 'skill_41BBqFKoS',
-    slides: [head(allSlides)],
+    slides: allSlides,
     rules: null
   }
 ];

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step-after-answer.review.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step-after-answer.review.js
@@ -311,7 +311,7 @@ test('should return one pending slide when user has answered the 5th slide', t =
         type: 'slide'
       },
       answer: ['foo', 'bar'],
-      godMode: true
+      godMode: false
     }
   };
 
@@ -339,26 +339,26 @@ test('should return one pending slide when user has answered the 5th slide', t =
         ref: '1.A1.5',
         type: 'slide'
       },
-      godMode: true,
+      godMode: false,
       nextContent: {
         type: 'slide',
         ref: '1.A1.2'
       },
-      isCorrect: true,
+      isCorrect: false,
       instructions: null
     }
   });
 });
 
 test('should return the next wrong slide when user has finished the 5 slides and has still remaining questions to validate', t => {
-  const partialAction = {
+  const answerForSlide2 = {
     type: 'answer',
     payload: {
       content: {
         ref: '1.A1.2',
         type: 'slide'
       },
-      answer: ['foo', 'bar'],
+      answer: ['foo'],
       godMode: false
     }
   };
@@ -371,31 +371,82 @@ test('should return the next wrong slide when user has finished the 5 slides and
     }
   ];
 
-  const nextStep = computeNextStepAfterAnswerForReview(
+  const nextStepWithSlide4 = computeNextStepAfterAnswerForReview(
     config,
     wrongAnswersAfterLastStepStateReview,
     availableContent,
     secondSlide,
-    partialAction
+    answerForSlide2
   );
 
-  if (!nextStep) {
+  if (!nextStepWithSlide4) {
     t.fail();
     return;
   }
-  t.is(nextStep.type, 'answer');
-  t.deepEqual(nextStep.payload.answer, ['foo', 'bar']);
-  t.deepEqual(nextStep.payload.content, {
-    ref: '1.A1.2',
-    type: 'slide'
+  t.deepEqual(nextStepWithSlide4, {
+    type: 'answer',
+    payload: {
+      answer: ['foo'],
+      content: {
+        ref: '1.A1.2',
+        type: 'slide'
+      },
+      godMode: false,
+      nextContent: {
+        type: 'slide',
+        ref: '1.A1.4'
+      },
+      isCorrect: false,
+      instructions: null
+    }
   });
-  t.false(nextStep.payload.godMode);
-  t.true(nextStep.payload.isCorrect);
-  t.is(nextStep.payload.instructions, null);
-  t.is(nextStep.payload.nextContent.type, 'slide');
-  t.true(
-    wrongAnswersAfterLastStepStateReview.pendingSlides.includes(nextStep.payload.nextContent.ref)
+
+  const answerForSlide4 = {
+    type: 'answer',
+    payload: {
+      content: {
+        ref: '1.A1.4',
+        type: 'slide'
+      },
+      answer: ['foo'],
+      godMode: false
+    }
+  };
+
+  const nextStepWithSlide5 = computeNextStepAfterAnswerForReview(
+    config,
+    {
+      ...wrongAnswersAfterLastStepStateReview,
+      nextContent: {
+        ref: '1.A1.4',
+        type: 'slide'
+      }
+    },
+    availableContent,
+    fourthSlide,
+    answerForSlide4
   );
+  if (!nextStepWithSlide5) {
+    t.fail();
+    return;
+  }
+  t.deepEqual(nextStepWithSlide5, {
+    type: 'answer',
+    payload: {
+      answer: ['foo'],
+      content: {
+        ref: '1.A1.4',
+        type: 'slide'
+      },
+      godMode: false,
+      nextContent: {
+        type: 'slide',
+        ref: '1.A1.5'
+      },
+      isCorrect: false,
+      instructions: null
+    }
+  });
 });
 
 test('should return the same slide when user has answered wrong, has finished the 5 slides and has still remaining one questions to validate', t => {

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step-after-answer.review.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step-after-answer.review.js
@@ -19,7 +19,7 @@ const [firstSlide, secondSlide, thirdSlide, fifthSlide, fourthSlide] = allSlides
 
 const config: Config = getConfig({ref: 'review', version: '1'});
 
-test('should return the next slide when user has answered the first slide and there is an available slide', t => {
+test('should return the next slide when user has answered the 1st slide and there are available slides', t => {
   const partialAction = {
     type: 'answer',
     payload: {
@@ -66,7 +66,7 @@ test('should return the next slide when user has answered the first slide and th
   });
 });
 
-test('should return the next slide when user has answered the second slide and there is an available slide', t => {
+test('should return the next slide when user has answered the 2nd slide and there are available slides', t => {
   const partialAction = {
     type: 'answer',
     payload: {
@@ -113,7 +113,7 @@ test('should return the next slide when user has answered the second slide and t
   });
 });
 
-test('should return the next slide when user has answered the third slide and there is an available slide', t => {
+test('should return the next slide when user has answered the 3rd slide and there are available slides', t => {
   const partialAction = {
     type: 'answer',
     payload: {
@@ -160,7 +160,7 @@ test('should return the next slide when user has answered the third slide and th
   });
 });
 
-test('should return the next slide when user has answered the fourth slide and there is an available slide', t => {
+test('should return the next slide when user has answered the 4th slide and there are available slides', t => {
   const partialAction = {
     type: 'answer',
     payload: {
@@ -207,7 +207,7 @@ test('should return the next slide when user has answered the fourth slide and t
   });
 });
 
-test('should return the exitNode when user is finishing the 5th slide correctly, all other are also true and there is no more available slide', t => {
+test('should return the exitNode when user has answered the 5th slide correctly, all other are also true', t => {
   const partialAction = {
     type: 'answer',
     payload: {
@@ -280,7 +280,7 @@ test('should return the exitNode when user has only one question correct and the
     config,
     firstStateReview,
     availableContent,
-    allSlides[0],
+    firstSlide,
     partialAction
   );
   t.deepEqual(nextStep, {
@@ -302,7 +302,7 @@ test('should return the exitNode when user has only one question correct and the
   });
 });
 
-test('should return the first pending slide when user has finished the 5 slides, all are true and there is no available slide', t => {
+test('should return one pending slide when user has answered the 5th slide', t => {
   const partialAction = {
     type: 'answer',
     payload: {
@@ -366,7 +366,7 @@ test('should return the next wrong slide when user has finished the 5 slides and
   const availableContent: AvailableContent = [
     {
       ref: 'skill_41BBqFKoS',
-      slides: [],
+      slides: allSlides,
       rules: null
     }
   ];
@@ -375,7 +375,7 @@ test('should return the next wrong slide when user has finished the 5 slides and
     config,
     wrongAnswersAfterLastStepStateReview,
     availableContent,
-    allSlides[1],
+    secondSlide,
     partialAction
   );
 
@@ -414,7 +414,7 @@ test('should return the same slide when user has answered wrong, has finished th
   const availableContent: AvailableContent = [
     {
       ref: 'skill_41BBqFKoS',
-      slides: [],
+      slides: allSlides,
       rules: null
     }
   ];
@@ -423,7 +423,7 @@ test('should return the same slide when user has answered wrong, has finished th
     config,
     stillOneWrongAnswersAfterLastStepStateReview,
     availableContent,
-    allSlides[4],
+    fourthSlide,
     partialAction
   );
 
@@ -471,7 +471,7 @@ test('should return the successExitNode when user has finished the 5 slides afte
     config,
     stillOneWrongAnswersAfterLastStepStateReview,
     availableContent,
-    allSlides[4],
+    fourthSlide,
     partialAction
   );
 

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step-after-answer.review.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step-after-answer.review.js
@@ -6,6 +6,7 @@ import {computeNextStepAfterAnswerForReview} from '..';
 import allSlides from './fixtures/slides';
 import {
   firstStateReview,
+  secondStateReview,
   allRightAnswersBeforeLastStepStateReview,
   wrongAnswersBeforeLastStepStateReview,
   wrongAnswersAfterLastStepStateReview,
@@ -30,7 +31,7 @@ test('should return the next slide when user has answered the first slide and th
   const availableContent: AvailableContent = [
     {
       ref: 'skill_41BBqFKoS',
-      slides: [allSlides[1]],
+      slides: allSlides,
       rules: null
     }
   ];
@@ -53,6 +54,53 @@ test('should return the next slide when user has answered the first slide and th
       godMode: false,
       nextContent: {
         ref: '1.A1.2',
+        type: 'slide'
+      },
+      isCorrect: true,
+      instructions: null
+    }
+  });
+});
+
+test('should return the next slide when user has answered the second slide and there is an available slide', t => {
+  const partialAction = {
+    type: 'answer',
+    payload: {
+      content: {
+        ref: '1.A1.2',
+        type: 'slide'
+      },
+      answer: ['foo', 'bar'],
+      godMode: true
+    }
+  };
+
+  const availableContent: AvailableContent = [
+    {
+      ref: 'skill_41BBqFKoS',
+      slides: allSlides,
+      rules: null
+    }
+  ];
+
+  const nextStep = computeNextStepAfterAnswerForReview(
+    config,
+    secondStateReview,
+    availableContent,
+    allSlides[1],
+    partialAction
+  );
+  t.deepEqual(nextStep, {
+    type: 'answer',
+    payload: {
+      answer: ['foo', 'bar'],
+      content: {
+        ref: '1.A1.2',
+        type: 'slide'
+      },
+      godMode: true,
+      nextContent: {
+        ref: '1.A1.3',
         type: 'slide'
       },
       isCorrect: true,
@@ -172,7 +220,7 @@ test('should return the first pending slide when user has finished the 5 slides,
   const availableContent: AvailableContent = [
     {
       ref: 'skill_41BBqFKoS',
-      slides: [],
+      slides: allSlides,
       rules: null
     }
   ];
@@ -316,7 +364,7 @@ test('should return the successExitNode when user has finished the 5 slides afte
   const availableContent: AvailableContent = [
     {
       ref: 'skill_41BBqFKoS',
-      slides: [],
+      slides: allSlides,
       rules: null
     }
   ];

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step-after-answer.review.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step-after-answer.review.js
@@ -7,11 +7,15 @@ import allSlides from './fixtures/slides';
 import {
   firstStateReview,
   secondStateReview,
+  thirdStateReview,
+  fourthStateReview,
   allRightAnswersBeforeLastStepStateReview,
   wrongAnswersBeforeLastStepStateReview,
   wrongAnswersAfterLastStepStateReview,
   stillOneWrongAnswersAfterLastStepStateReview
 } from './fixtures/states';
+// on fixtures the order is 1, 2, 3, 5, 4
+const [firstSlide, secondSlide, thirdSlide, fifthSlide, fourthSlide] = allSlides;
 
 const config: Config = getConfig({ref: 'review', version: '1'});
 
@@ -31,7 +35,7 @@ test('should return the next slide when user has answered the first slide and th
   const availableContent: AvailableContent = [
     {
       ref: 'skill_41BBqFKoS',
-      slides: allSlides,
+      slides: [firstSlide, secondSlide, thirdSlide, fourthSlide, fifthSlide],
       rules: null
     }
   ];
@@ -40,7 +44,7 @@ test('should return the next slide when user has answered the first slide and th
     config,
     firstStateReview,
     availableContent,
-    allSlides[0],
+    firstSlide,
     partialAction
   );
   t.deepEqual(nextStep, {
@@ -78,7 +82,7 @@ test('should return the next slide when user has answered the second slide and t
   const availableContent: AvailableContent = [
     {
       ref: 'skill_41BBqFKoS',
-      slides: allSlides,
+      slides: [secondSlide, thirdSlide, fourthSlide, fifthSlide],
       rules: null
     }
   ];
@@ -87,7 +91,7 @@ test('should return the next slide when user has answered the second slide and t
     config,
     secondStateReview,
     availableContent,
-    allSlides[1],
+    secondSlide,
     partialAction
   );
   t.deepEqual(nextStep, {
@@ -122,20 +126,19 @@ test('should return the next slide when user has answered the third slide and th
     }
   };
 
-  const [, ...slides] = allSlides;
   const availableContent: AvailableContent = [
     {
       ref: 'skill_41BBqFKoS',
-      slides,
+      slides: [thirdSlide, fourthSlide, fifthSlide],
       rules: null
     }
   ];
 
   const nextStep = computeNextStepAfterAnswerForReview(
     config,
-    secondStateReview,
+    thirdStateReview,
     availableContent,
-    allSlides[1],
+    thirdSlide,
     partialAction
   );
   t.deepEqual(nextStep, {
@@ -143,13 +146,108 @@ test('should return the next slide when user has answered the third slide and th
     payload: {
       answer: ['foo', 'bar'],
       content: {
-        ref: '1.A1.2',
+        ref: '1.A1.3',
         type: 'slide'
       },
       godMode: true,
       nextContent: {
-        ref: '1.A1.3',
+        ref: '1.A1.4',
         type: 'slide'
+      },
+      isCorrect: true,
+      instructions: null
+    }
+  });
+});
+
+test('should return the next slide when user has answered the fourth slide and there is an available slide', t => {
+  const partialAction = {
+    type: 'answer',
+    payload: {
+      content: {
+        ref: '1.A1.4',
+        type: 'slide'
+      },
+      answer: ['foo', 'bar'],
+      godMode: true
+    }
+  };
+
+  const availableContent: AvailableContent = [
+    {
+      ref: 'skill_41BBqFKoS',
+      slides: [fourthSlide, fifthSlide],
+      rules: null
+    }
+  ];
+
+  const nextStep = computeNextStepAfterAnswerForReview(
+    config,
+    fourthStateReview,
+    availableContent,
+    fourthSlide,
+    partialAction
+  );
+  t.deepEqual(nextStep, {
+    type: 'answer',
+    payload: {
+      answer: ['foo', 'bar'],
+      content: {
+        ref: '1.A1.4',
+        type: 'slide'
+      },
+      godMode: true,
+      nextContent: {
+        ref: '1.A1.5',
+        type: 'slide'
+      },
+      isCorrect: true,
+      instructions: null
+    }
+  });
+});
+
+test('should return the exitNode when user is finishing the 5th slide correctly, all other are also true and there is no more available slide', t => {
+  const partialAction = {
+    type: 'answer',
+    payload: {
+      content: {
+        ref: '1.A1.5',
+        type: 'slide'
+      },
+      answer: ['foo', 'bar'],
+      godMode: true
+    }
+  };
+
+  const availableContent: AvailableContent = [
+    {
+      ref: 'skill_41BBqFKoS',
+      slides: [fifthSlide],
+      rules: null
+    }
+  ];
+
+  const nextStep = computeNextStepAfterAnswerForReview(
+    config,
+    allRightAnswersBeforeLastStepStateReview,
+    availableContent,
+    fifthSlide,
+    partialAction
+  );
+
+  t.deepEqual(nextStep, {
+    type: 'answer',
+    payload: {
+      answer: ['foo', 'bar'],
+      content: {
+        ref: '1.A1.5',
+        type: 'slide'
+      },
+      godMode: true,
+      nextContent: {
+        type: 'success',
+        ref: 'successExitNode'
       },
       isCorrect: true,
       instructions: null
@@ -204,54 +302,6 @@ test('should return the exitNode when user has only one question correct and the
   });
 });
 
-test('should return the exitNode when user is finishing the 5th slide correctly, all other are also true and there is no more available slide', t => {
-  const partialAction = {
-    type: 'answer',
-    payload: {
-      content: {
-        ref: '1.A1.5',
-        type: 'slide'
-      },
-      answer: ['foo', 'bar'],
-      godMode: true
-    }
-  };
-
-  const availableContent: AvailableContent = [
-    {
-      ref: 'skill_41BBqFKoS',
-      slides: [],
-      rules: null
-    }
-  ];
-
-  const nextStep = computeNextStepAfterAnswerForReview(
-    config,
-    allRightAnswersBeforeLastStepStateReview,
-    availableContent,
-    allSlides[4],
-    partialAction
-  );
-
-  t.deepEqual(nextStep, {
-    type: 'answer',
-    payload: {
-      answer: ['foo', 'bar'],
-      content: {
-        ref: '1.A1.5',
-        type: 'slide'
-      },
-      godMode: true,
-      nextContent: {
-        type: 'success',
-        ref: 'successExitNode'
-      },
-      isCorrect: true,
-      instructions: null
-    }
-  });
-});
-
 test('should return the first pending slide when user has finished the 5 slides, all are true and there is no available slide', t => {
   const partialAction = {
     type: 'answer',
@@ -265,11 +315,10 @@ test('should return the first pending slide when user has finished the 5 slides,
     }
   };
 
-  const [, , , , , ...slides] = allSlides;
   const availableContent: AvailableContent = [
     {
       ref: 'skill_41BBqFKoS',
-      slides,
+      slides: [fifthSlide],
       rules: null
     }
   ];
@@ -278,7 +327,7 @@ test('should return the first pending slide when user has finished the 5 slides,
     config,
     wrongAnswersBeforeLastStepStateReview,
     availableContent,
-    allSlides[4],
+    fifthSlide,
     partialAction
   );
 

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step-after-answer.review.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step-after-answer.review.js
@@ -109,6 +109,54 @@ test('should return the next slide when user has answered the second slide and t
   });
 });
 
+test('should return the next slide when user has answered the third slide and there is an available slide', t => {
+  const partialAction = {
+    type: 'answer',
+    payload: {
+      content: {
+        ref: '1.A1.3',
+        type: 'slide'
+      },
+      answer: ['foo', 'bar'],
+      godMode: true
+    }
+  };
+
+  const [, ...slides] = allSlides;
+  const availableContent: AvailableContent = [
+    {
+      ref: 'skill_41BBqFKoS',
+      slides,
+      rules: null
+    }
+  ];
+
+  const nextStep = computeNextStepAfterAnswerForReview(
+    config,
+    secondStateReview,
+    availableContent,
+    allSlides[1],
+    partialAction
+  );
+  t.deepEqual(nextStep, {
+    type: 'answer',
+    payload: {
+      answer: ['foo', 'bar'],
+      content: {
+        ref: '1.A1.2',
+        type: 'slide'
+      },
+      godMode: true,
+      nextContent: {
+        ref: '1.A1.3',
+        type: 'slide'
+      },
+      isCorrect: true,
+      instructions: null
+    }
+  });
+});
+
 test('should return the exitNode when user has only one question correct and there is no available slide', t => {
   const partialAction = {
     type: 'answer',
@@ -217,10 +265,11 @@ test('should return the first pending slide when user has finished the 5 slides,
     }
   };
 
+  const [, , , , , ...slides] = allSlides;
   const availableContent: AvailableContent = [
     {
       ref: 'skill_41BBqFKoS',
-      slides: allSlides,
+      slides,
       rules: null
     }
   ];

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/fixtures/states.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/fixtures/states.js
@@ -456,7 +456,7 @@ export const wrongAnswersBeforeLastStepStateReview: State = {
     },
     {
       slideRef: '1.A1.3',
-      isCorrect: true,
+      isCorrect: false,
       answer: ['foo']
     },
     {
@@ -466,7 +466,7 @@ export const wrongAnswersBeforeLastStepStateReview: State = {
     }
   ],
   variables: {},
-  pendingSlides: ['1.A1.2']
+  pendingSlides: ['1.A1.2', '1.A1.3']
 };
 
 export const wrongAnswersAfterLastStepStateReview: State = {
@@ -509,12 +509,12 @@ export const wrongAnswersAfterLastStepStateReview: State = {
     },
     {
       slideRef: '1.A1.5',
-      isCorrect: true,
+      isCorrect: false,
       answer: ['foo']
     }
   ],
   variables: {},
-  pendingSlides: ['1.A1.2', '1.A1.4']
+  pendingSlides: ['1.A1.2', '1.A1.4', '1.A1.5']
 };
 
 export const stillOneWrongAnswersAfterLastStepStateReview: State = {

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/fixtures/states.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/fixtures/states.js
@@ -284,6 +284,34 @@ export const firstStateReview: State = {
   pendingSlides: []
 };
 
+export const secondStateReview: State = {
+  nextContent: {
+    ref: '1.A1.2',
+    type: 'slide'
+  },
+  lives: 0,
+  livesDisabled: true,
+  stars: 8,
+  slides: ['1.A1.1'],
+  requestedClues: [],
+  viewedResources: [],
+  step: {
+    current: 2
+  },
+  isCorrect: null,
+  remainingLifeRequests: 0,
+  hasViewedAResourceAtThisStep: false,
+  allAnswers: [
+    {
+      slideRef: '1.A1.1',
+      isCorrect: true,
+      answer: ['foo', 'bar']
+    }
+  ],
+  variables: {},
+  pendingSlides: []
+};
+
 export const allRightAnswersBeforeLastStepStateReview: State = {
   nextContent: {
     ref: '1.A1.5',

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/fixtures/states.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/fixtures/states.js
@@ -312,6 +312,77 @@ export const secondStateReview: State = {
   pendingSlides: []
 };
 
+export const thirdStateReview: State = {
+  nextContent: {
+    ref: '1.A1.3',
+    type: 'slide'
+  },
+  lives: 0,
+  livesDisabled: true,
+  stars: 16,
+  slides: ['1.A1.1', '1.A1.2'],
+  requestedClues: [],
+  viewedResources: [],
+  step: {
+    current: 2
+  },
+  isCorrect: null,
+  remainingLifeRequests: 0,
+  hasViewedAResourceAtThisStep: false,
+  allAnswers: [
+    {
+      slideRef: '1.A1.1',
+      isCorrect: true,
+      answer: ['foo', 'bar']
+    },
+    {
+      slideRef: '1.A1.2',
+      isCorrect: true,
+      answer: ['foo', 'bar']
+    }
+  ],
+  variables: {},
+  pendingSlides: []
+};
+
+export const fourthStateReview: State = {
+  nextContent: {
+    ref: '1.A1.4',
+    type: 'slide'
+  },
+  lives: 0,
+  livesDisabled: true,
+  stars: 32,
+  slides: ['1.A1.1', '1.A1.2', '1.A1.3'],
+  requestedClues: [],
+  viewedResources: [],
+  step: {
+    current: 2
+  },
+  isCorrect: null,
+  remainingLifeRequests: 0,
+  hasViewedAResourceAtThisStep: false,
+  allAnswers: [
+    {
+      slideRef: '1.A1.1',
+      isCorrect: true,
+      answer: ['foo', 'bar']
+    },
+    {
+      slideRef: '1.A1.2',
+      isCorrect: true,
+      answer: ['foo', 'bar']
+    },
+    {
+      slideRef: '1.A1.3',
+      isCorrect: true,
+      answer: ['foo', 'bar']
+    }
+  ],
+  variables: {},
+  pendingSlides: []
+};
+
 export const allRightAnswersBeforeLastStepStateReview: State = {
   nextContent: {
     ref: '1.A1.5',

--- a/packages/@coorpacademy-progression-engine/src/test/update-state.js
+++ b/packages/@coorpacademy-progression-engine/src/test/update-state.js
@@ -585,7 +585,7 @@ test('should update pendingSlides when answer is wrong', t => {
   });
 });
 
-test('should update pendingSlides when a pending slide if finally correctly answeres', t => {
+test('should update pendingSlides when a pending slide if finally correctly answered', t => {
   const configReview = getConfig({
     ref: 'review',
     version: '1'
@@ -654,7 +654,7 @@ test('should update pendingSlides when a pending slide if finally correctly answ
       },
       {
         slideRef: '1.A1.5',
-        isCorrect: true,
+        isCorrect: false,
         answer: ['foo']
       },
       {
@@ -664,6 +664,6 @@ test('should update pendingSlides when a pending slide if finally correctly answ
       }
     ],
     variables: {},
-    pendingSlides: ['1.A1.4']
+    pendingSlides: ['1.A1.4', '1.A1.5']
   });
 });


### PR DESCRIPTION
 https://trello.com/c/3nSz5f04/2667-or-update-computenextstep-for-review-available-content-contient-un-tableau-de-slides

**Detailed purpose of the PR**

Before available content send only one slide (the next content), but we found that this can be used only for the initialisation of the progression. For the next steps, the next slide was always the current slide. So this PR allows to have an array of slides and pick the nextSlide according to the current step on the state if we've not finished the `slidesToComplete` and then pick the ref of the next slide from pendingSlides.

**Testing Strategy**

- Already covered by tests
- Unit testing
