### PR TITLE
Add player close redirect function in app-review

### DIFF
--- a/packages/@coorpacademy-app-review/public/sandbox.tsx
+++ b/packages/@coorpacademy-app-review/public/sandbox.tsx
@@ -34,7 +34,11 @@ const createSandbox = (options: SandboxOptions): void => {
     const appOptions: AppOptions = {
       token: process.env.API_TEST_TOKEN || '',
       skillRef: '123',
-      services
+      services,
+      onQuitClick: () => {
+        // eslint-disable-next-line no-console
+        console.log('onQuitClick');
+      }
     };
     const skin = {
       common: {

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -29,7 +29,8 @@ const ConnectedApp = ({onQuitClick}: {onQuitClick: Function}): JSX.Element => {
     slides: useSelector((state: StoreState) => mapStateToSlidesProps(state, dispatch, onQuitClick)),
     skills: useSelector((state: StoreState) => mapStateToSkillsProps(state))
   };
-
+  // eslint-disable-next-line no-console
+  console.log(props);
   return <AppReviewTemplate {...props} />;
 };
 

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -36,7 +36,7 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
   const [store, setStore] = useState<Store<StoreState, AnyAction> | null>(null);
   const [isProgressionCreated, setIsProgressionCreated] = useState(false);
 
-  const onQuitClick = get('onQuitClick', options);
+  const onQuitClick = options.onQuitClick;
 
   useEffect(() => {
     if (store) return;

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -29,8 +29,6 @@ const ConnectedApp = ({onQuitClick}: {onQuitClick: Function}): JSX.Element => {
     slides: useSelector((state: StoreState) => mapStateToSlidesProps(state, dispatch, onQuitClick)),
     skills: useSelector((state: StoreState) => mapStateToSkillsProps(state))
   };
-  // eslint-disable-next-line no-console
-  console.log(props);
   return <AppReviewTemplate {...props} />;
 };
 

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -19,14 +19,14 @@ import {VIEWS} from './common';
 import {mapStateToSlidesProps} from './views/slides';
 import {mapStateToSkillsProps} from './views/skills';
 
-const ConnectedApp = (): JSX.Element => {
+const ConnectedApp = ({onQuitClick}: {onQuitClick: Function}): JSX.Element => {
   const dispatch = useDispatch();
 
   const props = {
     viewName: useSelector(
       (state: StoreState) => state.ui.navigation[state.ui.navigation.length - 1]
     ),
-    slides: useSelector((state: StoreState) => mapStateToSlidesProps(state, dispatch)),
+    slides: useSelector((state: StoreState) => mapStateToSlidesProps(state, dispatch, onQuitClick)),
     skills: useSelector((state: StoreState) => mapStateToSkillsProps(state))
   };
 
@@ -36,6 +36,8 @@ const ConnectedApp = (): JSX.Element => {
 const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
   const [store, setStore] = useState<Store<StoreState, AnyAction> | null>(null);
   const [isProgressionCreated, setIsProgressionCreated] = useState(false);
+
+  const onQuitClick = get('onQuitClick', options);
 
   useEffect(() => {
     if (store) return;
@@ -88,7 +90,7 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
 
   return (
     <Provider store={store}>
-      <ConnectedApp />
+      <ConnectedApp onQuitClick={onQuitClick} />
     </Provider>
   );
 };

--- a/packages/@coorpacademy-app-review/src/test/index.test.tsx
+++ b/packages/@coorpacademy-app-review/src/test/index.test.tsx
@@ -59,7 +59,11 @@ const clickAllSlides = async (
 const appOptions: AppOptions = {
   token: process.env.API_TEST_TOKEN || '',
   skillRef: 'skill_NJC0jFKoH',
-  services
+  services,
+  onQuitClick: (): void => {
+    // eslint-disable-next-line no-console
+    console.log('onQuitClick - options');
+  }
 };
 
 test('should show the loader while the app is fetching the data', async t => {

--- a/packages/@coorpacademy-app-review/src/test/index.test.tsx
+++ b/packages/@coorpacademy-app-review/src/test/index.test.tsx
@@ -1,4 +1,5 @@
 import browserEnv from 'browser-env';
+import identity from 'lodash/fp/identity';
 import test from 'ava';
 import type {ExecutionContext} from 'ava';
 import React from 'react';
@@ -60,10 +61,7 @@ const appOptions: AppOptions = {
   token: process.env.API_TEST_TOKEN || '',
   skillRef: 'skill_NJC0jFKoH',
   services,
-  onQuitClick: (): void => {
-    // eslint-disable-next-line no-console
-    console.log('onQuitClick');
-  }
+  onQuitClick: identity
 };
 
 test('should show the loader while the app is fetching the data', async t => {

--- a/packages/@coorpacademy-app-review/src/test/index.test.tsx
+++ b/packages/@coorpacademy-app-review/src/test/index.test.tsx
@@ -62,7 +62,7 @@ const appOptions: AppOptions = {
   services,
   onQuitClick: (): void => {
     // eslint-disable-next-line no-console
-    console.log('onQuitClick - options');
+    console.log('onQuitClick');
   }
 };
 

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -171,6 +171,7 @@ export type AppOptions = {
   token: string;
   skillRef?: string;
   services: Services;
+  onQuitClick: Function;
 };
 
 export type JWT = {

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -298,7 +298,11 @@ const getCorrectionPopinProps = (
   type: isCorrect ? 'right' : 'wrong'
 });
 
-export const mapStateToSlidesProps = (state: StoreState, dispatch: Dispatch): SlidesViewProps => {
+export const mapStateToSlidesProps = (
+  state: StoreState,
+  dispatch: Dispatch,
+  onQuitClick: Function
+): SlidesViewProps => {
   const currentSlideRef = get(['ui', 'currentSlideRef'], state);
   const correction = get(['data', 'corrections', currentSlideRef], state);
   const isCorrect = get(['data', 'progression', 'state', 'isCorrect'], state);
@@ -311,6 +315,7 @@ export const mapStateToSlidesProps = (state: StoreState, dispatch: Dispatch): Sl
       onQuitClick: (): void => {
         // eslint-disable-next-line no-console
         console.log('onQuitClick');
+        onQuitClick;
       },
       'aria-label': 'aria-header-wrapper',
       closeButtonAriaLabel: 'aria-close-button',

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -312,7 +312,9 @@ export const mapStateToSlidesProps = (
     header: {
       mode: '__revision_mode',
       skillName: '__agility',
-      onQuitClick,
+      onQuitClick: (): void => {
+        onQuitClick();
+      },
       'aria-label': 'aria-header-wrapper',
       closeButtonAriaLabel: 'aria-close-button',
       steps: buildStepItems(state)

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -312,9 +312,7 @@ export const mapStateToSlidesProps = (
     header: {
       mode: '__revision_mode',
       skillName: '__agility',
-      onQuitClick: (): void => {
-        onQuitClick();
-      },
+      onQuitClick,
       'aria-label': 'aria-header-wrapper',
       closeButtonAriaLabel: 'aria-close-button',
       steps: buildStepItems(state)

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -312,11 +312,7 @@ export const mapStateToSlidesProps = (
     header: {
       mode: '__revision_mode',
       skillName: '__agility',
-      onQuitClick: (): void => {
-        // eslint-disable-next-line no-console
-        console.log('onQuitClick');
-        onQuitClick;
-      },
+      onQuitClick,
       'aria-label': 'aria-header-wrapper',
       closeButtonAriaLabel: 'aria-close-button',
       steps: buildStepItems(state)

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -74,7 +74,7 @@ test('should create initial props when fetched slide is not still received', t =
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.is(props.congratsProps, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
@@ -169,7 +169,7 @@ test('should create props when first slide is on the state', t => {
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.is(props.congratsProps, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
@@ -278,7 +278,7 @@ test('should create props when slide is on the state and user has selected answe
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.is(props.congratsProps, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
@@ -393,7 +393,7 @@ test('should verify props when first slide was answered correctly and next slide
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.is(props.congratsProps, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
@@ -512,7 +512,7 @@ test('should verify props when first slide was answered with error and next slid
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.is(props.congratsProps, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
@@ -584,7 +584,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.is(props.congratsProps, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
@@ -705,7 +705,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.is(props.congratsProps, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
@@ -828,7 +828,7 @@ test('should verify props when currentSlideRef has changed to nextContent of pro
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.is(props.congratsProps, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
@@ -930,7 +930,7 @@ test('should verify props when progression is in success', t => {
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.is(props.congratsProps, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
@@ -1032,7 +1032,7 @@ test('should verify props when progression has answered a current pendingSlide',
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
@@ -1131,7 +1131,7 @@ test('should verify props when progression still has a pendingSlide', t => {
     }
   };
 
-  const props = mapStateToSlidesProps(state, identity);
+  const props = mapStateToSlidesProps(state, identity, identity);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import omit from 'lodash/fp/omit';
 import get from 'lodash/fp/get';
+import identity from 'lodash/fp/identity';
 import {mapStateToSlidesProps} from '..';
 import {ProgressionFromAPI} from '../../../types/common';
 import {services} from '../../../test/util/services.mock';
@@ -69,7 +70,7 @@ test('should dispatch EDIT_BASIC action via the property onChange of a Free Text
   ];
   const {dispatch, getState} = createTestStore(t, initialState, services, expectedActions);
 
-  const props = mapStateToSlidesProps(getState(), dispatch);
+  const props = mapStateToSlidesProps(getState(), dispatch, identity);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
     animateCorrectionPopin: false,
     showCorrectionPopin: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import omit from 'lodash/fp/omit';
 import get from 'lodash/fp/get';
+import identity from 'lodash/fp/identity';
 import {mapStateToSlidesProps} from '..';
 import {ProgressionFromAPI} from '../../../types/common';
 import {services} from '../../../test/util/services.mock';
@@ -69,7 +70,7 @@ test('should dispatch EDIT_QCM_DRAG action via the property onClick of a QCM Dra
   ];
   const {dispatch, getState} = createTestStore(t, initialState, services, expectedActions);
 
-  const props = mapStateToSlidesProps(getState(), dispatch);
+  const props = mapStateToSlidesProps(getState(), dispatch, identity);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
     animateCorrectionPopin: false,
     showCorrectionPopin: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import omit from 'lodash/fp/omit';
 import get from 'lodash/fp/get';
+import identity from 'lodash/fp/identity';
 import {mapStateToSlidesProps} from '..';
 import {ProgressionFromAPI} from '../../../types/common';
 import {services} from '../../../test/util/services.mock';
@@ -69,7 +70,7 @@ test('should dispatch EDIT_QCM_GRAPHIC action via the property onClick of a QCM 
   ];
   const {dispatch, getState} = createTestStore(t, initialState, services, expectedActions);
 
-  const props = mapStateToSlidesProps(getState(), dispatch);
+  const props = mapStateToSlidesProps(getState(), dispatch, identity);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
     animateCorrectionPopin: false,
     showCorrectionPopin: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import omit from 'lodash/fp/omit';
 import get from 'lodash/fp/get';
+import identity from 'lodash/fp/identity';
 import {mapStateToSlidesProps} from '..';
 import {ProgressionFromAPI} from '../../../types/common';
 import {services} from '../../../test/util/services.mock';
@@ -71,7 +72,7 @@ test('should dispatch EDIT_QCM action via the property onClick of a QCM slide', 
   ];
   const {dispatch, getState} = createTestStore(t, initialState, services, expectedActions);
 
-  const props = mapStateToSlidesProps(getState(), dispatch);
+  const props = mapStateToSlidesProps(getState(), dispatch, identity);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
     animateCorrectionPopin: false,
     showCorrectionPopin: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import omit from 'lodash/fp/omit';
 import get from 'lodash/fp/get';
+import identity from 'lodash/fp/identity';
 import {mapStateToSlidesProps} from '..';
 import {ProgressionFromAPI} from '../../../types/common';
 import {services} from '../../../test/util/services.mock';
@@ -69,7 +70,7 @@ test('should dispatch EDIT_SLIDER action via the property onChange of a Slider s
   ];
   const {dispatch, getState} = createTestStore(t, initialState, services, expectedActions);
 
-  const props = mapStateToSlidesProps(getState(), dispatch);
+  const props = mapStateToSlidesProps(getState(), dispatch, identity);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
     animateCorrectionPopin: false,
     showCorrectionPopin: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
 import get from 'lodash/fp/get';
+import identity from 'lodash/fp/identity';
 import {ProgressionFromAPI} from '../../../types/common';
 import {StoreState} from '../../../reducers';
 import {mapStateToSlidesProps} from '..';
@@ -67,7 +68,7 @@ test('should dispatch EDIT_SLIDER action via the property onSliderChange of a Sl
     }
   ];
   const {dispatch, getState} = createTestStore(t, initialState, services, expectedActions);
-  const props = mapStateToSlidesProps(getState(), dispatch);
+  const props = mapStateToSlidesProps(getState(), dispatch, identity);
 
   const SlideProps = props.stack.slides['0'].answerUI?.model as QuestionRange;
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import omit from 'lodash/fp/omit';
 import get from 'lodash/fp/get';
+import identity from 'lodash/fp/identity';
 import {mapStateToSlidesProps} from '..';
 import {ProgressionFromAPI} from '../../../types/common';
 import {services} from '../../../test/util/services.mock';
@@ -65,7 +66,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
   ];
   const {dispatch, getState} = createTestStore(t, initialState, services, expectedActions);
 
-  const props = mapStateToSlidesProps(getState(), dispatch);
+  const props = mapStateToSlidesProps(getState(), dispatch, identity);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -89,7 +90,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
   ];
   const {dispatch, getState} = createTestStore(t, initialState, services, expectedActions);
 
-  const props = mapStateToSlidesProps(getState(), dispatch);
+  const props = mapStateToSlidesProps(getState(), dispatch, identity);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
     animateCorrectionPopin: false,
     showCorrectionPopin: false,


### PR DESCRIPTION
This PR is part of this ticket :
[https://trello.com/c/cY21kKro/2756-moocapp-review-passer-la-fonction-pour-rediriger-vers-le-dashboard-skills-lors-du-click-du-bouton-close-du-header-du-player](url)

**Detailed purpose of the PR**
We need to implement the close redirect function from the review slide to the review dashboard.
This feature needs to be implemented in both app-review  and MOOC.
This first PR is about implementing the feature in app-review.

Current Behaviour : 
close button is disable.
![Capture d’écran 2022-09-21 à 11 11 02](https://user-images.githubusercontent.com/113359769/191464880-babd4e37-2f06-40b6-8351-477d1db6e8ec.png)

**Result and observation**
- onQuitClick function added to MapStateSlidesProps
- tests have been updated.

**Testing Strategy**
- Manual testing
- Unit testing
