### PR TITLE
[review] Allowing hide bouton on congrats for review

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-congrats/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-congrats/index.js
@@ -60,12 +60,16 @@ const ReviewCongrats = props => {
           )}
         </div>
         <div className={style.buttonContainer}>
-          <ButtonLink
-            {...buttonRevising}
-            className={style.buttonRevise}
-            data-name="revise-skill-link"
-          />
-          <ButtonLink {...buttonRevisingSkill} className={style.buttonRevise} />
+          {buttonRevising ? (
+            <ButtonLink
+              {...buttonRevising}
+              className={style.buttonRevise}
+              data-name="revise-skill-link"
+            />
+          ) : null}
+          {buttonRevisingSkill ? (
+            <ButtonLink {...buttonRevisingSkill} className={style.buttonRevise} />
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/@coorpacademy-components/src/organism/review-congrats/test/fixtures/no-buttons.js
+++ b/packages/@coorpacademy-components/src/organism/review-congrats/test/fixtures/no-buttons.js
@@ -6,14 +6,7 @@ export const defaultProps = {
   'data-name': 'review-congrats',
   animationLottie: {...animationLottie.props, height: undefined, width: undefined},
   title: 'Congratulations!',
-  cardCongratsStar: moleculeReviewCardStar.props,
-  cardCongratsRank: undefined,
-  buttonRevising: {
-    'aria-label': 'Continue revising button',
-    label: 'Continue revising',
-    onClick: () => console.log('Continue revising'),
-    type: 'tertiary'
-  }
+  cardCongratsStar: moleculeReviewCardStar.props
 };
 
 export default {props: defaultProps};


### PR DESCRIPTION
https://trello.com/c/9CWZMOsz/2783-app-review-show-congrats

**Detailed purpose of the PR**

Currently the congrats view for the review player shows both CTA bouton on the bottom.
The component should support to not show this cta if related attribute on the property is undefined.

**Result and observation**

![no-button-congrats](https://user-images.githubusercontent.com/7602475/194579262-bf9ee94a-14ec-48c6-a184-da274a9446c0.gif)


**Testing Strategy**

- Already covered by tests
- Manual testing
