### PR TITLE
Fixes slides order building

### DIFF
--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -138,7 +138,7 @@ export const initialState: SlidesStack = {
 const getProgressionSlidesRefs = (progression: ProgressionFromAPI): string[] => {
   if (progression.state.step.current < 5) {
     const slideRef = progression.state.nextContent.ref;
-    return concat([slideRef], progression.state.slides);
+    return concat(progression.state.slides, [slideRef]);
   }
   return slice(0, 5, progression.state.slides);
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -238,3 +238,256 @@ test('should create initial props when the slide is on the state', t => {
     }
   });
 });
+
+test('should create props when the next slide is on the state', t => {
+  const state: StoreState = {
+    data: {
+      progression: {
+        _id: '62b1d1087aa12f00253f40ee',
+        content: {
+          ref: '_skill-ref',
+          type: 'skill'
+        },
+        engine: {
+          ref: 'review'
+        },
+        state: {
+          allAnswers: [
+            {
+              slideRef: 'sli_VJYjJnJhg',
+              isCorrect: true,
+              answer: ['Benchmark']
+            }
+          ],
+          isCorrect: true,
+          nextContent: {
+            ref: 'sli_VkSQroQnx',
+            type: 'slide'
+          },
+          content: {
+            ref: 'sli_VJYjJnJhg',
+            type: 'slide'
+          },
+          pendingSlides: [],
+          slides: ['sli_VJYjJnJhg'],
+          step: {
+            current: 2
+          },
+          stars: 4
+        }
+      },
+      skills: [],
+      slides: {
+        sli_VJYjJnJhg: {
+          question: {
+            content: {
+              media: {
+                src: [],
+                posters: [],
+                subtitles: []
+              },
+              label: '',
+              placeholder: 'Type here',
+              id: 'sli_VJYjJnJhg.choice_1'
+            },
+            type: 'basic',
+            header:
+              'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?',
+            explanation: 'Type your answer.'
+          },
+          klf: 'To negotiate your salary when being hired, you have to establish a benchmark beforehand. In other words, you should assess the salary to which you aspire by enquiring about the remuneration paid in the same industry, the same region and the same position.',
+          tips: 'According to Insee, Paris salaries are 20-25% higher compared with those of the provinces in 2015.',
+          universalRef: 'sli_VJYjJnJhg',
+          id: 'sli_VJYjJnJhg',
+          parentContentTitle: {
+            title: 'Developing the review app',
+            type: 'course'
+          }
+        },
+        sli_VkSQroQnx: {
+          question: {
+            content: {
+              media: {
+                src: [],
+                posters: [],
+                subtitles: []
+              },
+              choices: [
+                {
+                  media: {
+                    src: [
+                      {
+                        _id: '624efd915948a7013083e986',
+                        mimeType: 'image/jpeg',
+                        url: '//static.coorpacademy.com/content/CoorpAcademy/content-partnerships/cockpit-partner-au-feminin/default/true-1512554153232.jpg',
+                        id: '624efd915948a7013083e986'
+                      }
+                    ],
+                    posters: [],
+                    subtitles: [],
+                    type: 'img'
+                  },
+                  items: [],
+                  _id: '624efd915948a7013083e985',
+                  label: 'Vrai',
+                  value: 'sli_VkSQroQnx.choice_NJesyUo7nx',
+                  id: '624efd915948a7013083e985'
+                },
+                {
+                  media: {
+                    src: [
+                      {
+                        _id: '624efd915948a7013083e988',
+                        mimeType: 'image/jpeg',
+                        url: '//static.coorpacademy.com/content/CoorpAcademy/content-partnerships/cockpit-partner-au-feminin/default/false-1512554160848.jpg',
+                        id: '624efd915948a7013083e988'
+                      }
+                    ],
+                    posters: [],
+                    subtitles: [],
+                    type: 'img'
+                  },
+                  items: [],
+                  _id: '624efd915948a7013083e987',
+                  label: 'Faux',
+                  value: 'sli_VkSQroQnx.choice_VkgayLjX3e',
+                  id: '624efd915948a7013083e987'
+                }
+              ]
+            },
+            type: 'qcmGraphic',
+            header:
+              'Pour mener une bonne négociation, il ne faut ressentir aucune émotion. Vrai ou faux ?',
+            explanation: 'Sélectionnez la bonne réponse.'
+          },
+          klf: "Il ne faut pas prendre la négociation comme une affaire personnelle, afin de rester centré sur son sujet. Mais cela ne signifie pas être dépourvu de toute émotion, car celles-ci peuvent être de vrais atouts. À condition de réussir à les exprimer sans accuser l'autre d'en être à l'origine.",
+          tips: "Pour gérer ses émotions, il faut d'abord les identifier, notamment en analysant ses ressentis physiques et en trouvant l'élément déclencheur.",
+          universalRef: 'sli_VkSQroQnx',
+          id: 'sli_VkSQroQnx',
+          parentContentTitle: {
+            title: 'Developing the review app',
+            type: 'course'
+          }
+        }
+      },
+      token: 'undefined'
+    },
+    ui: {
+      currentSlideRef: 'sli_VJYjJnJhg',
+      navigation: ['loader', 'slides'],
+      answers: ['My value'],
+      slide: {
+        validateButton: false
+      }
+    }
+  };
+
+  const props = mapStateToSlidesProps(state, identity);
+  t.is(props.congratsProps, undefined);
+  t.deepEqual(omit(['onQuitClick'], props.header), {
+    'aria-label': 'aria-header-wrapper',
+    closeButtonAriaLabel: 'aria-close-button',
+    mode: '__revision_mode',
+    skillName: '__agility',
+    steps: [
+      {
+        current: true,
+        icon: 'right',
+        value: '1'
+      },
+      {
+        // FIX ME: update on PR -> https://trello.com/c/qOSDa8Fm/2715-app-review-props-dynamiques-pour-les-step-items-du-header-bas%C3%A9-sur-le-state
+        current: true,
+        icon: 'no-answer',
+        value: '2'
+      },
+      {
+        current: false,
+        icon: 'no-answer',
+        value: '3'
+      },
+      {
+        current: false,
+        icon: 'no-answer',
+        value: '4'
+      },
+      {
+        current: false,
+        icon: 'no-answer',
+        value: '5'
+      }
+    ]
+  });
+  t.deepEqual(omit(['validateButton', 'slides'], props.stack), {
+    correctionPopinProps: undefined,
+    endReview: false
+  });
+  t.true(props.stack.validateButton.disabled);
+  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+    hidden: false,
+    position: 0,
+    loading: false,
+    parentContentTitle: 'From "Developing the review app" course',
+    questionText:
+      'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
+  });
+  t.deepEqual(omit('model.onChange', props.stack.slides['0'].answerUI), {
+    help: 'Type your answer.',
+    model: {
+      placeholder: 'Type here',
+      type: 'freeText',
+      value: 'My value'
+    }
+  });
+  t.deepEqual(
+    omit(
+      ['0', '1.answerUI.model.answers.0.onClick', '1.answerUI.model.answers.1.onClick'],
+      props.stack.slides
+    ),
+    {
+      '1': {
+        answerUI: {
+          help: 'Sélectionnez la bonne réponse.',
+          model: {
+            answers: [
+              {
+                image:
+                  '//static.coorpacademy.com/content/CoorpAcademy/content-partnerships/cockpit-partner-au-feminin/default/true-1512554153232.jpg',
+                selected: false,
+                title: 'Vrai'
+              },
+              {
+                image:
+                  '//static.coorpacademy.com/content/CoorpAcademy/content-partnerships/cockpit-partner-au-feminin/default/false-1512554160848.jpg',
+                selected: false,
+                title: 'Faux'
+              }
+            ],
+            type: 'qcmGraphic'
+          }
+        },
+        hidden: false,
+        loading: false,
+        position: 1,
+        parentContentTitle: 'From "Developing the review app" course',
+        questionText:
+          'Pour mener une bonne négociation, il ne faut ressentir aucune émotion. Vrai ou faux ?'
+      },
+      '2': {
+        hidden: false,
+        position: 2,
+        loading: true
+      },
+      '3': {
+        hidden: false,
+        position: 3,
+        loading: true
+      },
+      '4': {
+        hidden: false,
+        position: 4,
+        loading: true
+      }
+    }
+  );
+});


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- Fixes slides order building (order should not change for additional slide fetch triggered by a validation click)

**Result and observation**

Before
![Kapture 2022-08-29 at 10 44 48](https://user-images.githubusercontent.com/33550261/187161812-2623278d-06e7-4cb2-bedc-d5e5c4ab7cef.gif)

After
![Kapture 2022-08-29 at 10 43 50](https://user-images.githubusercontent.com/33550261/187161796-b216d327-6e15-4ca9-a9f1-427dc0dd2a52.gif)


<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
