### PR TITLE
Get parentContentTitle from the SlideAPI + related refactor

### DIFF
--- a/packages/@coorpacademy-app-review/src/services/fetch-slide.ts
+++ b/packages/@coorpacademy-app-review/src/services/fetch-slide.ts
@@ -6,7 +6,7 @@ import {toJSON} from './tools/fetch-responses';
 
 export const fetchSlide = async (slideRef: string, token: string): Promise<SlideFromAPI | void> => {
   const {host}: JWT = decode(token);
-  const response = await crossFetch(`${host}/api/v2/slide/${slideRef}`, {
+  const response = await crossFetch(`${host}/api/v2/slide/${slideRef}/parentContentTitle`, {
     headers: {authorization: token}
   });
 

--- a/packages/@coorpacademy-app-review/src/services/test/fetch-slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/services/test/fetch-slide.test.ts
@@ -1,0 +1,30 @@
+import test from 'ava';
+import nock from 'nock';
+import {qcmDragSlide} from '../../views/slides/test/fixtures/qcm-drag';
+import {fetchSlide} from '../fetch-slide';
+
+test.before(() => {
+  nock('http://localhost:3000')
+    .get('/api/v2/slide/sli_123546/parentContentTitle')
+    .reply(200, qcmDragSlide);
+});
+
+test.after(() => {
+  nock.cleanAll();
+});
+
+test('should fetch a slide with the parentTitleContent info successfully', async t => {
+  const token = process.env.API_TEST_TOKEN || '';
+  const slide = await fetchSlide('sli_123546', token);
+  t.deepEqual(qcmDragSlide, slide);
+});
+
+test('should reject if a bad token is passed', async t => {
+  const badToken = 'token is not a jwt';
+  const error = await t.throwsAsync(() => fetchSlide('sli_123546', badToken));
+
+  t.is(
+    error?.message,
+    "Invalid token specified: Cannot read properties of undefined (reading 'replace')"
+  );
+});

--- a/packages/@coorpacademy-app-review/src/test/util/services.mock.ts
+++ b/packages/@coorpacademy-app-review/src/test/util/services.mock.ts
@@ -9,15 +9,12 @@ export const services: Services = {
         slidesToReview: 2,
         name: 'skill-test',
         custom: false
-        // TODO parentContentTitle
       },
       {
         skillRef: '_skill-ref-2',
         slidesToReview: 2,
         name: 'skill-test-2',
-        custom: true,
-        parentContentTitle: 'parentContentTitle 2'
-        // TODO parentContentTitle
+        custom: true
       }
     ]);
   },

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -85,6 +85,10 @@ export type SlideFromAPI = {
   clue?: string;
   hasClue?: boolean;
   id: string;
+  parentContentTitle: {
+    title: string;
+    type: 'chapter' | 'course';
+  };
 };
 
 type ProgressionAnswerItem = {

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import concat from 'lodash/fp/concat';
 
 import get from 'lodash/fp/get';
@@ -72,10 +71,10 @@ export type SlidesViewProps = {
   congratsProps?: {
     'aria-label'?: string;
     'data-name'?: string;
-    animationLottie: any;
+    animationLottie: unknown;
     title: string;
-    cardCongratsStar: any;
-    cardCongratsRank: any;
+    cardCongratsStar: unknown;
+    cardCongratsRank: unknown;
     buttonRevising: {
       'aria-label'?: string;
       label: string;
@@ -137,10 +136,12 @@ const buildStackSlides = (state: StoreState): SlidesStack => {
 
       const slideFromAPI = get(slideRef, state.data.slides);
       const {questionText, answerUI} = mapApiSlideToUi(slideFromAPI);
+      const {title: parentContentTitle, type} = slideFromAPI.parentContentTitle;
+
       const updatedUiSlide = pipe(
         set(['questionText'], questionText),
         set(['answerUI'], answerUI),
-        set(['parentContentTitle'], 'Parent Title') // TODO parentContentTitle + translate
+        set(['parentContentTitle'], `From ${parentContentTitle} ${type}`) // TODO translate: -From- .... -Course/chapter-
         // TODO: Set position according to currentSlideRef et slideRefs (or maybe a value on the state ui.slidePositions !!)
       )(uiSlide);
 
@@ -153,7 +154,7 @@ const buildStackSlides = (state: StoreState): SlidesStack => {
   return stack;
 };
 
-const buildStepItemps = (state: StoreState): StepItem[] => {
+const buildStepItems = (state: StoreState): StepItem[] => {
   const {progression} = state.data;
   const {currentSlideRef} = state.ui;
   if (!progression) return [];
@@ -223,7 +224,7 @@ export const mapStateToSlidesProps = (state: StoreState): SlidesViewProps | null
       },
       'aria-label': 'aria-header-wrapper',
       closeButtonAriaLabel: 'aria-close-button',
-      steps: buildStepItemps(state)
+      steps: buildStepItems(state)
     },
     stack: {
       slides: buildStackSlides(state),

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -143,7 +143,7 @@ const buildStackSlides = (state: StoreState): SlidesStack => {
       const updatedUiSlide = pipe(
         set(['questionText'], questionText),
         set(['answerUI'], answerUI),
-        set(['parentContentTitle'], `From ${parentContentTitle} ${parentContentType}`) // TODO translate: -From- .... -Course/chapter-
+        set(['parentContentTitle'], `From "${parentContentTitle}" ${parentContentType}`) // TODO translate: -From- .... -Course/chapter-
         // TODO: Set position according to currentSlideRef et slideRefs (or maybe a value on the state ui.slidePositions !!)
       )(uiSlide);
 

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -1,6 +1,7 @@
 import concat from 'lodash/fp/concat';
 
 import get from 'lodash/fp/get';
+import getOr from 'lodash/fp/getOr';
 import isEmpty from 'lodash/fp/isEmpty';
 import pipe from 'lodash/fp/pipe';
 import reduce from 'lodash/fp/reduce';
@@ -136,12 +137,13 @@ const buildStackSlides = (state: StoreState): SlidesStack => {
 
       const slideFromAPI = get(slideRef, state.data.slides);
       const {questionText, answerUI} = mapApiSlideToUi(slideFromAPI);
-      const {title: parentContentTitle, type} = slideFromAPI.parentContentTitle;
+      const parentContentTitle = getOr('', 'parentContentTitle.title', slideFromAPI);
+      const parentContentType = getOr('', 'parentContentTitle.type', slideFromAPI);
 
       const updatedUiSlide = pipe(
         set(['questionText'], questionText),
         set(['answerUI'], answerUI),
-        set(['parentContentTitle'], `From ${parentContentTitle} ${type}`) // TODO translate: -From- .... -Course/chapter-
+        set(['parentContentTitle'], `From ${parentContentTitle} ${parentContentType}`) // TODO translate: -From- .... -Course/chapter-
         // TODO: Set position according to currentSlideRef et slideRefs (or maybe a value on the state ui.slidePositions !!)
       )(uiSlide);
 

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/free-text.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/free-text.ts
@@ -23,7 +23,7 @@ export const freeTextSlide: SlideFromAPI = {
   universalRef: 'sli_VJYjJnJhg',
   id: 'sli_VJYjJnJhg',
   parentContentTitle: {
-    title: 'Some course',
+    title: 'Developing the review app',
     type: 'course'
   }
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/free-text.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/free-text.ts
@@ -21,7 +21,11 @@ export const freeTextSlide: SlideFromAPI = {
   klf: 'To negotiate your salary when being hired, you have to establish a benchmark beforehand. In other words, you should assess the salary to which you aspire by enquiring about the remuneration paid in the same industry, the same region and the same position.',
   tips: 'According to Insee, Paris salaries are 20-25% higher compared with those of the provinces in 2015.',
   universalRef: 'sli_VJYjJnJhg',
-  id: 'sli_VJYjJnJhg'
+  id: 'sli_VJYjJnJhg',
+  parentContentTitle: {
+    title: 'Some course',
+    type: 'course'
+  }
 };
 
 export const freeTextUISlide: Partial<UISlide> = {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm-drag.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm-drag.ts
@@ -67,7 +67,11 @@ export const qcmDragSlide: SlideFromAPI = {
   klf: "Le burn out s'installe en quatre étapes : tout d'abord, l'implication (investissement émotionnel et/ou affectif, sacrifice de sa vie privée) ; en second, la stagnation (premières déceptions, signes de fatigue) ; ensuite, la frustration (efforts non reconnus) ; et enfin, la démoralisation (problèmes de concentration, sentiment d'inutilité, désespoir).",
   tips: "Encadré par la loi, l'entretien professionnel a pour but d'aider le collaborateur à verbaliser ses difficultés et à construire son projet professionnel.",
   universalRef: 'sli_4yGBq-mCg',
-  id: 'sli_4yGBq-mCg'
+  id: 'sli_4yGBq-mCg',
+  parentContentTitle: {
+    title: 'Some chapter',
+    type: 'chapter'
+  }
 };
 
 export const qcmDragUISlide: Partial<UISlide> = {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm-drag.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm-drag.ts
@@ -69,7 +69,7 @@ export const qcmDragSlide: SlideFromAPI = {
   universalRef: 'sli_4yGBq-mCg',
   id: 'sli_4yGBq-mCg',
   parentContentTitle: {
-    title: 'Some chapter',
+    title: 'Using redux',
     type: 'chapter'
   }
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm-graphic.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm-graphic.ts
@@ -59,7 +59,11 @@ export const qcmGraphicSlide: SlideFromAPI = {
   klf: "Il ne faut pas prendre la négociation comme une affaire personnelle, afin de rester centré sur son sujet. Mais cela ne signifie pas être dépourvu de toute émotion, car celles-ci peuvent être de vrais atouts. À condition de réussir à les exprimer sans accuser l'autre d'en être à l'origine.",
   tips: "Pour gérer ses émotions, il faut d'abord les identifier, notamment en analysant ses ressentis physiques et en trouvant l'élément déclencheur.",
   universalRef: 'sli_VkSQroQnx',
-  id: 'sli_VkSQroQnx'
+  id: 'sli_VkSQroQnx',
+  parentContentTitle: {
+    title: 'Some course',
+    type: 'course'
+  }
 };
 
 export const qcmGraphicUISlide: Partial<UISlide> = {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm-graphic.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm-graphic.ts
@@ -61,7 +61,7 @@ export const qcmGraphicSlide: SlideFromAPI = {
   universalRef: 'sli_VkSQroQnx',
   id: 'sli_VkSQroQnx',
   parentContentTitle: {
-    title: 'Some course',
+    title: 'Developing the review app',
     type: 'course'
   }
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm.ts
@@ -70,7 +70,11 @@ export const qcmSlide: SlideFromAPI = {
   tips: 'En 2021, le média en ligne Numerama a créé un NFT vendu aux enchères sur OpenSea. Sur cette plateforme, il est obligatoire de mettre un prix de réserve, autrement dit un prix minimum au-dessous duquel la vente ne sera pas automatiquement acceptée. Sur OpenSea il ne peut être inférieur à 1 ETH. Si le prix de réserve est atteint, pas de problème, les "gas fees" (les frais de gaz) sont couverts par OpenSea. Mais, si ce n’est pas le cas, c’est au vendeur de s’en acquitter. <br/>Le NFT en question est parti à 0,021 ETH, soit 40€ au cours de l\'époque, un prix inférieur au prix de réserve. Numerama a dû acquitter des frais de gaz, et payer 190 €. <br/>Avec les NFT, on ne gagne pas à tous les coups.',
   universalRef: 'sli_N1XACJobn',
   hasClue: true,
-  id: 'sli_N1XACJobn'
+  id: 'sli_N1XACJobn',
+  parentContentTitle: {
+    title: 'Some course',
+    type: 'course'
+  }
 };
 
 export const qcmUISlide: Partial<UISlide> = {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/qcm.ts
@@ -72,7 +72,7 @@ export const qcmSlide: SlideFromAPI = {
   hasClue: true,
   id: 'sli_N1XACJobn',
   parentContentTitle: {
-    title: 'Some course',
+    title: 'Developing the review app',
     type: 'course'
   }
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/select-template.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/select-template.ts
@@ -44,7 +44,11 @@ export const selectTemplateSlide: SlideFromAPI = {
   klf: 'L’apprenant peut aussi évaluer sa performance grâce à un classement disponible sur la vue leaderboard. Elle compare sa position par rapport à celle des autres apprenants de la plateforme.',
   tips: "La position d'un apprenant peut être aussi consultée depuis le header ou en-tête de la page. Elle se met à jour à chaque fois qu'un apprenant obtient des étoiles.",
   universalRef: 'sli_N13-hG3kX',
-  id: 'sli_N13-hG3kX'
+  id: 'sli_N13-hG3kX',
+  parentContentTitle: {
+    title: 'Some course',
+    type: 'course'
+  }
 };
 
 export const selectTemplateUISlide: Partial<UISlide> = {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/select-template.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/select-template.ts
@@ -46,7 +46,7 @@ export const selectTemplateSlide: SlideFromAPI = {
   universalRef: 'sli_N13-hG3kX',
   id: 'sli_N13-hG3kX',
   parentContentTitle: {
-    title: 'Some course',
+    title: 'Developing the review app',
     type: 'course'
   }
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/slider.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/slider.ts
@@ -16,7 +16,11 @@ export const sliderSlide: SlideFromAPI = {
   klf: 'Dans le cadre d’un projet local, la communauté de communes du Thouarsais, dans le Poitou (ouest de la France), a développé un parc diversifié d’énergies renouvelables : éolien, biomasse, solaire… En sept ans seulement, entre 2007 et 2014, la part d’énergies renouvelables est passée de zéro à un tiers !',
   tips: 'En 2014, le Thouarsais a reçu la médaille de bronze du championnat européen des énergies renouvelables.',
   universalRef: 'sli_VkAzsCLKb',
-  id: 'sli_VkAzsCLKb'
+  id: 'sli_VkAzsCLKb',
+  parentContentTitle: {
+    title: 'Some course',
+    type: 'course'
+  }
 };
 
 export const sliderUISlide: Partial<UISlide> = {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/slider.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/slider.ts
@@ -18,7 +18,7 @@ export const sliderSlide: SlideFromAPI = {
   universalRef: 'sli_VkAzsCLKb',
   id: 'sli_VkAzsCLKb',
   parentContentTitle: {
-    title: 'Some course',
+    title: 'Developing the review app',
     type: 'course'
   }
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/text-template.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/text-template.ts
@@ -35,7 +35,7 @@ export const textTemplateSlide: SlideFromAPI = {
   hasClue: true,
   id: 'sli_VJKQonm2g',
   parentContentTitle: {
-    title: 'Some chapter',
+    title: 'Using redux',
     type: 'chapter'
   }
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/text-template.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/text-template.ts
@@ -33,7 +33,11 @@ export const textTemplateSlide: SlideFromAPI = {
   tips: "L'origine de l'expression <i>role model</i> est attribué au sociologue Robert K. Merton.",
   universalRef: 'sli_VJKQonm2g',
   hasClue: true,
-  id: 'sli_VJKQonm2g'
+  id: 'sli_VJKQonm2g',
+  parentContentTitle: {
+    title: 'Some chapter',
+    type: 'chapter'
+  }
 };
 
 export const textTemplateUISlide: Partial<UISlide> = {


### PR DESCRIPTION
**Detailed purpose of the PR**

- Fixes typos, adds parentContentTitle.
- Adds missing fetch-slide test.
- Updates types & fixtures

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**
![Screenshot 2022-08-19 at 16 07 36](https://user-images.githubusercontent.com/33550261/185636811-b9958a45-e0e9-4c9f-9e0c-e0bcfa766149.png)

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
