### PR TITLE
Fix no card ranking

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-congrats/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-congrats/index.js
@@ -46,12 +46,18 @@ const ReviewCongrats = props => {
       <div className={style.containerCongrats}>
         <div className={style.title}>{title}</div>
         <div ref={container} className={style.containerCards}>
-          <MoleculeReviewCardCongrats {...cardCongratsStar} className={style.cardStar} />
-          <MoleculeReviewCardCongrats
-            {...cardCongratsRank}
-            timerAnimation={1800}
-            className={style.cardRank}
-          />
+          {cardCongratsRank ? (
+            <>
+              <MoleculeReviewCardCongrats {...cardCongratsStar} className={style.cardStar} />
+              <MoleculeReviewCardCongrats
+                {...cardCongratsRank}
+                timerAnimation={1800}
+                className={style.cardRank}
+              />
+            </>
+          ) : (
+            <MoleculeReviewCardCongrats {...cardCongratsStar} className={style.cardStarNoRank} />
+          )}
         </div>
         <div className={style.buttonContainer}>
           <ButtonLink

--- a/packages/@coorpacademy-components/src/organism/review-congrats/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-congrats/style.css
@@ -130,8 +130,7 @@
 }
 
 .cardStarNoRank {
-  animation: translateYCardStar 0.5s ease-out 0.8s forwards,
-    translateXCardStar 0.2s ease-in-out 2s forwards;
+  animation: translateYCardStar 0.5s ease-out 0.8s forwards;
   opacity: 0;
 }
 

--- a/packages/@coorpacademy-components/src/organism/review-congrats/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-congrats/style.css
@@ -129,6 +129,12 @@
   opacity: 0;
 }
 
+.cardStarNoRank {
+  animation: translateYCardStar 0.5s ease-out 0.8s forwards,
+    translateXCardStar 0.2s ease-in-out 2s forwards;
+  opacity: 0;
+}
+
 .cardRank {
   animation: translateCardRank 0.2s ease-in-out 2s forwards;
   position: absolute;

--- a/packages/@coorpacademy-components/src/organism/review-congrats/test/fixtures/no-rank.js
+++ b/packages/@coorpacademy-components/src/organism/review-congrats/test/fixtures/no-rank.js
@@ -1,0 +1,25 @@
+import animationLottie from '../../../../atom/lottie-wrapper/test/fixtures/confetti';
+import moleculeReviewCardStar from '../../../../molecule/review-card-congrats/test/fixtures/star';
+
+export const defaultProps = {
+  'aria-label': 'Review Congratulations',
+  'data-name': 'review-congrats',
+  animationLottie: {...animationLottie.props, height: undefined, width: undefined},
+  title: 'Congratulations!',
+  cardCongratsStar: moleculeReviewCardStar.props,
+  cardCongratsRank: undefined,
+  buttonRevising: {
+    'aria-label': 'Continue revising button',
+    label: 'Continue revising',
+    onClick: () => console.log('Continue revising'),
+    type: 'tertiary'
+  },
+  buttonRevisingSkill: {
+    label: 'Revise another skill',
+    'aria-label': 'Revise another skill button',
+    onClick: () => console.log('Revise another skill'),
+    type: 'primary'
+  }
+};
+
+export default {props: defaultProps};

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -984,6 +984,7 @@ import OrganismResourceBrowserFixturePdf from '../src/organism/resource-browser/
 import OrganismResourceBrowserFixtureVimeoWithOverlay from '../src/organism/resource-browser/test/fixtures/vimeo-with-overlay';
 import OrganismResourceBrowserFixtureVimeo from '../src/organism/resource-browser/test/fixtures/vimeo';
 import OrganismReviewCongratsFixtureDefault from '../src/organism/review-congrats/test/fixtures/default';
+import OrganismReviewCongratsFixtureNoRank from '../src/organism/review-congrats/test/fixtures/no-rank';
 import OrganismReviewHeaderFixtureAllQuestionsOk from '../src/organism/review-header/test/fixtures/all-questions-ok';
 import OrganismReviewHeaderFixtureCurrentQuestionNoAnswered from '../src/organism/review-header/test/fixtures/current-question-no-answered';
 import OrganismReviewHeaderFixtureCurrentQuestionWrong from '../src/organism/review-header/test/fixtures/current-question-wrong';
@@ -2694,7 +2695,8 @@ export const fixtures = {
       Vimeo: OrganismResourceBrowserFixtureVimeo
     },
     OrganismReviewCongrats: {
-      Default: OrganismReviewCongratsFixtureDefault
+      Default: OrganismReviewCongratsFixtureDefault,
+      NoRank: OrganismReviewCongratsFixtureNoRank
     },
     OrganismReviewHeader: {
       AllQuestionsOk: OrganismReviewHeaderFixtureAllQuestionsOk,


### PR DESCRIPTION
Trello ticket : https://trello.com/c/itUSRvt4/2747-components-ne-pas-afficher-la-card-ranking-si-pas-de-changement

**Detailed purpose of the PR**
When there is no changes in ranking status, the rank card is still displayed.

**Result and observation**

### BEFORE
<img width="1290" alt="no-card-ranking" src="https://user-images.githubusercontent.com/113359769/190197121-0360540f-c7f0-4a1d-affe-a6c1a369ce5e.png">

### AFTER
![Kapture 2022-09-14 at 16 43 32](https://user-images.githubusercontent.com/113359769/190197166-12fb17a2-11a3-4ddf-9bf5-29b20f491772.gif)

**Testing Strategy**
- Already covered by tests
- Manual testing