### PR TITLE
fix template review player ie11 style

### DIFF
--- a/packages/@coorpacademy-components/src/template/app-review/player/style.css
+++ b/packages/@coorpacademy-components/src/template/app-review/player/style.css
@@ -39,3 +39,10 @@
   top: 0;
   left: 0;
 }
+
+/* ie fallback */
+:-ms-fullscreen,
+:root .congrats {
+  position: relative;
+  bottom: 20%;
+}


### PR DESCRIPTION
 This PR solved this issue : 
https://trello.com/c/qAz5cIlZ/2752-components-popin-congrats-naffiche-pas-limage-sur-ie11

**Detailed purpose of the PR**
Popping congrat card in App Review was not displayed in IE11.

**Result and observation**

### BEFORE
<img width="1512" alt="IE11-template-card-congrats-issue" src="https://user-images.githubusercontent.com/113359769/190414694-21b09e21-fbc1-44bf-92d4-84708f8900ac.png">

### AFTER
### IE11
![Capture d’écran 2022-09-15 150957](https://user-images.githubusercontent.com/113359769/190419785-9554f459-23c8-44c4-ba03-2f71981399e6.png)

### CHROME
<img width="1661" alt="chrome-capture" src="https://user-images.githubusercontent.com/113359769/190421009-612da606-2ab8-4862-8440-7c717abd1661.png">


### FIREFOX
<img width="1661" alt="firefox-capture" src="https://user-images.githubusercontent.com/113359769/190421048-c3540692-1431-451b-82c8-430163e487ff.png">

**Testing Strategy**
- Already covered by tests
- Manual testing
