### PR TITLE
[SCORMIFICATION] fix retry button access in scorm mode

### DIFF
--- a/packages/@coorpacademy-components/src/template/app-player/popin-end/summary.js
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-end/summary.js
@@ -249,8 +249,8 @@ const BackgroundScorm = props => {
   if (mode === 'scorm')
     return (
       <div className={style.organismPlayerResultContainerScorm}>
-        <div className={style.animationContainer}>
-          {failed === false ? (
+        {failed === false ? (
+          <div className={style.animationContainer}>
             <AtomLottieWrapper
               {...{
                 'aria-label': 'aria lottie',
@@ -275,8 +275,8 @@ const BackgroundScorm = props => {
               className={style.lottie}
               backupImageClassName={style.ie11Backup}
             />
-          ) : null}
-        </div>
+          </div>
+        ) : null}
         <div className={style.background}>
           <div className={style.largeCircle} />
           <div className={style.mediumCircle} />


### PR DESCRIPTION
La div de l'animation de succès était au dessus du bouton `retry`. Or en mode échec, il n'y a pas d'animation.

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
