### PR TITLE
Expand author section

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/discipline-partners/index.js
+++ b/packages/@coorpacademy-components/src/molecule/discipline-partners/index.js
@@ -86,12 +86,7 @@ const DisciplinePartners = (props, context) => {
 
     return (
       <div key={index} className={style.authorWrapper}>
-        <input
-          type="checkbox"
-          id={authorToggleId}
-          className={style.toggle}
-          defaultChecked={authors.length === 1 ? true : null}
-        />
+        <input type="checkbox" id={authorToggleId} className={style.toggle} defaultChecked />
         <label htmlFor={authorToggleId}>{logoView}</label>
         {authorContent}
       </div>


### PR DESCRIPTION
[IDEA 4360 - Affichage de plusieurs auteurs dans le même cours](https://app.prodpad.com/ideas/4360/canvas)
Quand il y a plusieurs auteurs sur un cours, par défaut il n'y a que la photo qui est affichée alors que quand il n'y a qu'un seul auteur on voit le nom/titre de l'auteur tel qu'enregistré et le lien pour accéder aux cours créés par l'auteur. Il faut cliquer sur une flèche pour que les infos s'affichent sous la photo s'il y a plus d'un auteur.
CSS remonte qu'ils aimeraient que l'affichage soit le même avec plusieurs auteurs, soit que les infos (nom/titre pour l'auteur et "détails sur l'auteur") soient montrées par défaut. Cela pourrait effectivement être changé sur toutes les plateformes sans gêner et en apportant même une amélioration à ce niveau.

### BEFORE
<img width="279" alt="Capture d’écran 2022-08-25 à 10 46 36" src="https://user-images.githubusercontent.com/15608581/187151292-92c1c164-4688-4d1c-b1ba-96f7d1fd34df.png">

### AFTER
<img width="287" alt="Capture d’écran 2022-08-25 à 10 46 05" src="https://user-images.githubusercontent.com/15608581/187151293-1537d626-e3e7-4695-bb4b-2ae356d62d03.png">

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
