### PR TITLE
[app-review] add lambda-review-url in state.data

### DIFF
--- a/packages/@coorpacademy-app-review/ava.config.js
+++ b/packages/@coorpacademy-app-review/ava.config.js
@@ -7,6 +7,6 @@ module.exports = {
   environmentVariables: {
     API_TEST_TOKEN:
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ1c2VyIjoiNTkyZDgzMGIyNDBiOTIzZjAwYmZmYmE2IiwiaG9zdCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMCJ9.uhlenI-dZCYm043sOSVHGbxjbpvGVlHWTdNaFDW5nFQ',
-      LAMBDA_REVIEW_URL: 'http://localhost:7006'
+    LAMBDA_REVIEW_URL: 'http://localhost:7006'
   }
 };

--- a/packages/@coorpacademy-app-review/ava.config.js
+++ b/packages/@coorpacademy-app-review/ava.config.js
@@ -7,6 +7,6 @@ module.exports = {
   environmentVariables: {
     API_TEST_TOKEN:
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ1c2VyIjoiNTkyZDgzMGIyNDBiOTIzZjAwYmZmYmE2IiwiaG9zdCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMCJ9.uhlenI-dZCYm043sOSVHGbxjbpvGVlHWTdNaFDW5nFQ',
-    LAMBDA_API_REVIEW_GET_SLIDES_URL: 'http://localhost:7006'
+      LAMBDA_REVIEW_URL: 'http://localhost:7006'
   }
 };

