### PR TITLE
Fixing condition to get the 5th slide on review mode

### DIFF
--- a/packages/@coorpacademy-app-review/src/common/index.ts
+++ b/packages/@coorpacademy-app-review/src/common/index.ts
@@ -17,7 +17,7 @@ export const slideIndexes = ['0', '1', '2', '3', '4'] as const;
 export type SlideIndexes = typeof slideIndexes[number];
 
 export const getProgressionSlidesRefs = (progression: ProgressionFromAPI): string[] => {
-  if (progression.state.step.current < 5) {
+  if (progression.state.step.current <= 5) {
     const slideRef = progression.state.nextContent.ref;
     return concat(progression.state.slides, [slideRef]);
   }

--- a/packages/@coorpacademy-app-review/src/common/test/get-progression-slide-ref.test.ts
+++ b/packages/@coorpacademy-app-review/src/common/test/get-progression-slide-ref.test.ts
@@ -1,0 +1,35 @@
+import test from 'ava';
+import {
+  postAnswerResponses,
+  postProgressionResponse,
+  progressionSlideWithPendingSlide
+} from '../../test/util/services.mock';
+import {templateSlide} from '../../views/slides/test/fixtures/template';
+import {getProgressionSlidesRefs} from '..';
+
+test('should return first slide for a created slide', t => {
+  const slides = getProgressionSlidesRefs(postProgressionResponse);
+  t.deepEqual(slides, ['sli_VJYjJnJhg']);
+});
+
+test('should return all 5 slides when user is going to answer the 5th slide', t => {
+  const slides = getProgressionSlidesRefs(postAnswerResponses[templateSlide._id]);
+  t.deepEqual(slides, [
+    'sli_VJYjJnJhg',
+    'sli_VkSQroQnx',
+    'sli_N1XACJobn',
+    'sli_VkAzsCLKb',
+    'sli_N13-hG3kX'
+  ]);
+});
+
+test('should return all 5 slides when progression has a nextContent ref that is a pending slide', t => {
+  const slides = getProgressionSlidesRefs(progressionSlideWithPendingSlide);
+  t.deepEqual(slides, [
+    'sli_VJYjJnJhg',
+    'sli_VkSQroQnx',
+    'sli_N1XACJobn',
+    'sli_VkAzsCLKb',
+    'sli_N13-hG3kX'
+  ]);
+});


### PR DESCRIPTION
**Detailed purpose of the PR**

Before this PR the fifth question of the review mode was not charged. This Prs fixes this bug.

**Result and observation**

![5th-slide-review](https://user-images.githubusercontent.com/7602475/193554869-cf50933b-7c93-4de6-ae08-9ca8f09c4e5e.gif)

**Testing Strategy**

- Already covered by tests
- Manual testing
