### PR TITLE
Fix slide question content locked

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -100,7 +100,7 @@ ValidateButton.propTypes = {
 };
 
 const QuestionContainer = props => {
-  const {answerUI, questionText, questionOrigin, disabledContent} = props;
+  const {answerUI, questionText, questionOrigin, disableContent} = props;
   if (!answerUI || !questionText) return null;
 
   const answerProps = get(['model', 'choices'], answerUI)
@@ -118,7 +118,7 @@ const QuestionContainer = props => {
       key="content-container"
       className={classnames(
         style.slideContentContainer,
-        disabledContent ? style.disabledSlideContent : null
+        disableContent ? style.disabledSlideContent : null
       )}
     >
       <div key="from-course" className={style.questionOrigin}>
@@ -144,7 +144,7 @@ QuestionContainer.propTypes = {
   answerUI: PropTypes.shape(propTypes.slide.answerUI),
   questionText: PropTypes.string,
   questionOrigin: PropTypes.string,
-  disabledContent: PropTypes.bool
+  disableContent: PropTypes.bool
 };
 
 const ReviewSlide = props => {
@@ -172,7 +172,7 @@ const ReviewSlide = props => {
             questionOrigin={parentContentTitle}
             questionText={questionText}
             answerUI={answerUI}
-            disabledContent={!showCorrectionPopin}
+            disableContent={!showCorrectionPopin}
             key="question-container"
           />,
           <ValidateButton

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -100,7 +100,7 @@ ValidateButton.propTypes = {
 };
 
 const QuestionContainer = props => {
-  const {answerUI, questionText, questionOrigin, disabled} = props;
+  const {answerUI, questionText, questionOrigin, disabledContent} = props;
   if (!answerUI || !questionText) return null;
 
   const answerProps = get(['model', 'choices'], answerUI)
@@ -117,7 +117,7 @@ const QuestionContainer = props => {
     <div
       key="content-container"
       className={
-        disabled
+        disabledContent
           ? style.slideContentContainer
           : classnames(style.slideContentContainer, style.disableSlideContent)
       }
@@ -145,7 +145,7 @@ QuestionContainer.propTypes = {
   answerUI: PropTypes.shape(propTypes.slide.answerUI),
   questionText: PropTypes.string,
   questionOrigin: PropTypes.string,
-  disabled: PropTypes.bool
+  disabledContent: PropTypes.bool
 };
 
 const ReviewSlide = props => {

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -100,7 +100,7 @@ ValidateButton.propTypes = {
 };
 
 const QuestionContainer = props => {
-  const {answerUI, questionText, questionOrigin, disabledContent} = props;
+  const {answerUI, questionText, questionOrigin, disableContent} = props;
   if (!answerUI || !questionText) return null;
 
   const answerProps = get(['model', 'choices'], answerUI)
@@ -117,9 +117,9 @@ const QuestionContainer = props => {
     <div
       key="content-container"
       className={
-        disabledContent
+        disableContent
           ? style.slideContentContainer
-          : classnames(style.slideContentContainer, style.disableSlideContent)
+          : classnames(style.slideContentContainer, style.disabledSlideContent)
       }
     >
       <div key="from-course" className={style.questionOrigin}>
@@ -145,7 +145,7 @@ QuestionContainer.propTypes = {
   answerUI: PropTypes.shape(propTypes.slide.answerUI),
   questionText: PropTypes.string,
   questionOrigin: PropTypes.string,
-  disabledContent: PropTypes.bool
+  disableContent: PropTypes.bool
 };
 
 const ReviewSlide = props => {

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -173,7 +173,7 @@ const ReviewSlide = props => {
             questionOrigin={parentContentTitle}
             questionText={questionText}
             answerUI={answerUI}
-            disabled={!showCorrectionPopin}
+            disableContent={!showCorrectionPopin}
             key="question-container"
           />,
           <ValidateButton

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -100,7 +100,7 @@ ValidateButton.propTypes = {
 };
 
 const QuestionContainer = props => {
-  const {answerUI, questionText, questionOrigin} = props;
+  const {answerUI, questionText, questionOrigin, disabled} = props;
   if (!answerUI || !questionText) return null;
 
   const answerProps = get(['model', 'choices'], answerUI)
@@ -114,7 +114,14 @@ const QuestionContainer = props => {
     : answerUI;
 
   return (
-    <div key="content-container" className={style.slideContentContainer}>
+    <div
+      key="content-container"
+      className={
+        disabled
+          ? style.slideContentContainer
+          : classnames(style.slideContentContainer, style.disableSlideContent)
+      }
+    >
       <div key="from-course" className={style.questionOrigin}>
         {questionOrigin}
       </div>
@@ -137,7 +144,8 @@ const QuestionContainer = props => {
 QuestionContainer.propTypes = {
   answerUI: PropTypes.shape(propTypes.slide.answerUI),
   questionText: PropTypes.string,
-  questionOrigin: PropTypes.string
+  questionOrigin: PropTypes.string,
+  disabled: PropTypes.bool
 };
 
 const ReviewSlide = props => {
@@ -165,6 +173,7 @@ const ReviewSlide = props => {
             questionOrigin={parentContentTitle}
             questionText={questionText}
             answerUI={answerUI}
+            disabled={!showCorrectionPopin}
             key="question-container"
           />,
           <ValidateButton

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -100,7 +100,7 @@ ValidateButton.propTypes = {
 };
 
 const QuestionContainer = props => {
-  const {answerUI, questionText, questionOrigin, disableContent} = props;
+  const {answerUI, questionText, questionOrigin, disabledContent} = props;
   if (!answerUI || !questionText) return null;
 
   const answerProps = get(['model', 'choices'], answerUI)
@@ -116,11 +116,10 @@ const QuestionContainer = props => {
   return (
     <div
       key="content-container"
-      className={
-        disableContent
-          ? style.slideContentContainer
-          : classnames(style.slideContentContainer, style.disabledSlideContent)
-      }
+      className={classnames(
+        style.slideContentContainer,
+        disabledContent ? style.disabledSlideContent : null
+      )}
     >
       <div key="from-course" className={style.questionOrigin}>
         {questionOrigin}
@@ -145,7 +144,7 @@ QuestionContainer.propTypes = {
   answerUI: PropTypes.shape(propTypes.slide.answerUI),
   questionText: PropTypes.string,
   questionOrigin: PropTypes.string,
-  disableContent: PropTypes.bool
+  disabledContent: PropTypes.bool
 };
 
 const ReviewSlide = props => {
@@ -173,7 +172,7 @@ const ReviewSlide = props => {
             questionOrigin={parentContentTitle}
             questionText={questionText}
             answerUI={answerUI}
-            disableContent={!showCorrectionPopin}
+            disabledContent={!showCorrectionPopin}
             key="question-container"
           />,
           <ValidateButton

--- a/packages/@coorpacademy-components/src/organism/review-slide/prop-types.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/prop-types.js
@@ -13,8 +13,7 @@ export const SlideProp = PropTypes.shape({
   showCorrectionPopin: PropTypes.bool,
   parentContentTitle: PropTypes.string,
   questionText: PropTypes.string,
-  answerUI: PropTypes.shape(AnswerPropTypes),
-  disabledContent: PropTypes.bool
+  answerUI: PropTypes.shape(AnswerPropTypes)
 });
 
 export default {

--- a/packages/@coorpacademy-components/src/organism/review-slide/prop-types.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/prop-types.js
@@ -13,7 +13,8 @@ export const SlideProp = PropTypes.shape({
   showCorrectionPopin: PropTypes.bool,
   parentContentTitle: PropTypes.string,
   questionText: PropTypes.string,
-  answerUI: PropTypes.shape(AnswerPropTypes)
+  answerUI: PropTypes.shape(AnswerPropTypes),
+  disabledContent: PropTypes.bool
 });
 
 export default {

--- a/packages/@coorpacademy-components/src/organism/review-slide/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-slide/style.css
@@ -138,7 +138,7 @@ _:-ms-fullscreen, :root .correctionPopinWrapper {
   width: 60px;
 }
 
-.disableSlideContent {
+.disabledSlideContent {
   pointer-events: none;
 }
 

--- a/packages/@coorpacademy-components/src/organism/review-slide/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-slide/style.css
@@ -138,6 +138,10 @@ _:-ms-fullscreen, :root .correctionPopinWrapper {
   width: 60px;
 }
 
+.disableSlideContent {
+  pointer-events: none;
+}
+
 @media tablet {
   @keyframes popInAnimation {
     from {


### PR DESCRIPTION
This PR solved this issue : 
https://trello.com/c/4drmAgoB/2718-componentsapp-review-bloquer-options-click-on-slide-after-validate-question

**Detailed purpose of the PR**
When correction poppin is enabled, the question content is unlocked.

**Result and observation**
### BEFORE
![Kapture 2022-09-16 at 17 21 44](https://user-images.githubusercontent.com/113359769/190674265-55d7dc5f-4bf1-46e1-8419-33c945bf5df8.gif)

### AFTER
![Kapture 2022-09-16 at 17 23 20](https://user-images.githubusercontent.com/113359769/190674592-ff4c5bad-2a0a-4036-9aec-76ff21768a10.gif)


**Testing Strategy**
- Already covered by tests
- Manual testing
