### PR TITLE
Add Molecule OnQuit Popin to TemplateAppReviewPlayer

### DIFF
--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -93,7 +93,7 @@ export type SlidesViewProps = {
     endReview: boolean;
   };
   reviewBackgroundAriaLabel?: string;
-  congratsProps?: {
+  congrats?: {
     'aria-label'?: string;
     'data-name'?: string;
     animationLottie: unknown;
@@ -336,6 +336,6 @@ export const mapStateToSlidesProps = (
         correction && getCorrectionPopinProps(dispatch)(isCorrect, correction.correctAnswer, klf),
       endReview: false
     },
-    congratsProps: undefined
+    congrats: undefined
   };
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -45,7 +45,7 @@ test('should create initial props when fetched slide is not still received', t =
   };
 
   const props = mapStateToSlidesProps(state, identity, identity);
-  t.is(props.congratsProps, undefined);
+  t.is(props.congrats, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
@@ -140,7 +140,7 @@ test('should create props when first slide is on the state', t => {
   };
 
   const props = mapStateToSlidesProps(state, identity, identity);
-  t.is(props.congratsProps, undefined);
+  t.is(props.congrats, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
@@ -250,7 +250,7 @@ test('should create props when slide is on the state and user has selected answe
   };
 
   const props = mapStateToSlidesProps(state, identity, identity);
-  t.is(props.congratsProps, undefined);
+  t.is(props.congrats, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
@@ -366,7 +366,7 @@ test('should verify props when first slide was answered correctly and next slide
   };
 
   const props = mapStateToSlidesProps(state, identity, identity);
-  t.is(props.congratsProps, undefined);
+  t.is(props.congrats, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
@@ -486,7 +486,7 @@ test('should verify props when first slide was answered with error and next slid
   };
 
   const props = mapStateToSlidesProps(state, identity, identity);
-  t.is(props.congratsProps, undefined);
+  t.is(props.congrats, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
@@ -558,7 +558,7 @@ test('should verify props when first slide was answered, next slide is fetched &
   };
 
   const props = mapStateToSlidesProps(state, identity, identity);
-  t.is(props.congratsProps, undefined);
+  t.is(props.congrats, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
@@ -692,7 +692,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
   };
 
   const props = mapStateToSlidesProps(state, identity, identity);
-  t.is(props.congratsProps, undefined);
+  t.is(props.congrats, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
@@ -833,7 +833,7 @@ test('should verify props when currentSlideRef has changed to nextContent of pro
   };
 
   const props = mapStateToSlidesProps(state, identity, identity);
-  t.is(props.congratsProps, undefined);
+  t.is(props.congrats, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
@@ -939,7 +939,7 @@ test('should verify props when progression is in success', t => {
   };
 
   const props = mapStateToSlidesProps(state, identity, identity);
-  t.is(props.congratsProps, undefined);
+  t.is(props.congrats, undefined);
   t.deepEqual(omit(['onQuitClick'], props.header), {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
@@ -361,3 +361,8 @@ _:-ms-fullscreen,
 .popin {
   position: relative;
 }
+
+_:-ms-fullscreen 
+.buttonContainer {
+  width: 85%;
+}

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
@@ -353,5 +353,10 @@ _:-ms-fullscreen,
 
 _:-ms-fullscreen,
 .button {
-  width: 40%;
+  width: 100%;
+}
+
+_:-ms-fullscreen,
+.popin {
+  position: relative;
 }

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
@@ -347,7 +347,8 @@ button {
 }
 
 _:-ms-fullscreen,
-.descriptionText {
+.descriptionText,
+.buttonContainer {
   width: 85%;
 }
 

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/style.css
@@ -155,9 +155,6 @@
 }
 
 @media mobile {
-  .stackedSlidesContainer {
-    max-width: 335px;
-  }
   .slideBase {
     height: calc(100vh - 185px);
   }

--- a/packages/@coorpacademy-components/src/template/app-review/player/index.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/index.js
@@ -15,10 +15,6 @@ const PlayerReview = ({
   congratsProps,
   onQuitPopinProps
 }) => {
-  // eslint-disable-next-line no-console
-  console.log('onQuitPopinProps');
-  // eslint-disable-next-line no-console
-  console.log(onQuitPopinProps);
   return (
     <div
       key="review-player-container"

--- a/packages/@coorpacademy-components/src/template/app-review/player/index.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/index.js
@@ -4,10 +4,21 @@ import ReviewBackground from '../../../atom/review-background';
 import ReviewCongrats from '../../../organism/review-congrats';
 import ReviewHeader from '../../../organism/review-header';
 import StackedSlides from '../../../organism/review-stacked-slides';
+import CMPopin from '../../../molecule/cm-popin';
 import style from './style.css';
 import {PlayerReviewPropTypes} from './prop-types';
 
-const PlayerReview = ({header, stack, reviewBackgroundAriaLabel, congratsProps}) => {
+const PlayerReview = ({
+  header,
+  stack,
+  reviewBackgroundAriaLabel,
+  congratsProps,
+  onQuitPopinProps
+}) => {
+  // eslint-disable-next-line no-console
+  console.log('onQuitPopinProps');
+  // eslint-disable-next-line no-console
+  console.log(onQuitPopinProps);
   return (
     <div
       key="review-player-container"
@@ -17,16 +28,19 @@ const PlayerReview = ({header, stack, reviewBackgroundAriaLabel, congratsProps})
       <div key="player-background-container" className={style.playerBackground}>
         <ReviewBackground aria-label={reviewBackgroundAriaLabel} />
       </div>
-
       <div key="review-header-wrapper" className={style.reviewHeaderContainer}>
         <ReviewHeader {...header} />
       </div>
-
       <StackedSlides {...stack} />
-
       {isNil(congratsProps) ? null : (
         <div className={style.congrats} data-name="congrats-container">
           <ReviewCongrats {...congratsProps} />
+        </div>
+      )}
+
+      {isNil(onQuitPopinProps) ? null : (
+        <div className={style.onQuitPopin} data-name="popin-container">
+          <CMPopin {...onQuitPopinProps} />
         </div>
       )}
     </div>

--- a/packages/@coorpacademy-components/src/template/app-review/player/index.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/index.js
@@ -8,13 +8,7 @@ import CMPopin from '../../../molecule/cm-popin';
 import style from './style.css';
 import {PlayerReviewPropTypes} from './prop-types';
 
-const PlayerReview = ({
-  header,
-  stack,
-  reviewBackgroundAriaLabel,
-  congratsProps,
-  onQuitPopinProps
-}) => {
+const PlayerReview = ({header, stack, reviewBackgroundAriaLabel, congrats, quitPopin}) => {
   return (
     <div
       key="review-player-container"
@@ -28,15 +22,15 @@ const PlayerReview = ({
         <ReviewHeader {...header} />
       </div>
       <StackedSlides {...stack} />
-      {isNil(congratsProps) ? null : (
+      {isNil(congrats) ? null : (
         <div className={style.congrats} data-name="congrats-container">
-          <ReviewCongrats {...congratsProps} />
+          <ReviewCongrats {...congrats} />
         </div>
       )}
 
-      {isNil(onQuitPopinProps) ? null : (
-        <div className={style.onQuitPopin} data-name="popin-container">
-          <CMPopin {...onQuitPopinProps} />
+      {isNil(quitPopin) ? null : (
+        <div className={style.quitPopin} data-name="popin-container">
+          <CMPopin {...quitPopin} />
         </div>
       )}
     </div>

--- a/packages/@coorpacademy-components/src/template/app-review/player/prop-types.ts
+++ b/packages/@coorpacademy-components/src/template/app-review/player/prop-types.ts
@@ -10,8 +10,8 @@ export const PlayerReviewPropTypes = {
   header: PropTypes.shape(ReviewHeaderPropTypes),
   stack: PropTypes.shape(StackedSlidesPropTypes),
   reviewBackgroundAriaLabel: ReviewBackgroundPropTypes['aria-label'],
-  congratsProps: PropTypes.shape(ReviewCongratsPropTypes),
-  onQuitPopinProps: PropTypes.shape({...CmPopin.propTypes})
+  congrats: PropTypes.shape(ReviewCongratsPropTypes),
+  quitPopin: PropTypes.shape({...CmPopin.propTypes})
 };
 
 export type Props = PropTypes.InferProps<typeof PlayerReviewPropTypes>;

--- a/packages/@coorpacademy-components/src/template/app-review/player/prop-types.ts
+++ b/packages/@coorpacademy-components/src/template/app-review/player/prop-types.ts
@@ -4,12 +4,14 @@ import ReviewCongratsPropTypes from '../../../organism/review-congrats/prop-type
 import ReviewBackgroundPropTypes from '../../../atom/review-background/prop-types';
 import ReviewHeaderPropTypes from '../../../organism/review-header/prop-types';
 import StackedSlidesPropTypes from '../../../organism/review-stacked-slides/prop-types';
+import CmPopin from '../../../molecule/cm-popin';
 
 export const PlayerReviewPropTypes = {
   header: PropTypes.shape(ReviewHeaderPropTypes),
   stack: PropTypes.shape(StackedSlidesPropTypes),
   reviewBackgroundAriaLabel: ReviewBackgroundPropTypes['aria-label'],
-  congratsProps: PropTypes.shape(ReviewCongratsPropTypes)
+  congratsProps: PropTypes.shape(ReviewCongratsPropTypes),
+  popin: PropTypes.shape({...CmPopin.propTypes})
 };
 
 export type Props = PropTypes.InferProps<typeof PlayerReviewPropTypes>;

--- a/packages/@coorpacademy-components/src/template/app-review/player/prop-types.ts
+++ b/packages/@coorpacademy-components/src/template/app-review/player/prop-types.ts
@@ -11,7 +11,7 @@ export const PlayerReviewPropTypes = {
   stack: PropTypes.shape(StackedSlidesPropTypes),
   reviewBackgroundAriaLabel: ReviewBackgroundPropTypes['aria-label'],
   congratsProps: PropTypes.shape(ReviewCongratsPropTypes),
-  popin: PropTypes.shape({...CmPopin.propTypes})
+  onQuitPopinProps: PropTypes.shape({...CmPopin.propTypes})
 };
 
 export type Props = PropTypes.InferProps<typeof PlayerReviewPropTypes>;

--- a/packages/@coorpacademy-components/src/template/app-review/player/style.css
+++ b/packages/@coorpacademy-components/src/template/app-review/player/style.css
@@ -50,3 +50,9 @@
   position: relative;
   bottom: 20%;
 }
+
+:-ms-fullscreen,
+.onQuitPopin {
+  position: absolute;
+  z-index: 80;
+}

--- a/packages/@coorpacademy-components/src/template/app-review/player/style.css
+++ b/packages/@coorpacademy-components/src/template/app-review/player/style.css
@@ -41,9 +41,8 @@
 }
 
 .onQuitPopin {
-  background-color: white;
+  z-index: 50;
 }
-
 
 /* ie fallback */
 :-ms-fullscreen,

--- a/packages/@coorpacademy-components/src/template/app-review/player/style.css
+++ b/packages/@coorpacademy-components/src/template/app-review/player/style.css
@@ -40,6 +40,11 @@
   left: 0;
 }
 
+.onQuitPopin {
+  background-color: white;
+}
+
+
 /* ie fallback */
 :-ms-fullscreen,
 :root .congrats {

--- a/packages/@coorpacademy-components/src/template/app-review/player/style.css
+++ b/packages/@coorpacademy-components/src/template/app-review/player/style.css
@@ -40,7 +40,7 @@
   left: 0;
 }
 
-.onQuitPopin {
+.quitPopin {
   z-index: 50;
 }
 
@@ -52,7 +52,7 @@
 }
 
 :-ms-fullscreen,
-.onQuitPopin {
+.quitPopin {
   position: absolute;
   z-index: 80;
 }

--- a/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/end-review.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/end-review.js
@@ -1,4 +1,4 @@
-import congratsProps from '../../../../../organism/review-congrats/test/fixtures/default';
+import congrats from '../../../../../organism/review-congrats/test/fixtures/default';
 import Header from '../../../../../organism/review-header/test/fixtures/steps-animation';
 import EndReviewStackedSlides from '../../../../../organism/review-stacked-slides/test/fixtures/end-review';
 
@@ -7,6 +7,6 @@ export default {
     header: Header.props,
     stack: EndReviewStackedSlides.props,
     reviewBackgroundAriaLabel: 'image background',
-    congrats: congratsProps.props
+    congrats: congrats.props
   }
 };

--- a/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/end-review.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/end-review.js
@@ -7,6 +7,6 @@ export default {
     header: Header.props,
     stack: EndReviewStackedSlides.props,
     reviewBackgroundAriaLabel: 'image background',
-    congratsProps: congratsProps.props
+    congrats: congratsProps.props
   }
 };

--- a/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/on-quit.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/on-quit.js
@@ -7,6 +7,6 @@ export default {
     header: headerProps.props,
     stack: DefaultStackedSlides.props,
     reviewBackgroundAriaLabel: 'review BG Aria',
-    onQuitPopinProps: onReviewQuitPopin.props
+    quitPopin: onReviewQuitPopin.props
   }
 };

--- a/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/on-quit.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/on-quit.js
@@ -1,0 +1,12 @@
+import headerProps from '../../../../../organism/review-header/test/fixtures/no-answered-question';
+import DefaultStackedSlides from '../../../../../organism/review-stacked-slides/test/fixtures/initial-state';
+import onReviewQuitPopin from '../../../../../molecule/cm-popin/test/fixtures/on-review-quit';
+
+export default {
+  props: {
+    header: headerProps.props,
+    stack: DefaultStackedSlides.props,
+    reviewBackgroundAriaLabel: 'review BG Aria',
+    popin: onReviewQuitPopin.props
+  }
+};

--- a/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/on-quit.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/on-quit.js
@@ -7,6 +7,6 @@ export default {
     header: headerProps.props,
     stack: DefaultStackedSlides.props,
     reviewBackgroundAriaLabel: 'review BG Aria',
-    popin: onReviewQuitPopin.props
+    onQuitPopinProps: onReviewQuitPopin.props
   }
 };

--- a/packages/@coorpacademy-components/storybook/components.js
+++ b/packages/@coorpacademy-components/storybook/components.js
@@ -1183,6 +1183,7 @@ import TemplateAppReviewPlayerFixtureEndReview from '../src/template/app-review/
 import TemplateAppReviewPlayerFixtureFirstRight from '../src/template/app-review/player/test/fixtures/first-right';
 import TemplateAppReviewPlayerFixtureInitialState from '../src/template/app-review/player/test/fixtures/initial-state';
 import TemplateAppReviewPlayerFixtureLoading from '../src/template/app-review/player/test/fixtures/loading';
+import TemplateAppReviewPlayerFixtureOnQuit from '../src/template/app-review/player/test/fixtures/on-quit';
 import TemplateAppReviewPlayerFixtureOneFail from '../src/template/app-review/player/test/fixtures/one-fail';
 import TemplateAppReviewPlayerFixtureRestack from '../src/template/app-review/player/test/fixtures/restack';
 import TemplateAppReviewPlayerFixtureSecondFailedQuestion from '../src/template/app-review/player/test/fixtures/second-failed-question';
@@ -2994,6 +2995,7 @@ export const fixtures = {
       FirstRight: TemplateAppReviewPlayerFixtureFirstRight,
       InitialState: TemplateAppReviewPlayerFixtureInitialState,
       Loading: TemplateAppReviewPlayerFixtureLoading,
+      OnQuit: TemplateAppReviewPlayerFixtureOnQuit,
       OneFail: TemplateAppReviewPlayerFixtureOneFail,
       Restack: TemplateAppReviewPlayerFixtureRestack,
       SecondFailedQuestion: TemplateAppReviewPlayerFixtureSecondFailedQuestion,


### PR DESCRIPTION
This PR is part of this issue :
https://trello.com/c/B6reeZqQ/2772-components-popin-confirmer-quitter-mode-revision

**Detailed purpose of the PR**
Add the popin quit to the template AppReviewPlayer

**Result and observation**
### CHROME
![Capture d’écran 2022-09-27 à 17 57 59](https://user-images.githubusercontent.com/113359769/192576313-f1980fae-77e7-4dee-9cfe-7b8d36cd9f14.png)

### IE
![Capture d’écran 2022-09-27 180136](https://user-images.githubusercontent.com/113359769/192577103-7ad5b53d-0ba4-4ba9-a6a7-50d32097f5ef.png)

### IE MOBILE
![Capture d’écran 2022-09-28 121113](https://user-images.githubusercontent.com/113359769/192755246-84dcb315-6544-47b0-8044-4038b6fd59f1.png)

### MOBILE
![Capture d’écran 2022-09-27 à 18 00 08](https://user-images.githubusercontent.com/113359769/192576681-88961842-70d6-4e1b-8b55-ddb7b71c9c24.png)

**Testing Strategy**
- Already covered by tests
- Manual testing
