### PR TITLE
clear token passed to mooc's progression endpoints

### DIFF
--- a/packages/@coorpacademy-app-review/src/services/post-answer.ts
+++ b/packages/@coorpacademy-app-review/src/services/post-answer.ts
@@ -14,7 +14,7 @@ export const postAnswer = async (
   const {host}: JWT = decode(token);
   const response = await crossFetch(`${host}/api/v2/progressions/${progressionId}/answers`, {
     method: 'post',
-    headers: {authorization: token, 'content-type': 'application/json'},
+    headers: {'content-type': 'application/json'},
     body: JSON.stringify({
       content: {
         ref: slideRef,

--- a/packages/@coorpacademy-app-review/src/services/post-progression.ts
+++ b/packages/@coorpacademy-app-review/src/services/post-progression.ts
@@ -11,7 +11,7 @@ export const postProgression = async (
   const {host}: JWT = decode(token);
   const response = await crossFetch(`${host}/api/v2/progressions`, {
     method: 'post',
-    headers: {authorization: token, 'content-type': 'application/json'},
+    headers: {'content-type': 'application/json'},
     body: JSON.stringify({
       content: {
         ref: skillRef,


### PR DESCRIPTION
https://trello.com/c/iEXLvm3G/2624-installer-poc-app-review-sur-le-mooc

**Detailed purpose of the PR**

Currently the app-review is passing the JWT token of the connected user to the mooc's api. This is generating a [weird behavior](https://coorpacademy.slack.com/archives/G03TLJ8S6/p1662384279791019) on the onboarding platform.

After a verification with @esa-coorp, we see that token is not sent by app-player services, nor asked by the swagger (the inner logic uses the connected user to compute the good user.id to create the progression and fetch the needed data).