### PR TITLE
Fix missing type

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -162,7 +162,7 @@ const ReviewSlide = props => {
             questionOrigin={parentContentTitle}
             questionText={questionText}
             answerUI={answerUI}
-            disableContent={!showCorrectionPopin}
+            disableContent={showCorrectionPopin}
             key="question-container"
           />,
           <ValidateButton

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/prop-types.ts
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/prop-types.ts
@@ -1,15 +1,15 @@
 import PropTypes from 'prop-types';
-import ReviewSlideProps, {SlideProp} from '../review-slide/prop-types';
+import ReviewSlideProps, {SlidePropsTypes} from '../review-slide/prop-types';
 
 const propTypes = {
   validateButton: ReviewSlideProps.validateButton,
   correctionPopinProps: ReviewSlideProps.correctionPopinProps,
   slides: PropTypes.shape({
-    '0': SlideProp,
-    '1': SlideProp,
-    '2': SlideProp,
-    '3': SlideProp,
-    '4': SlideProp
+    '0': SlidePropsTypes,
+    '1': SlidePropsTypes,
+    '2': SlidePropsTypes,
+    '3': SlidePropsTypes,
+    '4': SlidePropsTypes
   }).isRequired,
   endReview: PropTypes.bool
 };

--- a/packages/@coorpacademy-components/src/util/proptypes.js
+++ b/packages/@coorpacademy-components/src/util/proptypes.js
@@ -2,9 +2,8 @@ import PropTypes from 'prop-types';
 import includes from 'lodash/fp/includes';
 import stringMatching from 'extended-proptypes/lib/validators/stringMatching';
 
-export ColorPropType from 'extended-proptypes/lib/validators/color';
-
-export HexPropType from 'extended-proptypes/lib/validators/hex';
+import _ColorPropType from 'extended-proptypes/lib/validators/color';
+import _HexPropType from 'extended-proptypes/lib/validators/hex';
 
 const URL_REGEXP = /^(http(s)?:\/\/.)[-a-zA-Z0-9@:%._\\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)$/;
 export const UrlPropType = stringMatching(URL_REGEXP);
@@ -20,3 +19,6 @@ export const ImagePropType = (propValue, key, componentName) => {
     `Invalid prop value: ${propValue[key]}, at component: ${componentName}. Expected a valid image type: jpg, png or svg+xml.`
   );
 };
+
+export const ColorPropType = _ColorPropType;
+export const HexPropType = _HexPropType;


### PR DESCRIPTION
**Detailed purpose of the PR**

We're currently having this error on the components project

````
lerna ERR! yarn run static --production stderr:
✘ [ERROR] No matching export in "../@coorpacademy-components/es/organism/review-slide/prop-types.js" for import "SlideProp"
    ../@coorpacademy-components/es/organism/review-stacked-slides/prop-types.js:2:27:
      2 │ import ReviewSlideProps, { SlideProp } from '../review-slide/prop-t...
        ╵                            ~~~~~~~~~
/home/travis/build/CoorpAcademy/components/node_modules/esbuild/lib/main.js:1603
  let error = new Error(`${text}${summary}`);
              ^
Error: Build failed with 1 error:
../@coorpacademy-components/es/organism/review-stacked-slides/prop-types.js:2:27: ERROR: No matching export in "../@coorpacademy-components/es/organism/review-slide/prop-types.js" for import "SlideProp"
    at failureErrorWithLog (/home/travis/build/CoorpAcademy/components/node_modules/esbuild/lib/main.js:1603:15)
    at /home/travis/build/CoorpAcademy/components/node_modules/esbuild/lib/main.js:1249:28
    at runOnEndCallbacks (/home/travis/build/CoorpAcademy/components/node_modules/esbuild/lib/main.js:1034:63)
    at buildResponseToResult (/home/travis/build/CoorpAcademy/components/node_modules/esbuild/lib/main.js:1247:7)
    at /home/travis/build/CoorpAcademy/components/node_modules/esbuild/lib/main.js:1356:14
    at /home/travis/build/CoorpAcademy/components/node_modules/esbuild/lib/main.js:666:9
    at handleIncomingPacket (/home/travis/build/CoorpAcademy/components/node_modules/esbuild/lib/main.js:763:9)
    at Socket.readFromStdout (/home/travis/build/CoorpAcademy/components/node_modules/esbuild/lib/main.js:632:7)
    at Socket.emit (node:events:527:28)
    at addChunk (node:internal/streams/readable:315:12) {
  errors: [
    {
      detail: undefined,
      location: {
        column: 27,
        file: '../@coorpacademy-components/es/organism/review-stacked-slides/prop-types.js',
        length: 9,
        line: 2,
        lineText: "import ReviewSlideProps, { SlideProp } from '../review-slide/prop-types';",
        namespace: '',
        suggestion: ''
      },
      notes: [],
      pluginName: '',
      text: 'No matching export in "../@coorpacademy-components/es/organism/review-slide/prop-types.js" for import "SlideProp"'
    }
  ],
  warnings: []
}
error Command failed with exit code 1.
lerna ERR! yarn run static --production exited 1 in '@coorpacademy/app-review'
lerna WARN complete Waiting for 1 child process to exit. CTRL-C to exit immediately.
The command "npm run static" exited with 1.
cache.2
store build cache
````

This PR fixes the error and allow the app-review to start.
This PR also fixes a problem with the ReviewSlide being blocked without correction popin... the scenario should be the inverse.