### PR TITLE
fix responsive exit node retry button

### DIFF
--- a/packages/@coorpacademy-components/src/template/app-player/popin-end/summary.css
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-end/summary.css
@@ -65,7 +65,7 @@
 }
 
 @media mobile {
-  .simpleWrapper {
+  .simpleTexts {
     display: none;
   }
 }


### PR DESCRIPTION
fix the problem: responsive exit node retry button is hidden in mobile dimensions
[ticket](https://trello.com/c/MowL2OtQ/1056-fixer-responsive-exitnode-en-mobile-sur-le-player-scorm-bouton-retry-non-cliquable)

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
