### PR TITLE
fix html question tag

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -118,9 +118,12 @@ const QuestionContainer = props => {
       <div key="from-course" className={style.questionOrigin}>
         {questionOrigin}
       </div>
-      <div key="title" className={style.question}
-        dangerouslySetInnerHTML={{__html: questionText}}>
-      </div>
+      <div
+        key="title"
+        className={style.question}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{__html: questionText}}
+      />
       <div key="help" className={style.help}>
         {get('help', answerUI)}
       </div>
@@ -160,8 +163,7 @@ const ReviewSlide = props => {
         [
           <QuestionContainer
             questionOrigin={parentContentTitle}
-            // eslint-disable-next-line react/no-danger
-            questionText={ questionText } 
+            questionText={questionText}
             answerUI={answerUI}
             key="question-container"
           />,

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -118,8 +118,8 @@ const QuestionContainer = props => {
       <div key="from-course" className={style.questionOrigin}>
         {questionOrigin}
       </div>
-      <div key="title" className={style.question}>
-        {questionText}
+      <div key="title" className={style.question}
+        dangerouslySetInnerHTML={{__html: questionText}}>
       </div>
       <div key="help" className={style.help}>
         {get('help', answerUI)}
@@ -160,7 +160,8 @@ const ReviewSlide = props => {
         [
           <QuestionContainer
             questionOrigin={parentContentTitle}
-            questionText={questionText}
+            // eslint-disable-next-line react/no-danger
+            questionText={ questionText } 
             answerUI={answerUI}
             key="question-container"
           />,

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/initial-state.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/initial-state.js
@@ -14,7 +14,8 @@ export default {
       position: 0,
       loading: false,
       parentContentTitle: 'From "Master Design Thinking to become more agile" course',
-      questionText: 'Question 1',
+      questionText:
+        'Lorsque vous cherchez à développer une intelligence culturelle, quels sont les trois comportements <i>fondamentaux</i> que vous devrez connaître',
       answerUI: qcmGraphic,
       showCorrectionPopin: false
     },

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/initial-state.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/initial-state.js
@@ -15,7 +15,7 @@ export default {
       loading: false,
       parentContentTitle: 'From "Master Design Thinking to become more agile" course',
       questionText:
-        'Lorsque vous cherchez à développer une intelligence culturelle, quels sont les trois comportements <i>fondamentaux</i> que vous devrez connaître',
+        'Lorsque vous cherchez à développer une intelligence culturelle, quels sont les trois comportements <i>fondamentaux</i> que vous devrez adopter',
       answerUI: qcmGraphic,
       showCorrectionPopin: false
     },


### PR DESCRIPTION
https://trello.com/c/iP7KhbVM/2745-components-les-tags-html-ne-sont-pas-support%C3%A9s-par-le-titre-de-reviewslide

**Detailed purpose of the PR**

Fix HTML tag not recognized during rendering question title content. This PR add dangerouslySetInnerHTML function to fix this issue.

**Result and observation**

### Before
<img width="1050" alt="Capture_d’écran_2022-09-07_à_10 13 31" src="https://user-images.githubusercontent.com/113359769/189929767-4607f998-15f8-4413-a306-d4b854ad47ab.png">

### After
<img width="1335" alt="Capture d’écran 2022-09-14 à 12 00 42" src="https://user-images.githubusercontent.com/113359769/190124640-b346596e-8a28-46c9-989b-18b09226fc84.png">

**Testing Strategy**
- Already covered by tests
- Manual testing
