### PR TITLE
Add Content title property of slide

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -141,13 +141,18 @@ const Slide = (props, context) => {
 
   const {skin} = context;
   const primarySkinColor = useMemo(() => getOr('#00B0FF', 'common.primary', skin), [skin]);
-  const {questionText, answerUI, showCorrectionPopin, animateCorrectionPopin} = slide;
-  const questionOrigin = 'From "Master Design Thinking to become more agile" course';
+  const {
+    parentContentTitle,
+    questionText,
+    answerUI,
+    showCorrectionPopin,
+    animateCorrectionPopin
+  } = slide;
 
   return (
     <div data-name={`slide-container`} className={style.slide}>
       <QuestionContainer
-        questionOrigin={questionOrigin}
+        questionOrigin={parentContentTitle}
         questionText={questionText}
         answerUI={answerUI}
       />

--- a/packages/@coorpacademy-components/src/organism/review-slide/prop-types.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/prop-types.js
@@ -9,6 +9,7 @@ export const SlideProp = PropTypes.shape({
   isCorrect: PropTypes.bool,
   animateCorrectionPopin: PropTypes.bool,
   showCorrectionPopin: PropTypes.bool,
+  parentContentTitle: PropTypes.string,
   questionText: PropTypes.string,
   answerUI: PropTypes.shape(AnswerPropTypes)
 });

--- a/packages/@coorpacademy-components/src/organism/review-slide/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-slide/style.css
@@ -82,7 +82,7 @@ _:-ms-fullscreen, :root .validateButtonWrapper {
   color: cm_blue_900;
   margin-top: 49px;
   text-align: center;
-  width: 95%;
+  width: 85%;
 }
 
 .questionOrigin:empty:after {

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/choices-selected.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/choices-selected.js
@@ -7,6 +7,7 @@ export default {
     slide: {
       hidden: false,
       position: 0,
+      parentContentTitle: 'From "Master Design Thinking to become more agile" course',
       questionText: 'Question 1',
       answerUI: qcmGraphic,
       showCorrectionPopin: false

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-ok-animated.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-ok-animated.js
@@ -8,6 +8,7 @@ export default {
     slide: {
       hidden: false,
       position: 0,
+      parentContentTitle: 'From "Master Design Thinking to become more agile" course',
       questionText: 'Question 1',
       answerUI: qcmGraphic,
       animateCorrectionPopin: true,

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-ok.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-ok.js
@@ -8,6 +8,7 @@ export default {
     slide: {
       hidden: false,
       position: 0,
+      parentContentTitle: 'From "Master Design Thinking to become more agile" course',
       questionText: 'Question 1',
       answerUI: qcmGraphic,
       animateCorrectionPopin: false,

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-wrong-animated.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-wrong-animated.js
@@ -8,6 +8,7 @@ export default {
     slide: {
       hidden: false,
       position: 0,
+      parentContentTitle: 'From "Master Design Thinking to become more agile" course',
       questionText: 'Question 1',
       answerUI: qcmGraphic,
       animateCorrectionPopin: true,

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-wrong.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-wrong.js
@@ -8,6 +8,7 @@ export default {
     slide: {
       hidden: false,
       position: 0,
+      parentContentTitle: 'From "Master Design Thinking to become more agile" course',
       questionText: 'Question 1',
       answerUI: qcmGraphic,
       animateCorrectionPopin: false,

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/initial-state.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/initial-state.js
@@ -12,6 +12,7 @@ export default {
     slide: {
       hidden: false,
       position: 0,
+      parentContentTitle: 'From "Master Design Thinking to become more agile" course',
       questionText: 'Question 1',
       answerUI: qcmGraphic,
       showCorrectionPopin: false

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/all-ok.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/all-ok.js
@@ -27,6 +27,7 @@ export default {
       '0': {
         hidden: true,
         position: 0,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 1',
         answerUI: qcmDrag,
         isCorrect: true
@@ -34,6 +35,7 @@ export default {
       '1': {
         hidden: true,
         position: 1,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 2',
         answerUI: qcmDrag,
         isCorrect: true
@@ -41,6 +43,7 @@ export default {
       '2': {
         hidden: true,
         position: 2,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 3',
         answerUI: qcmDrag,
         isCorrect: true
@@ -48,6 +51,7 @@ export default {
       '3': {
         hidden: true,
         position: 3,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 4',
         answerUI: qcmDrag,
         isCorrect: true
@@ -55,6 +59,7 @@ export default {
       '4': {
         hidden: false,
         position: 4,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question',
         answerUI: qcmDrag,
         isCorrect: true,

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/first-correct.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/first-correct.js
@@ -27,6 +27,7 @@ export default {
       '0': {
         hidden: false,
         position: 0,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Hey there, .....suspense.... ready to select some answers?',
         answerUI: qcmDrag,
         isCorrect: true,

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/initial-state.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/initial-state.js
@@ -27,6 +27,7 @@ export default {
       '0': {
         hidden: false,
         position: 0,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 1',
         answerUI: qcmDrag
       },

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/restack.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/restack.js
@@ -35,6 +35,7 @@ export default {
       '0': {
         hidden: false,
         position: 0,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 1',
         answerUI: qcmDrag,
         isCorrect: false,
@@ -46,6 +47,7 @@ export default {
       '1': {
         hidden: false,
         position: 1,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 2',
         answerUI: qcmGraphic
       },

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/unstack.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/unstack.js
@@ -29,6 +29,7 @@ export default {
       '0': {
         hidden: false,
         position: 0,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Hey there, .....suspense.... ready to select some answers?',
         answerUI: qcmDrag,
         isCorrect: true,
@@ -40,6 +41,7 @@ export default {
       '1': {
         hidden: false,
         position: 1,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 2',
         answerUI: qcmGraphic
       },

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/wrong-ko.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/wrong-ko.js
@@ -27,12 +27,14 @@ export default {
       '0': {
         hidden: true,
         position: 0,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 1',
         answerUI: qcmDrag,
         isCorrect: true
       },
       '1': {
         hidden: false,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 2',
         position: 1,
         answerUI: qcmDrag,
@@ -40,6 +42,7 @@ export default {
       },
       '2': {
         hidden: false,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 3',
         position: 2,
         answerUI: qcmDrag,
@@ -49,11 +52,13 @@ export default {
       },
       '3': {
         hidden: false,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 4',
         position: 3
       },
       '4': {
         hidden: false,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 5',
         position: 4
       }

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/wrong.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/wrong.js
@@ -27,12 +27,14 @@ export default {
       '0': {
         hidden: true,
         position: 0,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 1',
         answerUI: qcmDrag,
         isCorrect: true
       },
       '1': {
         hidden: true,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 2',
         position: 1,
         answerUI: qcmDrag,
@@ -40,6 +42,7 @@ export default {
       },
       '2': {
         hidden: false,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 3',
         position: 2,
         answerUI: qcmDrag,
@@ -49,11 +52,13 @@ export default {
       },
       '3': {
         hidden: false,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 4',
         position: 3
       },
       '4': {
         hidden: false,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 5',
         position: 4
       }


### PR DESCRIPTION
<!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
This PR adds parentContentTitle in slide property, updates fixtures and modifies width of parentContentTitle div.
-> https://trello.com/c/CBw7ZRJV/2701-ajouter-property-pour-le-content-parent-de-la-slide-qui-saffiche

Tested with:
- ie11
- safari
- chrome
- mozilla
<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**
BEFORE
<img width="307" alt="Capture d’écran 2022-08-12 à 18 18 05" src="https://user-images.githubusercontent.com/79636283/184403516-18cbbf2d-0887-495c-a998-51e8a3688d0a.png">


AFTER
-chrome:
<img width="307" alt="Capture d’écran 2022-08-12 à 18 17 47" src="https://user-images.githubusercontent.com/79636283/184403554-8080b006-5d2c-4e27-9211-fff7688a809f.png">

-ie:
<img width="323" alt="Capture d’écran 2022-08-12 à 18 49 45" src="https://user-images.githubusercontent.com/79636283/184406226-63f804a9-062f-4277-be23-f270d17c4804.png">

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
