### PR TITLE
Fix - mooc menu for iphone SE

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -578,14 +578,14 @@
     height: auto;
     background-color: white;
     left: 0;
-    top: -100%;
+    top: -100vh;
     width: 100%;
     transition: top 0.8s ease-out;
     max-height: 100vh;
   }
 
   .menuWrapper:last-child  {
-    padding-bottom: 40px;  
+    padding-bottom: 60px;  
   }
 
   .hiddenSearchBar {


### PR DESCRIPTION
[IDEA 4288 - Header (version web) devient non responsive sur certains devices](https://app.prodpad.com/ideas/4288/canvas)
Demande Safran : Le header ne semble pas responsive sur certaines pages (web) sur un iPhone XS et un iPhone SE avec l'avant dernière version d'iOS
photos et boutons qui ne devraient pas être visibles apparaissent coupés

https://user-images.githubusercontent.com/15608581/176661050-55fc5ee1-4978-45dd-9c49-e74b143a83bb.mp4



**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
