### PR TITLE
Fix congrats - mobile version

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-congrats/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-congrats/style.css
@@ -277,7 +277,7 @@ _:-ms-fullscreen,
     display: flex;
     flex-direction: column;
     margin-top: 25px;
-    width: 90%;
+    max-width: 335px;
   }
 
   .buttonRevise {


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
This PR modifies buttons width of ReviewCongrats component to fix bug in mobile version in component TemplateAppReviewPlayer, fixture EndReview.
-> https://trello.com/c/L1KVNKuW/2696-fix-congrats-version-mobile

<!--What existing problem does the PR solve?/
What is the current behavior? -->
Tested with:
 - ie11
 - safari
 - chrome
 - mozilla

**Result and observation**
 - chrome:
![Kapture 2022-08-12 at 13 10 06](https://user-images.githubusercontent.com/79636283/184342734-1a24bcf9-6372-4ef4-b971-7e784abbcf2c.gif)

- ie:
<img width="454" alt="Capture d’écran 2022-08-12 à 12 54 56" src="https://user-images.githubusercontent.com/79636283/184340523-0ba6cba0-2fd0-4268-b1e4-ad39633309bc.png">

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