--- a/packages/@coorpacademy-app-review/sandbox/index.tsx
+++ b/packages/@coorpacademy-app-review/sandbox/index.tsx
@@ -58,7 +58,7 @@ const createSandbox = (options: SandboxOptions): void => {
       onQuitClick: () => {
         location.reload();
       },
-      url: process.env.LAMBDA_API_REVIEW_GET_SLIDES_URL || 'http://localhost:7006'
+      lambdaReviewURL: process.env.LAMBDA_REVIEW_URL || 'http://localhost:7006'
     };
     const skin = {
       common: {

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-correction.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-correction.test.ts
@@ -29,6 +29,7 @@ const initialState: StoreState = {
     },
     skills: [{skillRef, custom: false, name: skillRef, slidesToReview: 5}],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-rank.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-rank.test.ts
@@ -21,6 +21,7 @@ const initialState: StoreState = {
     slides: {},
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: Number.NaN, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skills.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skills.test.ts
@@ -16,6 +16,7 @@ const initialState: StoreState = {
     slides: {},
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slide.test.ts
@@ -18,6 +18,7 @@ const initialState: StoreState = {
     slides: {},
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/api/test/post-answer.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/post-answer.test.ts
@@ -58,6 +58,7 @@ const initialState: StoreState = {
     },
     skills: [{skillRef, custom: false, name: skillRef, slidesToReview: 5}],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },
@@ -140,6 +141,7 @@ test('should dispatch post-answer, fetch-correction and fetch-end-rank actions w
       },
       skills: [{skillRef, custom: false, name: skillRef, slidesToReview: 5}],
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {},
       rank: {start: 10, end: Number.NaN}
     },

--- a/packages/@coorpacademy-app-review/src/actions/api/test/post-progression.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/post-progression.test.ts
@@ -19,6 +19,7 @@ const initialState: StoreState = {
     slides: {},
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/data/lambda-review-url.ts
+++ b/packages/@coorpacademy-app-review/src/actions/data/lambda-review-url.ts
@@ -1,0 +1,11 @@
+export const STORE_LAMBDA_REVIEW_URL = '@@data/lambdaReviewURL/STORE_LAMBDA_REVIEW_URL';
+
+export type StoreLambdaReviewURL = {
+  type: typeof STORE_LAMBDA_REVIEW_URL;
+  payload: string;
+};
+
+export const storeLambdaReviewURL = (lambdaReviewURL: string): StoreLambdaReviewURL => ({
+  type: STORE_LAMBDA_REVIEW_URL,
+  payload: lambdaReviewURL
+});

--- a/packages/@coorpacademy-app-review/src/actions/data/test/lambda-review-url.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/data/test/lambda-review-url.test.ts
@@ -10,6 +10,7 @@ const initialState: StoreState = {
     slides: {},
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: Number.NaN, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/data/test/lambda-review-url.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/data/test/lambda-review-url.test.ts
@@ -1,0 +1,32 @@
+import test from 'ava';
+import {createTestStore} from '../../test/create-test-store';
+import {services} from '../../../test/util/services.mock';
+import {StoreState} from '../../../reducers';
+import {storeLambdaReviewURL, STORE_LAMBDA_REVIEW_URL} from '../lambda-review-url';
+
+const initialState: StoreState = {
+  data: {
+    progression: null,
+    slides: {},
+    skills: [],
+    token: '1234',
+    corrections: {},
+    rank: {start: Number.NaN, end: Number.NaN}
+  },
+  ui: {
+    showCongrats: false,
+    positions: [0, 1, 2, 3, 4],
+    currentSlideRef: '',
+    navigation: [],
+    answers: {},
+    slide: {},
+    showQuitPopin: false
+  }
+};
+
+test('should dispatch STORE_LAMBDA_REVIEW_URL action when storeLambdaReviewURL is called', async t => {
+  const expectedActions = [{type: STORE_LAMBDA_REVIEW_URL, payload: 'http://localhost:7006'}];
+
+  const {dispatch} = createTestStore(t, initialState, services, expectedActions);
+  await dispatch(storeLambdaReviewURL('http://localhost:7006'));
+});

--- a/packages/@coorpacademy-app-review/src/actions/data/test/lambda-review-url.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/data/test/lambda-review-url.test.ts
@@ -28,6 +28,6 @@ const initialState: StoreState = {
 test('should dispatch STORE_LAMBDA_REVIEW_URL action when storeLambdaReviewURL is called', async t => {
   const expectedActions = [{type: STORE_LAMBDA_REVIEW_URL, payload: 'http://localhost:7006'}];
 
-  const {dispatch} = createTestStore(t, initialState, services, expectedActions);
+  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
   await dispatch(storeLambdaReviewURL('http://localhost:7006'));
 });

--- a/packages/@coorpacademy-app-review/src/actions/data/test/token.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/data/test/token.test.ts
@@ -10,6 +10,7 @@ const initialState: StoreState = {
     slides: {},
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: Number.NaN, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/answers.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/answers.test.ts
@@ -45,6 +45,7 @@ const initialState: StoreState = {
     slides: {},
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/navigation.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/navigation.test.ts
@@ -10,6 +10,7 @@ const initialState: StoreState = {
     slides: {},
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/next-slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/next-slide.test.ts
@@ -25,6 +25,7 @@ const state: StoreState = {
     },
     skills: [{skillRef, custom: false, name: skillRef, slidesToReview: 5}],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {[freeTextSlide.universalRef]: getChoicesCorrection(freeTextSlide.universalRef)},
     rank: {start: 93, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/quit-popin.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/quit-popin.test.ts
@@ -10,6 +10,7 @@ const initialState: StoreState = {
     slides: {},
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: Number.NaN, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/slides.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/slides.test.ts
@@ -11,6 +11,7 @@ const initialState: StoreState = {
     slides: {},
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: Number.NaN, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -18,6 +18,7 @@ import {fetchSkills} from './actions/api/fetch-skills';
 import {postProgression} from './actions/api/post-progression';
 import {mapStateToSkillsProps} from './views/skills';
 import {mapStateToSlidesProps} from './views/slides';
+import {storeLambdaReviewURL} from './actions/data/lambda-review-url';
 
 const ConnectedApp = (options: ConnectedOptions): JSX.Element => {
   const dispatch = useDispatch();
@@ -58,8 +59,10 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
 
   useEffect(() => {
     const token = get('token', options);
+    const lambdaReviewURL = get('lambdaReviewURL', options);
     if (store === null || isEmpty(token)) return;
     store.dispatch(storeToken(token));
+    store.dispatch(storeLambdaReviewURL(lambdaReviewURL));
   }, [options, store]);
 
   useEffect(() => {

--- a/packages/@coorpacademy-app-review/src/reducers/data/index.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/data/index.ts
@@ -1,6 +1,7 @@
 import {combineReducers} from 'redux';
 
 import corrections, {CorrectionsState} from './corrections';
+import lambdaReviewURL, {LambdaReviewURLState} from './lambda-review-url';
 import progression, {ProgressionState} from './progression';
 import skills, {SkillsState} from './skills';
 import slides, {SlidesState} from './slides';
@@ -9,6 +10,7 @@ import rank, {RankState} from './rank';
 
 export type DataState = {
   corrections: CorrectionsState;
+  lambdaReviewURL: LambdaReviewURLState;
   progression: ProgressionState;
   skills: SkillsState;
   slides: SlidesState;
@@ -16,4 +18,12 @@ export type DataState = {
   rank: RankState;
 };
 
-export default combineReducers({corrections, progression, skills, slides, token, rank});
+export default combineReducers({
+  corrections,
+  lambdaReviewURL,
+  progression,
+  skills,
+  slides,
+  token,
+  rank
+});

--- a/packages/@coorpacademy-app-review/src/reducers/data/lambda-review-url.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/data/lambda-review-url.ts
@@ -1,0 +1,18 @@
+import {StoreLambdaReviewURL, STORE_LAMBDA_REVIEW_URL} from '../../actions/data/lambda-review-url';
+
+export type LambdaReviewURLState = string;
+
+const reducer = (
+  // eslint-disable-next-line default-param-last
+  state: LambdaReviewURLState = '',
+  action: StoreLambdaReviewURL
+): LambdaReviewURLState => {
+  switch (action.type) {
+    case STORE_LAMBDA_REVIEW_URL:
+      return action.payload;
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/packages/@coorpacademy-app-review/src/reducers/data/test/lambda-review-url.test.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/data/test/lambda-review-url.test.ts
@@ -1,0 +1,16 @@
+import test from 'ava';
+import reducer from '../lambda-review-url';
+import {
+  type StoreLambdaReviewURL,
+  STORE_LAMBDA_REVIEW_URL
+} from '../../../actions/data/lambda-review-url';
+
+test('should have initial value', t => {
+  const state = reducer(undefined, {} as StoreLambdaReviewURL);
+  t.is(state, '');
+});
+
+test('should set the value of STORE_LAMBDA_REVIEW_URL action', t => {
+  const state = reducer('', {type: STORE_LAMBDA_REVIEW_URL, payload: 'http://localhost:7006'});
+  t.is(state, 'http://localhost:7006');
+});

--- a/packages/@coorpacademy-app-review/src/services/fetch-slides-to-review-by-skill-ref.ts
+++ b/packages/@coorpacademy-app-review/src/services/fetch-slides-to-review-by-skill-ref.ts
@@ -5,13 +5,13 @@ import {JWT, SlideIdFromAPI} from '../types/common';
 import {toJSON} from './tools/fetch-responses';
 
 export const fetchSlidesToReviewBySkillRef = async (
-  url: string,
+  lambdaReviewURL: string,
   token: string,
   skillRef: string
 ): Promise<SlideIdFromAPI[]> => {
   const {user: userId}: JWT = decode(token);
   const response = await crossFetch(
-    `${url}/api/v1/review/users/${userId}/skills/${skillRef}/slide?limit=5&offset=0`
+    `${lambdaReviewURL}/api/v1/review/users/${userId}/skills/${skillRef}/slide?limit=5&offset=0`
   );
 
   return toJSON<SlideIdFromAPI[]>(response);

--- a/packages/@coorpacademy-app-review/src/services/test/fetch-slides-to-review-by-skill-ref.test.ts
+++ b/packages/@coorpacademy-app-review/src/services/test/fetch-slides-to-review-by-skill-ref.test.ts
@@ -3,7 +3,7 @@ import nock from 'nock';
 import {fetchSlidesToReviewBySkillRef} from '../fetch-slides-to-review-by-skill-ref';
 import {SlideIdFromAPI} from '../../types/common';
 
-const url = process.env.LAMBDA_API_REVIEW_GET_SLIDES_URL || 'http://localhost:7006';
+const lambdaReviewURL = process.env.LAMBDA_REVIEW_URL || 'http://localhost:7006';
 
 const result: SlideIdFromAPI[] = [
   {
@@ -24,7 +24,7 @@ const result: SlideIdFromAPI[] = [
 ];
 
 test.before(() => {
-  nock(url)
+  nock(lambdaReviewURL)
     .get('/api/v1/review/users/592d830b240b923f00bffba6/skills/_skill-ref/slide?limit=5&offset=0')
     .reply(200, result);
 });
@@ -35,14 +35,14 @@ test.after(() => {
 
 test('should fetch slides id with success', async t => {
   const token = process.env.API_TEST_TOKEN || '';
-  const slidesId = await fetchSlidesToReviewBySkillRef(url, token, '_skill-ref');
+  const slidesId = await fetchSlidesToReviewBySkillRef(lambdaReviewURL, token, '_skill-ref');
   t.deepEqual(result, slidesId);
 });
 
 test('should reject if a bad token is passed', async t => {
   const badToken = 'token is not a jwt';
   const error = await t.throwsAsync(() =>
-    fetchSlidesToReviewBySkillRef(url, badToken, '_skill-ref')
+    fetchSlidesToReviewBySkillRef(lambdaReviewURL, badToken, '_skill-ref')
   );
   t.is(
     error?.message,

--- a/packages/@coorpacademy-app-review/src/test/index.test.tsx
+++ b/packages/@coorpacademy-app-review/src/test/index.test.tsx
@@ -63,7 +63,7 @@ const appOptions: AppOptions = {
   services,
   onQuitClick: identity,
   translate: key => key,
-  url: process.env.LAMBDA_API_REVIEW_GET_SLIDES_URL || 'http://localhost:7006'
+  lambdaReviewURL: process.env.LAMBDA_REVIEW_URL || 'http://localhost:7006'
 };
 
 test('should show the loader while the app is fetching the data', async t => {

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -171,7 +171,7 @@ export type Services = {
   ): Promise<CorrectionFromAPI | void>;
   fetchRank(token: string): Promise<Rank>;
   fetchSlidesToReviewBySkillRef(
-    url: string,
+    lambdaReviewURL: string,
     token: string,
     skillRef: string
   ): Promise<SlideIdFromAPI[]>;
@@ -190,7 +190,7 @@ export type AppOptions = ConnectedOptions & {
   token: string;
   skillRef?: string;
   services: Services;
-  url: string;
+  lambdaReviewURL: string;
   callbackOnViewChanged?: (viewName: ViewName) => void;
 };
 

--- a/packages/@coorpacademy-app-review/src/views/skills/test/skills.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/skills/test/skills.test.ts
@@ -11,6 +11,7 @@ test('should create initial props when there are no skills on the state', t => {
       skills: [],
       slides: {},
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {},
       rank: {start: Number.NaN, end: Number.NaN}
     },
@@ -56,6 +57,7 @@ test('should create initial props when skills on the state', t => {
       ],
       slides: {},
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {},
       rank: {start: Number.NaN, end: Number.NaN}
     },

--- a/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
@@ -18,6 +18,7 @@ const state: StoreState = {
       sli_N1XACJobn: null
     },
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: Number.NaN, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -35,6 +35,7 @@ test('should create initial props when fetched slide is not still received', t =
         sli_N1XACJobn: null
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {},
       rank: {start: Number.NaN, end: Number.NaN}
     },
@@ -129,6 +130,7 @@ test('should create props when first slide is on the state', t => {
         sli_VJYjJnJhg: freeTextSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {},
       rank: {start: Number.NaN, end: Number.NaN}
     },
@@ -238,6 +240,7 @@ test('should create props when slide is on the state and user has selected answe
         sli_VJYjJnJhg: freeTextSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {},
       rank: {start: 10, end: Number.NaN}
     },
@@ -348,6 +351,7 @@ test('should verify props when first slide was answered correctly and next slide
         sli_VkSQroQnx: null
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {},
       rank: {start: 10, end: Number.NaN}
     },
@@ -467,6 +471,7 @@ test('should verify props when first slide was answered with error and next slid
         sli_VkSQroQnx: null
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {},
       rank: {start: 10, end: Number.NaN}
     },
@@ -541,6 +546,7 @@ test('should verify props when first slide was answered, next slide is fetched &
         sli_VkSQroQnx: qcmGraphicSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id)
       },
@@ -674,6 +680,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
         sli_VkSQroQnx: qcmGraphicSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id, true)
       },
@@ -810,6 +817,7 @@ test('should verify props when currentSlideRef has changed to nextContent of pro
         sli_VkSQroQnx: qcmGraphicSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id)
       },
@@ -919,6 +927,7 @@ test('should verify props when progression is in success, showing last correctio
         [templateSlide.universalRef]: templateSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id),
         [qcmGraphicSlide.universalRef]: getChoicesCorrection(qcmGraphicSlide._id),
@@ -1041,6 +1050,7 @@ test('should verify props showing congrats', t => {
         [templateSlide.universalRef]: templateSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id),
         [qcmGraphicSlide.universalRef]: getChoicesCorrection(qcmGraphicSlide._id),
@@ -1173,6 +1183,7 @@ test('should verify props showing congrats, with only stars card, if user has no
         [templateSlide.universalRef]: templateSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id),
         [qcmGraphicSlide.universalRef]: getChoicesCorrection(qcmGraphicSlide._id),
@@ -1285,6 +1296,7 @@ test('should verify props when progression has answered a current pendingSlide',
         [templateSlide.universalRef]: templateSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id),
         [qcmGraphicSlide.universalRef]: getChoicesCorrection(qcmGraphicSlide._id),
@@ -1392,6 +1404,7 @@ test('should verify props when progression still has a pendingSlide', t => {
         [templateSlide.universalRef]: templateSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id),
         [qcmGraphicSlide.universalRef]: getChoicesCorrection(qcmGraphicSlide._id),
@@ -1494,6 +1507,7 @@ test('should verify that props quitPopin is not undefined when popin is displaye
         sli_N1XACJobn: null
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {},
       rank: {start: Number.NaN, end: Number.NaN}
     },

--- a/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
@@ -24,6 +24,7 @@ const state: StoreState = {
       sli_VkSQroQnx: qcmGraphicSlide
     },
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -53,6 +53,7 @@ const initialState: StoreState = {
     },
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
@@ -31,6 +31,7 @@ test('correction popin actions after click', async t => {
         sli_VkSQroQnx: qcmGraphicSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id, true)
       },
@@ -94,6 +95,7 @@ test('correction popin actions after click when progression is finished', async 
         [templateSlide.universalRef]: templateSlide
       },
       token: '1234',
+      lambdaReviewURL: 'http://localhost:7006',
       corrections: {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id),
         [qcmGraphicSlide.universalRef]: getChoicesCorrection(qcmGraphicSlide._id),

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -42,6 +42,7 @@ const initialState: StoreState = {
     },
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -42,6 +42,7 @@ const initialState: StoreState = {
     },
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -42,6 +42,7 @@ const initialState: StoreState = {
     },
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -42,6 +42,7 @@ const initialState: StoreState = {
     },
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -42,6 +42,7 @@ const initialState: StoreState = {
     },
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -43,6 +43,7 @@ const initialState: StoreState = {
     },
     skills: [],
     token: '1234',
+    lambdaReviewURL: 'http://localhost:7006',
     corrections: {},
     rank: {start: 10, end: Number.NaN}
   },

--- a/packages/@coorpacademy-app-review/tsconfig.json
+++ b/packages/@coorpacademy-app-review/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "include": [
+    "src/types/globals.d.ts"
+  ],
   "compilerOptions": {
     "baseUrl": ".",
     "target": "es2020",

--- a/packages/@coorpacademy-app-review/webpack.config.js
+++ b/packages/@coorpacademy-app-review/webpack.config.js
@@ -7,7 +7,7 @@ const set = require('lodash/fp/set');
 const update = require('lodash/fp/update');
 const {default: generateConfig} = require('@coorpacademy/webpack-config');
 const {
-  environmentVariables: {API_TEST_TOKEN, LAMBDA_API_REVIEW_GET_SLIDES_URL}
+  environmentVariables: {API_TEST_TOKEN, LAMBDA_REVIEW_URL}
 } = require('./ava.config');
 
 const entry = {
@@ -44,7 +44,7 @@ module.exports = pipe(
     concat([
       new webpack.DefinePlugin({
         'process.env.API_TEST_TOKEN': JSON.stringify(API_TEST_TOKEN),
-        'process.env.LAMBDA_API_REVIEW_GET_SLIDES_URL': JSON.stringify(LAMBDA_API_REVIEW_GET_SLIDES_URL),
+        'process.env.LAMBDA_REVIEW_URL': JSON.stringify(LAMBDA_REVIEW_URL),
       }),
       new HtmlWebpackPlugin({
         filename: `index.html`,


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR creates action data and reducer lambdaReviewURL, dispatches this new action and updates unit tests. 
The value of the key `lambdaReviewURL` in the data state will be used by the service `fetchSlidesToReviewBySkillRef`.
-> https://trello.com/c/sSB2gDPW/2785-app-reviewcongrats-bouton-continue-revising-and-revise-another-skill

<img width="1440" alt="Screenshot 2022-10-11 at 16 55 59" src="https://user-images.githubusercontent.com/79636283/195126150-b9583bb9-af5c-49d9-b54b-42af39a13ec2.png">




**Testing Strategy**
- [x] Manual testing
