### PR TITLE
Adding missing oboarding property on AppReviewTemplate props

### DIFF
--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -27,7 +27,8 @@ const ConnectedApp = ({onQuitClick}: {onQuitClick: Function}): JSX.Element => {
       (state: StoreState) => state.ui.navigation[state.ui.navigation.length - 1]
     ),
     slides: useSelector((state: StoreState) => mapStateToSlidesProps(state, dispatch, onQuitClick)),
-    skills: useSelector((state: StoreState) => mapStateToSkillsProps(state))
+    skills: useSelector((state: StoreState) => mapStateToSkillsProps(state)),
+    onboarding: {}
   };
   return <AppReviewTemplate {...props} />;
 };


### PR DESCRIPTION
**Detailed purpose of the PR**

During `npm run build` on app-review, we have this error

```
> @coorpacademy/app-review@0.5.5 build
> concurrently "npm run build:commonjs" "npm run build:es"

[0] 
[0] > @coorpacademy/app-review@0.5.5 build:commonjs
[0] > tsc -p tsconfig.lib.json
[0] 
[1] 
[1] > @coorpacademy/app-review@0.5.5 build:es
[1] > tsc -p tsconfig.es.json
[1] 
[0] src/index.tsx(32,11): error TS2741: Property 'onboarding' is missing in type '{ viewName: "skills" | "slides" | "onboarding" | "loader"; slides: SlidesViewProps; skills: SkillsProps; }' but required in type '{ [x: string]: any; viewName: any; onboarding: any; skills: any; slides: any; }'.
[0] npm ERR! Lifecycle script `build:commonjs` failed with error: 
[0] npm ERR! Error: command failed 
[0] npm ERR!   in workspace: @coorpacademy/app-review@0.5.5 
[0] npm ERR!   at location: /Users/joan/workspace/components/packages/@coorpacademy-app-review 
[0] npm run build:commonjs exited with code 1
[1] src/index.tsx(32,11): error TS2741: Property 'onboarding' is missing in type '{ viewName: "skills" | "slides" | "onboarding" | "loader"; slides: SlidesViewProps; skills: SkillsProps; }' but required in type '{ [x: string]: any; viewName: any; onboarding: any; skills: any; slides: any; }'.
[1] npm ERR! Lifecycle script `build:es` failed with error: 
[1] npm ERR! Error: command failed 
[1] npm ERR!   in workspace: @coorpacademy/app-review@0.5.5 
npm ERR!   at location: /Users/joan/workspace/components/packages/@coorpacademy-app-review 
[1] npm run build:es exited with code 1
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run prepare stderr:
npm WARN config production Use `--omit=dev` instead.
npm ERR! Lifecycle script `build` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: @coorpacademy/app-review@0.5.5 
npm ERR!   at location: /Users/joan/workspace/components/packages/@coorpacademy-app-review 
error Command failed with exit code 1.
lerna ERR! yarn run prepare exited 1 in '@coorpacademy/app-review'
lerna WARN complete Waiting for 1 child process to exit. CTRL-C to exit immediately.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This PR adds missing property to fix the error.