### PR TITLE
News without cta

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/news/index.js
+++ b/packages/@coorpacademy-components/src/molecule/news/index.js
@@ -11,21 +11,25 @@ const News = (props, context) => {
   return (
     <div className={style.news}>
       <div className={style.image}>
-        <Link
-          href={cta.href}
-          className={style.linkImage}
-          target={cta.target}
-          data-name="news-image"
-        >
+        {cta ? (
+          <Link
+            href={cta.href}
+            className={style.linkImage}
+            target={cta.target}
+            data-name="news-image"
+          >
+            <img src={image} />
+          </Link>
+        ) : (
           <img src={image} />
-        </Link>
+        )}
       </div>
       <div className={style.infos}>
         <Link
-          href={cta.href}
+          href={cta && cta.href}
           title={title}
           className={classnames(style.title, style.innerHTML)}
-          target={cta.target}
+          target={cta && cta.target}
           data-name="news-title"
           dangerouslySetInnerHTML={{__html: title}}
         />
@@ -40,10 +44,10 @@ const News = (props, context) => {
           <div className={style.author}>
             <img src={authorLogo} />
           </div>
-          <Cta {...cta} secondary name="news-cta" />
+          {cta ? <Cta {...cta} secondary name="news-cta" /> : null}
         </div>
       </div>
-      <Link className={style.link} href={cta.href} target={cta.target} />
+      {cta ? <Link className={style.link} href={cta.href} target={cta.target} /> : null}
     </div>
   );
 };

--- a/packages/@coorpacademy-components/src/molecule/news/style.css
+++ b/packages/@coorpacademy-components/src/molecule/news/style.css
@@ -22,6 +22,8 @@
   height: 100%;
   overflow: hidden;
   flex: 0 0 450px;
+  display: flex;
+  align-items: center;
 }
 
 .linkImage {

--- a/packages/@coorpacademy-components/src/molecule/news/test/fixtures/without-cta.js
+++ b/packages/@coorpacademy-components/src/molecule/news/test/fixtures/without-cta.js
@@ -1,0 +1,10 @@
+export default {
+  props: {
+    image: 'http://minecraft.fr/wp-content/uploads/2013/05/Pa8WZj1-235x300.jpg',
+    title: 'A World Of Infinite Opportunities',
+    date: '3 january 2018',
+    description: 'Vestibulum id <b>ligula</b> porta felis <i>euismod semper</i>.',
+    authorLogo:
+      'https://static.coorpacademy.com/content/digital/raw/logo_coorpacademy-1487689750995.svg'
+  }
+};

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -714,6 +714,7 @@ import MoleculeNewsFixtureLongDescription from '../src/molecule/news/test/fixtur
 import MoleculeNewsFixtureLongTitle from '../src/molecule/news/test/fixtures/long-title';
 import MoleculeNewsFixtureSmallDesciption from '../src/molecule/news/test/fixtures/small-desciption';
 import MoleculeNewsFixtureSmallTitle from '../src/molecule/news/test/fixtures/small-title';
+import MoleculeNewsFixtureWithoutCta from '../src/molecule/news/test/fixtures/without-cta';
 import MoleculeNotificationBannerFixtureDefault from '../src/molecule/notification-banner/test/fixtures/default';
 import MoleculeNotificationBannerFixtureFeature from '../src/molecule/notification-banner/test/fixtures/feature';
 import MoleculeNotificationBannerFixtureSurvey from '../src/molecule/notification-banner/test/fixtures/survey';
@@ -2227,7 +2228,8 @@ export const fixtures = {
       LongDescription: MoleculeNewsFixtureLongDescription,
       LongTitle: MoleculeNewsFixtureLongTitle,
       SmallDesciption: MoleculeNewsFixtureSmallDesciption,
-      SmallTitle: MoleculeNewsFixtureSmallTitle
+      SmallTitle: MoleculeNewsFixtureSmallTitle,
+      WithoutCta: MoleculeNewsFixtureWithoutCta
     },
     MoleculeNotificationBanner: {
       Default: MoleculeNotificationBannerFixtureDefault,


### PR DESCRIPTION
[IDEA 4377 - CMS - retirer le bouton "more" dans les news quand il n'y a pas de lien](https://app.prodpad.com/ideas/4377/canvas)
Hello,
Retour d'un client  pour retirer le bouton "more" quand la news est publiée sans lien.

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
