### PR TITLE
Add review slides loader

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
@@ -37,29 +37,30 @@ const StackedSlides = ({
 }) => {
   const stackedSlides = [];
 
-  if (isNil(slides)) {
-    const slideView = (
-      <div className={classnames(style.slideBase, stylesByPosition[0])}>
-        <Loader className={style.loader} theme="default" aria-label={loadingAriaLabel} />
-      </div>
-    );
-    stackedSlides.push(slideView);
-  } else {
-    // eslint-disable-next-line fp/no-loops
-    for (let slideIndex = 0; slideIndex < TOTAL_SLIDES_STACK; slideIndex++) {
-      const slide = slides[_toString(slideIndex)];
-      const {animationType, hidden, position} = slide;
+  // eslint-disable-next-line fp/no-loops
+  for (let slideIndex = 0; slideIndex < TOTAL_SLIDES_STACK; slideIndex++) {
+    const slide = slides[_toString(slideIndex)];
+    const {animationType, hidden, position} = slide;
 
-      const slideView = (
-        <div
-          key={`slide-${slideIndex}`}
-          data-name={`slide-${slideIndex}`}
-          className={classnames(
-            style.slideBase,
-            getSlideAnimation(animationType, position, hidden),
-            endReview ? style.endReview : null
-          )}
-        >
+    const slideView = (
+      <div
+        key={`slide-${slideIndex}`}
+        data-name={`slide-${slideIndex}`}
+        className={classnames(
+          style.slideBase,
+          getSlideAnimation(animationType, position, hidden),
+          endReview ? style.endReview : null
+        )}
+      >
+        {isNil(slide.answerUI && slide.position === 0) ? (
+          <div
+            key={`slide-${slideIndex}`}
+            data-name={`slide-${slideIndex}`}
+            className={classnames(style.slideBase, stylesByPosition[slideIndex])}
+          >
+            <Loader className={style.loader} theme="default" aria-label={loadingAriaLabel} />
+          </div>
+        ) : (
           <ReviewSlide
             {...{
               slideIndex: _toString(slideIndex),
@@ -69,10 +70,10 @@ const StackedSlides = ({
             }}
             key={slideIndex}
           />
-        </div>
-      );
-      stackedSlides.push(slideView);
-    }
+        )}
+      </div>
+    );
+    stackedSlides.push(slideView);
   }
 
   return (

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
@@ -51,7 +51,7 @@ const StackedSlides = ({
           endReview ? style.endReview : null
         )}
       >
-        {isNil(slide.answerUI && slide.position === 0) ? (
+        {isNil(slide.answerUI) && slide.position === 0 ? (
           <Loader className={style.loader} theme="default" aria-label={loadingAriaLabel} />
         ) : (
           <ReviewSlide

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import classnames from 'classnames';
 import _toString from 'lodash/fp/toString';
+import isNil from 'lodash/fp/isNil';
+import Loader from '../../atom/loader';
 import ReviewSlide from '../review-slide';
 import propTypes from './prop-types';
 import style from './style.css';
@@ -26,35 +28,51 @@ const getSlideAnimation = (action, position, hidden) => {
   }
 };
 
-const StackedSlides = ({slides, endReview, validateButton, correctionPopinProps}) => {
+const StackedSlides = ({
+  slides,
+  endReview,
+  validateButton,
+  correctionPopinProps,
+  loadingAriaLabel
+}) => {
   const stackedSlides = [];
-  // eslint-disable-next-line fp/no-loops
-  for (let slideIndex = 0; slideIndex < TOTAL_SLIDES_STACK; slideIndex++) {
-    const slide = slides[_toString(slideIndex)];
-    const {animationType, hidden, position} = slide;
 
+  if (isNil(slides)) {
     const slideView = (
-      <div
-        key={`slide-${slideIndex}`}
-        data-name={`slide-${slideIndex}`}
-        className={classnames(
-          style.slideBase,
-          getSlideAnimation(animationType, position, hidden),
-          endReview ? style.endReview : null
-        )}
-      >
-        <ReviewSlide
-          {...{
-            slideIndex: _toString(slideIndex),
-            slide,
-            validateButton,
-            correctionPopinProps
-          }}
-          key={slideIndex}
-        />
+      <div className={classnames(style.slideBase, stylesByPosition[0])}>
+        <Loader className={style.loader} theme="default" aria-label={loadingAriaLabel} />
       </div>
     );
     stackedSlides.push(slideView);
+  } else {
+    // eslint-disable-next-line fp/no-loops
+    for (let slideIndex = 0; slideIndex < TOTAL_SLIDES_STACK; slideIndex++) {
+      const slide = slides[_toString(slideIndex)];
+      const {animationType, hidden, position} = slide;
+
+      const slideView = (
+        <div
+          key={`slide-${slideIndex}`}
+          data-name={`slide-${slideIndex}`}
+          className={classnames(
+            style.slideBase,
+            getSlideAnimation(animationType, position, hidden),
+            endReview ? style.endReview : null
+          )}
+        >
+          <ReviewSlide
+            {...{
+              slideIndex: _toString(slideIndex),
+              slide,
+              validateButton,
+              correctionPopinProps
+            }}
+            key={slideIndex}
+          />
+        </div>
+      );
+      stackedSlides.push(slideView);
+    }
   }
 
   return (

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
@@ -36,7 +36,6 @@ const StackedSlides = ({
   loadingAriaLabel
 }) => {
   const stackedSlides = [];
-
   // eslint-disable-next-line fp/no-loops
   for (let slideIndex = 0; slideIndex < TOTAL_SLIDES_STACK; slideIndex++) {
     const slide = slides[_toString(slideIndex)];

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
@@ -53,13 +53,7 @@ const StackedSlides = ({
         )}
       >
         {isNil(slide.answerUI && slide.position === 0) ? (
-          <div
-            key={`slide-${slideIndex}`}
-            data-name={`slide-${slideIndex}`}
-            className={classnames(style.slideBase, stylesByPosition[slideIndex])}
-          >
-            <Loader className={style.loader} theme="default" aria-label={loadingAriaLabel} />
-          </div>
+          <Loader className={style.loader} theme="default" aria-label={loadingAriaLabel} />
         ) : (
           <ReviewSlide
             {...{

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/prop-types.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/prop-types.js
@@ -11,5 +11,6 @@ export default {
     '3': SlideProp,
     '4': SlideProp
   }),
-  endReview: PropTypes.bool
+  endReview: PropTypes.bool,
+  loadingAriaLabel: PropTypes.string
 };

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/style.css
@@ -151,6 +151,11 @@
   animation: slideOut 2.5s ease forwards;
 }
 
+.loader {
+  height: 60px;
+  width: 60px;
+}
+
 @media tablet {
   .stackedSlidesContainer {
     height: 638px;

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/all-ok.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/all-ok.js
@@ -73,10 +73,6 @@ export default {
       onClick: () => console.log('onValidateClick'),
       disabled: true
     },
-    finishedSlides: {
-      '0': true
-    },
-    finishedSlidesSize: 1,
     correctionPopinProps
   }
 };

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/first-correct.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/first-correct.js
@@ -57,10 +57,6 @@ export default {
       onClick: () => console.log('onValidateClick'),
       disabled: true
     },
-    finishedSlides: {
-      '0': true
-    },
-    finishedSlidesSize: 1,
     correctionPopinProps
   }
 };

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/initial-state.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/initial-state.js
@@ -54,10 +54,6 @@ export default {
       onClick: () => console.log('onValidateClick'),
       disabled: false
     },
-    finishedSlides: {
-      '0': true
-    },
-    finishedSlidesSize: 1,
     correctionPopinProps
   }
 };

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/loading.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/loading.js
@@ -28,10 +28,6 @@ export default {
       onClick: () => console.log('onValidateClick'),
       disabled: false
     },
-    finishedSlides: {
-      '0': true
-    },
-    finishedSlidesSize: 1,
     loadingAriaLabel: 'Review slides container is loading'
   }
 };

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/loading.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/loading.js
@@ -1,0 +1,15 @@
+export default {
+  props: {
+    endReview: false,
+    validateButton: {
+      label: 'Validate',
+      onClick: () => console.log('onValidateClick'),
+      disabled: false
+    },
+    finishedSlides: {
+      '0': true
+    },
+    finishedSlidesSize: 1,
+    loadingAriaLabel: 'Review slides container is loading'
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/loading.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/loading.js
@@ -1,5 +1,27 @@
 export default {
   props: {
+    slides: {
+      '0': {
+        hidden: false,
+        position: 0
+      },
+      '1': {
+        hidden: false,
+        position: 1
+      },
+      '2': {
+        hidden: false,
+        position: 2
+      },
+      '3': {
+        hidden: false,
+        position: 3
+      },
+      '4': {
+        hidden: false,
+        position: 4
+      }
+    },
     endReview: false,
     validateButton: {
       label: 'Validate',

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/restack.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/restack.js
@@ -69,10 +69,6 @@ export default {
       onClick: () => console.log('onValidateClick'),
       disabled: true
     },
-    finishedSlides: {
-      '0': true
-    },
-    finishedSlidesSize: 1,
     correctionPopinProps
   }
 };

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/second-wrong.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/second-wrong.js
@@ -69,10 +69,6 @@ export default {
       disabled: true,
       onClick: () => console.log('onValidateClick')
     },
-    finishedSlides: {
-      '0': true
-    },
-    finishedSlidesSize: 1,
     correctionPopinProps
   }
 };

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/unstack.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/unstack.js
@@ -63,10 +63,6 @@ export default {
       disabled: true,
       onClick: () => console.log('onValidateClick')
     },
-    finishedSlides: {
-      '0': true
-    },
-    finishedSlidesSize: 1,
     correctionPopinProps
   }
 };

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/wrong.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/wrong.js
@@ -68,10 +68,6 @@ export default {
       disabled: true,
       onClick: () => console.log('onValidateClick')
     },
-    finishedSlides: {
-      '0': true
-    },
-    finishedSlidesSize: 1,
     correctionPopinProps
   }
 };

--- a/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/loading.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/loading.js
@@ -1,0 +1,10 @@
+import headerProps from '../../../../../organism/review-header/test/fixtures/no-answered-question';
+import LoadingStackedSlides from '../../../../../organism/review-stacked-slides/test/fixtures/loading';
+
+export default {
+  props: {
+    header: headerProps.props,
+    stack: LoadingStackedSlides.props,
+    reviewBackgroundAriaLabel: 'review BG Aria'
+  }
+};

--- a/packages/@coorpacademy-components/src/template/app-review/player/test/review-player.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/test/review-player.js
@@ -22,7 +22,7 @@ test.serial('validate click test', async t => {
   );
   t.truthy(elementExists(stackedSlidesContainer));
 
-  const validateButton = container.querySelectorAll('[data-name="slide-validate-button-4"]');
+  const validateButton = container.querySelectorAll('[data-name="slide-validate-button-0"]');
   t.truthy(elementExists(validateButton));
 
   await act(async () => {

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -996,6 +996,7 @@ import OrganismReviewStackedSlidesFixtureAllOk from '../src/organism/review-stac
 import OrganismReviewStackedSlidesFixtureEndReview from '../src/organism/review-stacked-slides/test/fixtures/end-review';
 import OrganismReviewStackedSlidesFixtureFirstCorrect from '../src/organism/review-stacked-slides/test/fixtures/first-correct';
 import OrganismReviewStackedSlidesFixtureInitialState from '../src/organism/review-stacked-slides/test/fixtures/initial-state';
+import OrganismReviewStackedSlidesFixtureLoading from '../src/organism/review-stacked-slides/test/fixtures/loading';
 import OrganismReviewStackedSlidesFixtureRestack from '../src/organism/review-stacked-slides/test/fixtures/restack';
 import OrganismReviewStackedSlidesFixtureSecondWrong from '../src/organism/review-stacked-slides/test/fixtures/second-wrong';
 import OrganismReviewStackedSlidesFixtureUnstack from '../src/organism/review-stacked-slides/test/fixtures/unstack';
@@ -2702,6 +2703,7 @@ export const fixtures = {
       EndReview: OrganismReviewStackedSlidesFixtureEndReview,
       FirstCorrect: OrganismReviewStackedSlidesFixtureFirstCorrect,
       InitialState: OrganismReviewStackedSlidesFixtureInitialState,
+      Loading: OrganismReviewStackedSlidesFixtureLoading,
       Restack: OrganismReviewStackedSlidesFixtureRestack,
       SecondWrong: OrganismReviewStackedSlidesFixtureSecondWrong,
       Unstack: OrganismReviewStackedSlidesFixtureUnstack,

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -1171,6 +1171,7 @@ import TemplateAppReviewPlayerFixtureAllOk from '../src/template/app-review/play
 import TemplateAppReviewPlayerFixtureEndReview from '../src/template/app-review/player/test/fixtures/end-review';
 import TemplateAppReviewPlayerFixtureFirstRight from '../src/template/app-review/player/test/fixtures/first-right';
 import TemplateAppReviewPlayerFixtureInitialState from '../src/template/app-review/player/test/fixtures/initial-state';
+import TemplateAppReviewPlayerFixtureLoading from '../src/template/app-review/player/test/fixtures/loading';
 import TemplateAppReviewPlayerFixtureOneFail from '../src/template/app-review/player/test/fixtures/one-fail';
 import TemplateAppReviewPlayerFixtureRestack from '../src/template/app-review/player/test/fixtures/restack';
 import TemplateAppReviewPlayerFixtureSecondFailedQuestion from '../src/template/app-review/player/test/fixtures/second-failed-question';
@@ -2968,6 +2969,7 @@ export const fixtures = {
       EndReview: TemplateAppReviewPlayerFixtureEndReview,
       FirstRight: TemplateAppReviewPlayerFixtureFirstRight,
       InitialState: TemplateAppReviewPlayerFixtureInitialState,
+      Loading: TemplateAppReviewPlayerFixtureLoading,
       OneFail: TemplateAppReviewPlayerFixtureOneFail,
       Restack: TemplateAppReviewPlayerFixtureRestack,
       SecondFailedQuestion: TemplateAppReviewPlayerFixtureSecondFailedQuestion,


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
This PR adds a loading state for review slides in components OrganismReviewStackedSlides and TemplateAppReviewPlayer.
-> https://trello.com/c/c2aya3Ky/2700-pr%C3%A9voir-%C3%A9tat-loading-pour-laffichage-des-slides-fetchslide

Tested with:
- ie11
- safari
- chrome
- mozilla
<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**
-chrome: 
![Kapture 2022-08-16 at 17 41 41](https://user-images.githubusercontent.com/79636283/184921649-e40aba3a-b0b3-46e6-8ff1-048e4a9b7a88.gif)

-ie:
<img width="578" alt="Capture d’écran 2022-08-16 à 17 49 37" src="https://user-images.githubusercontent.com/79636283/184924932-d4decb71-a67e-481a-af5d-c82df74726bc.png">


<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
