### PR TITLE
[App-review] Type thunks actions

### DIFF
--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-skills.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-skills.ts
@@ -13,10 +13,10 @@ export interface ReceivedSkills extends AnyAction {
   payload: Skill[];
 }
 
-export type PostProgressionAction = ThunkAction<Promise<void>, StoreState, Options, AnyAction>;
+export type FetchSKillsAction = ThunkAction<Promise<void>, StoreState, Options, AnyAction>;
 type Dispatch = ThunkDispatch<StoreState, Options, AnyAction>;
 
-export const fetchSkills = (token: string): PostProgressionAction =>
+export const fetchSkills = (token: string): FetchSKillsAction =>
   buildTask({
     types: [SKILLS_FETCH_REQUEST, SKILLS_FETCH_SUCCESS, SKILLS_FETCH_FAILURE],
     task: (dispatch: Dispatch, getState: () => StoreState, {services}: Options) =>

--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-skills.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-skills.ts
@@ -13,10 +13,10 @@ export interface ReceivedSkills extends AnyAction {
   payload: Skill[];
 }
 
-export type FetchSKillsAction = ThunkAction<Promise<void>, StoreState, Options, AnyAction>;
+export type FetchSkillsAction = ThunkAction<Promise<void>, StoreState, Options, AnyAction>;
 type Dispatch = ThunkDispatch<StoreState, Options, AnyAction>;
 
-export const fetchSkills = (token: string): FetchSKillsAction =>
+export const fetchSkills = (token: string): FetchSkillsAction =>
   buildTask({
     types: [SKILLS_FETCH_REQUEST, SKILLS_FETCH_SUCCESS, SKILLS_FETCH_FAILURE],
     task: (dispatch: Dispatch, getState: () => StoreState, {services}: Options) =>

--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-skills.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-skills.ts
@@ -1,5 +1,6 @@
 import buildTask from '@coorpacademy/redux-task';
-import {Action, Dispatch} from 'redux';
+import type {ThunkAction, ThunkDispatch} from 'redux-thunk';
+import {AnyAction} from 'redux';
 import type {StoreState} from '../../reducers';
 import {Options, Skill} from '../../types/common';
 
@@ -7,12 +8,15 @@ export const SKILLS_FETCH_REQUEST = '@@skills/FETCH_REQUEST' as const;
 export const SKILLS_FETCH_SUCCESS = '@@skills/FETCH_SUCCESS' as const;
 export const SKILLS_FETCH_FAILURE = '@@skills/FETCH_FAILURE' as const;
 
-export type ReceivedSkills = {
+export interface ReceivedSkills extends AnyAction {
   type: '@@skills/FETCH_SUCCESS';
   payload: Skill[];
-};
+}
 
-export const fetchSkills = (token: string): Action =>
+export type PostProgressionAction = ThunkAction<Promise<void>, StoreState, Options, AnyAction>;
+type Dispatch = ThunkDispatch<StoreState, Options, AnyAction>;
+
+export const fetchSkills = (token: string): PostProgressionAction =>
   buildTask({
     types: [SKILLS_FETCH_REQUEST, SKILLS_FETCH_SUCCESS, SKILLS_FETCH_FAILURE],
     task: (dispatch: Dispatch, getState: () => StoreState, {services}: Options) =>

--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-slide.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-slide.ts
@@ -1,4 +1,5 @@
-import type {Action, Dispatch} from 'redux';
+import type {AnyAction} from 'redux';
+import type {ThunkAction, ThunkDispatch} from 'redux-thunk';
 import buildTask from '@coorpacademy/redux-task';
 import type {StoreState} from '../../reducers';
 import {Options, SlideFromAPI} from '../../types/common';
@@ -7,12 +8,15 @@ export const SLIDE_FETCH_REQUEST = '@@slides/FETCH_REQUEST' as const;
 export const SLIDE_FETCH_SUCCESS = '@@slides/FETCH_SUCCESS' as const;
 export const SLIDE_FETCH_FAILURE = '@@slides/FETCH_FAILURE' as const;
 
-export type ReceivedSlide = {
+export interface ReceivedSlide extends AnyAction {
   type: typeof SLIDE_FETCH_SUCCESS;
   payload: SlideFromAPI;
-};
+}
 
-export const fetchSlide = (slideRef: string, token: string): Action =>
+export type FetchSlideAction = ThunkAction<Promise<void>, StoreState, Options, AnyAction>;
+type Dispatch = ThunkDispatch<StoreState, Options, AnyAction>;
+
+export const fetchSlide = (slideRef: string, token: string): FetchSlideAction =>
   buildTask({
     types: [SLIDE_FETCH_REQUEST, SLIDE_FETCH_SUCCESS, SLIDE_FETCH_FAILURE],
     task: (dispatch: Dispatch, getState: () => StoreState, {services}: Options) =>

--- a/packages/@coorpacademy-app-review/src/actions/api/post-progression.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/post-progression.ts
@@ -1,4 +1,5 @@
-import type {Action, Dispatch} from 'redux';
+import type {AnyAction, Dispatch} from 'redux';
+import type {ThunkAction} from 'redux-thunk';
 import buildTask from '@coorpacademy/redux-task';
 import {Options, ProgressionFromAPI} from '../../types/common';
 import type {StoreState} from '../../reducers';
@@ -13,8 +14,15 @@ export type ReceiveProgression = {
   payload: ProgressionFromAPI;
 };
 
-export const postProgression = (skillRef: string, token: string): Action =>
-  buildTask({
+export type PostProgressionAction = ThunkAction<
+  Promise<ProgressionFromAPI>,
+  StoreState,
+  Options,
+  AnyAction
+>;
+
+export const postProgression = (skillRef: string, token: string): PostProgressionAction => 
+buildTask({
     types: [POST_PROGRESSION_REQUEST, POST_PROGRESSION_SUCCESS, POST_PROGRESSION_FAILURE],
     task: (dispatch: Dispatch, getState: () => StoreState, {services}: Options) => {
       return services.postProgression(skillRef, token).then((progression: ProgressionFromAPI) => {

--- a/packages/@coorpacademy-app-review/src/actions/api/post-progression.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/post-progression.ts
@@ -1,5 +1,5 @@
-import type {AnyAction, Dispatch} from 'redux';
-import type {ThunkAction} from 'redux-thunk';
+import type {AnyAction} from 'redux';
+import type {ThunkAction, ThunkDispatch} from 'redux-thunk';
 import buildTask from '@coorpacademy/redux-task';
 import {Options, ProgressionFromAPI} from '../../types/common';
 import type {StoreState} from '../../reducers';
@@ -9,10 +9,10 @@ export const POST_PROGRESSION_REQUEST = '@@progression/POST_REQUEST' as const;
 export const POST_PROGRESSION_SUCCESS = '@@progression/POST_SUCCESS' as const;
 export const POST_PROGRESSION_FAILURE = '@@progression/POST_FAILURE' as const;
 
-export type ReceiveProgression = {
+export interface ReceiveProgression extends AnyAction {
   type: typeof POST_PROGRESSION_SUCCESS;
   payload: ProgressionFromAPI;
-};
+}
 
 export type PostProgressionAction = ThunkAction<
   Promise<ProgressionFromAPI>,
@@ -21,8 +21,10 @@ export type PostProgressionAction = ThunkAction<
   AnyAction
 >;
 
-export const postProgression = (skillRef: string, token: string): PostProgressionAction => 
-buildTask({
+type Dispatch = ThunkDispatch<StoreState, Options, AnyAction>;
+
+export const postProgression = (skillRef: string, token: string): PostProgressionAction =>
+  buildTask({
     types: [POST_PROGRESSION_REQUEST, POST_PROGRESSION_SUCCESS, POST_PROGRESSION_FAILURE],
     task: (dispatch: Dispatch, getState: () => StoreState, {services}: Options) => {
       return services.postProgression(skillRef, token).then((progression: ProgressionFromAPI) => {

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useState} from 'react';
+import type {} from 'redux-thunk/extend-redux'; // https://github.com/reduxjs/redux-thunk/issues/333
 import {AnyAction, Store} from 'redux';
 import {connect, Provider} from 'react-redux';
 import AppReviewTemplate from '@coorpacademy/components/es/template/app-review';
@@ -20,9 +21,8 @@ import {updateFinishedSlides} from './actions/ui/finished-slides';
 import {updateReviewStatus} from './actions/ui/review-status';
 import {updateStepItemsOnValidation, updateStepItemsOnNext} from './actions/ui/step-items';
 import {fetchSkills} from './actions/api/fetch-skills';
-import {postProgression, PostProgressionAction} from './actions/api/post-progression';
+import {postProgression} from './actions/api/post-progression';
 import {VIEWS} from './common';
-import {FetchSlideAction} from './actions/api/fetch-slide';
 
 // -----------------------------------------------------------------------------
 
@@ -154,6 +154,8 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
     if (store === null) return;
 
     const {skillRef, token} = options;
+    // ThunkAction is not assignable to parameter of type 'AnyAction'
+    // ts problem describre here = https://github.com/reduxjs/redux-thunk/issues/333
     skillRef
       ? store.dispatch(postProgression(skillRef, token))
       : store.dispatch(fetchSkills(token));

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -24,15 +24,11 @@ import {fetchSkills} from './actions/api/fetch-skills';
 import {postProgression} from './actions/api/post-progression';
 import {VIEWS} from './common';
 
-// -----------------------------------------------------------------------------
-
 type StaticProps = {
   viewName: 'skills' | 'onboarding' | 'slides';
   slides: SlidesViewStaticProps | null;
   skills: SkillsProps | null;
 };
-
-// -----------------------------------------------------------------------------
 
 const mapDispatchToProps: Dispatchers = {
   navigateTo,
@@ -48,8 +44,6 @@ const mapDispatchToProps: Dispatchers = {
 
 const getCurrentViewName = (storeState: StoreState): ViewPath =>
   storeState.ui.navigation[storeState.ui.navigation.length - 1];
-
-// -----------------------------------------------------------------------------
 
 const mapStateToSkillsProps = (state: StoreState): SkillsProps | null => {
   if (!state.data.skills) {
@@ -77,8 +71,6 @@ const mapStateToSkillsProps = (state: StoreState): SkillsProps | null => {
     }))
   };
 };
-
-// -----------------------------------------------------------------------------
 
 const mapStateToSlidesProps = (state: StoreState): SlidesViewStaticProps | null => {
   if (!state.data.slides) {
@@ -109,8 +101,6 @@ const mapStateToSlidesProps = (state: StoreState): SlidesViewStaticProps | null 
   };
 };
 
-// -----------------------------------------------------------------------------
-
 const mapStateToProps = (state: StoreState): StaticProps => {
   return {
     viewName: getCurrentViewName(state),
@@ -119,11 +109,7 @@ const mapStateToProps = (state: StoreState): StaticProps => {
   };
 };
 
-// Props = StaticProps && Dispatchers
-
 const App = connect(mapStateToProps, mapDispatchToProps)(AppReviewTemplate);
-
-// -----------------------------------------------------------------------------
 
 const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
   const [store, setStore] = useState<Store<StoreState, AnyAction> | null>(null);
@@ -174,15 +160,11 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
   );
 };
 
-// -----------------------------------------------------------------------------
-
 declare global {
   // eslint-disable-next-line no-shadow
   interface Window {
-    __REDUX_DEVTOOLS_EXTENSION__?: boolean;
+    __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;
   }
 }
-
-// -----------------------------------------------------------------------------
 
 export default AppReview;

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -22,6 +22,7 @@ import {updateStepItemsOnValidation, updateStepItemsOnNext} from './actions/ui/s
 import {fetchSkills} from './actions/api/fetch-skills';
 import {postProgression, PostProgressionAction} from './actions/api/post-progression';
 import {VIEWS} from './common';
+import {FetchSlideAction} from './actions/api/fetch-slide';
 
 // -----------------------------------------------------------------------------
 
@@ -30,8 +31,6 @@ type StaticProps = {
   slides: SlidesViewStaticProps | null;
   skills: SkillsProps | null;
 };
-
-type ThunkActions = PostProgressionAction;
 
 // -----------------------------------------------------------------------------
 
@@ -127,7 +126,7 @@ const App = connect(mapStateToProps, mapDispatchToProps)(AppReviewTemplate);
 // -----------------------------------------------------------------------------
 
 const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
-  const [store, setStore] = useState<Store<StoreState, AnyAction | ReceiveProgression> | null>(null);
+  const [store, setStore] = useState<Store<StoreState, AnyAction> | null>(null);
 
   useEffect(() => {
     if (store) return;

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -20,7 +20,7 @@ import {updateFinishedSlides} from './actions/ui/finished-slides';
 import {updateReviewStatus} from './actions/ui/review-status';
 import {updateStepItemsOnValidation, updateStepItemsOnNext} from './actions/ui/step-items';
 import {fetchSkills} from './actions/api/fetch-skills';
-import {postProgression} from './actions/api/post-progression';
+import {postProgression, PostProgressionAction} from './actions/api/post-progression';
 import {VIEWS} from './common';
 
 // -----------------------------------------------------------------------------
@@ -30,6 +30,8 @@ type StaticProps = {
   slides: SlidesViewStaticProps | null;
   skills: SkillsProps | null;
 };
+
+type ThunkActions = PostProgressionAction;
 
 // -----------------------------------------------------------------------------
 
@@ -125,7 +127,7 @@ const App = connect(mapStateToProps, mapDispatchToProps)(AppReviewTemplate);
 // -----------------------------------------------------------------------------
 
 const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
-  const [store, setStore] = useState<Store<StoreState, AnyAction> | null>(null);
+  const [store, setStore] = useState<Store<StoreState, AnyAction | ReceiveProgression> | null>(null);
 
   useEffect(() => {
     if (store) return;

--- a/packages/@coorpacademy-app-review/src/types/globals.d.ts
+++ b/packages/@coorpacademy-app-review/src/types/globals.d.ts
@@ -3,8 +3,3 @@ declare module 'browser-env';
 declare module '@coorpacademy/components/es/template/app-review';
 declare module '@coorpacademy/components/es/template/app-review/template-context';
 declare module '@coorpacademy/redux-task';
-
-// eslint-disable-next-line no-shadow
-declare interface Window {
-  __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;
-}


### PR DESCRIPTION
https://trello.com/c/x9ZucBlG/2686-or-mock-services-pour-sandbox

**Detailed purpose of the PR**

Adding type to api thunk-actions added for app-review.
There was an ts error generated at `index.ts:160` and `index.ts:161`: **ThunkAction is not assignable to parameter of type 'AnyAction'**

```js
    skillRef
      ? store.dispatch(postProgression(skillRef, token))
      : store.dispatch(fetchSkills(token));
    }, [options, store]);
```

As far as I understood what was related on this [issue](https://github.com/reduxjs/redux-thunk/issues/333), react-redux's `store.dispacth` type was changed on `v8` (which we're using) and only receives `AnyAction` objects, so our `ThunkAction` are refused (`postProgression` and `fetchSkills`) are `ThunkAction`.

The solution implemented on this PR for this problem follow what it's recommended is this [comment](https://github.com/reduxjs/redux-thunk/issues/333#issuecomment-1109308664).