### PR TITLE
Fix ReviewCorrectionPopin style

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -1,7 +1,6 @@
 @value colors: "../../variables/colors.css";
 @value breakpoints: "../../variables/breakpoints.css";
 @value tablet from breakpoints;
-@value mobile from breakpoints;
 @value white from colors;
 @value cm_positive_100 from colors;
 @value cm_negative_100 from colors;
@@ -225,28 +224,6 @@
 }
 
 @media tablet {
-  .resultLabel {
-    display: none;
-  }
-
-  .feedbackSection {
-    margin: 0 20px 0 20px;
-  }
-
-  .correctionSection {
-    min-width: 60px;
-  }  
-
-  .actions {
-    width: 25%;
-  }
-
-  .actionsWrong {
-    width: 47%;
-  }
-}
-
-@media mobile {
   .popin {
     width: 100%;
     min-height: 100px;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/style.css
@@ -1,6 +1,7 @@
 @value colors: "../../variables/colors.css";
 @value breakpoints: "../../variables/breakpoints.css";
 @value tablet from breakpoints;
+@value mobile from breakpoints;
 @value white from colors;
 @value cm_positive_100 from colors;
 @value cm_negative_100 from colors;
@@ -224,6 +225,28 @@
 }
 
 @media tablet {
+  .resultLabel {
+    display: none;
+  }
+
+  .feedbackSection {
+    margin: 0 20px 0 20px;
+  }
+
+  .correctionSection {
+    min-width: 60px;
+  }  
+
+  .actions {
+    width: 25%;
+  }
+
+  .actionsWrong {
+    width: 47%;
+  }
+}
+
+@media mobile {
   .popin {
     width: 100%;
     min-height: 100px;

--- a/packages/@coorpacademy-components/src/organism/review-slide/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-slide/style.css
@@ -82,6 +82,7 @@ _:-ms-fullscreen, :root .validateButtonWrapper {
   color: cm_blue_900;
   margin-top: 49px;
   text-align: center;
+  width: 95%;
 }
 
 .questionOrigin:empty:after {
@@ -109,7 +110,7 @@ _:-ms-fullscreen, :root .validateButtonWrapper {
     transform: translate3d(0, 200px, 0);
   }
   to {
-    transform: translate3d(0, -40px, 0);
+    transform: translate3d(0, 0, 0);
   }
 }
 
@@ -117,7 +118,7 @@ _:-ms-fullscreen, :root .validateButtonWrapper {
   position: absolute;
   bottom: 0px;
   border-radius: 7px;
-  margin: 0 15px;
+  margin: 0 15px 40px;
   width: 95%;
 }
 
@@ -128,6 +129,7 @@ _:-ms-fullscreen, :root .validateButtonWrapper {
 /* ie fallback */
 _:-ms-fullscreen, :root .correctionPopinWrapper {
   left: 15px;
+  right: 15%;
 }
 
 .validateButton {
@@ -149,7 +151,7 @@ _:-ms-fullscreen, :root .correctionPopinWrapper {
       transform: translate3d(0, 400px, 0);
     }
     to {
-      transform: translate3d(0, -40px, 0);
+      transform: translate3d(0, 0, 0);
     }
   }
 }
@@ -164,7 +166,7 @@ _:-ms-fullscreen, :root .correctionPopinWrapper {
       transform: translate3d(0, 500px, 0);
     }
     to {
-      transform: translate3d(0, -40px, 0);
+      transform: translate3d(0, 0, 0);
     }
   }
 }

--- a/packages/@coorpacademy-components/src/organism/review-slide/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-slide/style.css
@@ -129,7 +129,6 @@ _:-ms-fullscreen, :root .validateButtonWrapper {
 /* ie fallback */
 _:-ms-fullscreen, :root .correctionPopinWrapper {
   left: 15px;
-  right: 15%;
 }
 
 .validateButton {


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
This PR  adds a margin bottom for CorrectionOK and CorrectionWrong fixtures (in component OrganismReviewSlide).
-> https://trello.com/c/JFzVC7OS/2698-fix-reviewcorrectionpopin-style
<!--What existing problem does the PR solve?/
What is the current behavior? -->

Tested with:
- ie11
- safari
- chrome
- mozilla

**Result and observation**
BEFORE

<img width="876" alt="Capture d’écran 2022-08-12 à 14 55 04" src="https://user-images.githubusercontent.com/79636283/184379606-46d73240-08fa-407c-8700-6d83c8939808.png">

AFTER
- chrome:
![Kapture 2022-08-12 at 16 46 36](https://user-images.githubusercontent.com/79636283/184380811-5e754c4a-c3fc-4414-86c3-9f4689884765.gif)


-ie: 
<img width="709" alt="Capture d’écran 2022-08-12 à 16 57 56 2" src="https://user-images.githubusercontent.com/79636283/184383446-a551f239-8652-414a-9b2a-b9305b5ca2fe.png">

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
