### PR TITLE
Get skill name in player review

### DIFF
--- a/packages/@coorpacademy-app-review/sandbox/index.tsx
+++ b/packages/@coorpacademy-app-review/sandbox/index.tsx
@@ -52,7 +52,7 @@ const createSandbox = (options: SandboxOptions): void => {
     // mode mobile/web
     const appOptions: AppOptions = {
       token: process.env.API_TEST_TOKEN || '',
-      skillRef: '123',
+      skill: {name: 'skill_name', ref: '123'},
       services,
       translate,
       onQuitClick: () => {

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -38,7 +38,7 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
   const [store, setStore] = useState<Store<StoreState, AnyAction> | null>(null);
   const [isProgressionCreated, setIsProgressionCreated] = useState(false);
 
-  const {translate, onQuitClick} = options;
+  const {translate, onQuitClick, skill} = options;
 
   useEffect(() => {
     if (store) return;
@@ -76,9 +76,6 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
   useEffect(() => {
     if (store === null) return;
 
-    const {skill} = options;
-    // eslint-disable-next-line no-console
-    console.log(options);
     if (skill.ref && !isProgressionCreated) {
       store.dispatch(navigateTo('loader')); // use loader while posting progression
       return;
@@ -92,7 +89,7 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
 
   return (
     <Provider store={store}>
-      <ConnectedApp onQuitClick={onQuitClick} translate={translate} />
+      <ConnectedApp onQuitClick={onQuitClick} translate={translate} skill={skill} />
     </Provider>
   );
 };

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -66,11 +66,9 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
     const token = get('token', options);
     if (store === null || isEmpty(token)) return;
 
-    const skillRef = get(['skill', 'ref'], options);
-
     /* ThunkAction is not assignable to parameter of type 'AnyAction'
       ts problem is described here = https://github.com/reduxjs/redux-thunk/issues/333 */
-    skillRef ? store.dispatch(postProgression(skillRef)) : store.dispatch(fetchSkills);
+    skill.ref ? store.dispatch(postProgression(skill.ref)) : store.dispatch(fetchSkills);
   }, [options, store]);
 
   useEffect(() => {

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -66,7 +66,7 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
     const token = get('token', options);
     if (store === null || isEmpty(token)) return;
 
-    const skillRef = get('skillRef', options);
+    const skillRef = get(['skill', 'ref'], options);
 
     /* ThunkAction is not assignable to parameter of type 'AnyAction'
       ts problem is described here = https://github.com/reduxjs/redux-thunk/issues/333 */
@@ -76,14 +76,15 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
   useEffect(() => {
     if (store === null) return;
 
-    const {skillRef} = options;
-
-    if (skillRef && !isProgressionCreated) {
+    const {skill} = options;
+    // eslint-disable-next-line no-console
+    console.log(options);
+    if (skill.ref && !isProgressionCreated) {
       store.dispatch(navigateTo('loader')); // use loader while posting progression
       return;
     }
 
-    const initialView: ViewName = skillRef ? 'slides' : 'skills';
+    const initialView: ViewName = skill.ref ? 'slides' : 'skills';
     store.dispatch(navigateTo(initialView));
   }, [isProgressionCreated, options, store]);
 

--- a/packages/@coorpacademy-app-review/src/test/index.test.tsx
+++ b/packages/@coorpacademy-app-review/src/test/index.test.tsx
@@ -59,7 +59,7 @@ const clickAllSlides = async (
 
 const appOptions: AppOptions = {
   token: process.env.API_TEST_TOKEN || '',
-  skillRef: 'skill_NJC0jFKoH',
+  skill: {name: 'skill_name', ref: 'skill_NJC0jFKoH'},
   services,
   onQuitClick: identity,
   translate: key => key

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -154,6 +154,11 @@ export type Skill = {
   name: string;
 };
 
+export type SkillOptions = {
+  name: string;
+  ref: string;
+};
+
 export type Services = {
   fetchSkills(token: string): Promise<Skill[]>;
   fetchSlide(slideRef: string, token: string): Promise<SlideFromAPI | void>;
@@ -184,7 +189,7 @@ export type ConnectedOptions = {
 
 export type AppOptions = ConnectedOptions & {
   token: string;
-  skillRef?: string;
+  skill: SkillOptions;
   services: Services;
   callbackOnViewChanged?: (viewName: ViewName) => void;
 };

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -185,11 +185,11 @@ export type Options = {
 export type ConnectedOptions = {
   translate: (key: string, data?: unknown) => string;
   onQuitClick: () => void;
+  skill: SkillOptions;
 };
 
 export type AppOptions = ConnectedOptions & {
   token: string;
-  skill: SkillOptions;
   services: Services;
   callbackOnViewChanged?: (viewName: ViewName) => void;
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -401,11 +401,11 @@ export const mapStateToSlidesProps = (
   const showQuitPopin = get(['ui', 'showQuitPopin'], state);
   const showCongrats = get(['ui', 'showCongrats'], state);
   // eslint-disable-next-line no-console
-  console.log(skill);
+  console.log(skill.name);
   return {
     header: {
       mode: translate('Review Title'),
-      skillName: '__agility',
+      skillName: skill.name,
       onQuitClick: () => dispatch(openQuitPopin),
       'aria-label': 'aria-header-wrapper',
       closeButtonAriaLabel: 'aria-close-button',

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -392,7 +392,7 @@ export const mapStateToSlidesProps = (
   dispatch: Dispatch,
   options: ConnectedOptions
 ): ReviewPlayerProps => {
-  const {translate, onQuitClick} = options;
+  const {translate, onQuitClick, skill} = options;
   const currentSlideRef = getCurrentSlideRef(state);
   const endReview = isEndOfProgression(state.data.progression);
   const correction = get(['data', 'corrections', currentSlideRef], state);
@@ -400,6 +400,8 @@ export const mapStateToSlidesProps = (
   const klf = getOr('', ['data', 'slides', currentSlideRef, 'klf'], state);
   const showQuitPopin = get(['ui', 'showQuitPopin'], state);
   const showCongrats = get(['ui', 'showCongrats'], state);
+  // eslint-disable-next-line no-console
+  console.log(skill);
   return {
     header: {
       mode: translate('Review Title'),

--- a/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
@@ -23,7 +23,11 @@ import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 import {sliderSlide} from './fixtures/slider';
 import {templateSlide} from './fixtures/template';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: 'skill_ref'}
+};
 
 const state: StoreState = {
   data: {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
@@ -42,12 +42,17 @@ const state: StoreState = {
 test('should dispatch OPEN_POPIN action after a click on close button in header', async t => {
   const expectedAction = [{type: OPEN_POPIN}];
   const {dispatch, getState} = createTestStore(t, state, {services}, expectedAction);
-  const props = mapStateToSlidesProps(getState(), dispatch, {translate, onQuitClick: identity});
+  const props = mapStateToSlidesProps(getState(), dispatch, {
+    translate,
+    onQuitClick: identity,
+    skill: {name: 'skill_name', ref: '123'}
+  });
   t.is(props.quitPopin, undefined);
   await props.header.onQuitClick();
   const updatedProps = mapStateToSlidesProps(getState(), dispatch, {
     translate,
-    onQuitClick: identity
+    onQuitClick: identity,
+    skill: {name: 'skill_name', ref: '123'}
   });
   t.not(updatedProps.quitPopin, undefined);
   t.pass();

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -23,7 +23,11 @@ import {templateSlide} from './fixtures/template';
 import {qcmSlide} from './fixtures/qcm';
 import {sliderSlide} from './fixtures/slider';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: 'skill_ref'}
+};
 
 test('should create initial props when fetched slide is not still received', t => {
   // SCENARIO : @@progression/POST_SUCCESS ok and @@slides/FETCH_REQUEST, (the slide is being fetched)
@@ -63,7 +67,7 @@ test('should create initial props when fetched slide is not still received', t =
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: true,
@@ -158,7 +162,7 @@ test('should create props when first slide is on the state', t => {
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: true,
@@ -268,7 +272,7 @@ test('should create props when slide is on the state and user has selected answe
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: true,
@@ -384,7 +388,7 @@ test('should verify props when first slide was answered correctly and next slide
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: true,
@@ -504,7 +508,7 @@ test('should verify props when first slide was answered with error and next slid
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: true,
@@ -581,7 +585,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: true,
@@ -715,7 +719,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: true,
@@ -856,7 +860,7 @@ test('should verify props when currentSlideRef has changed to nextContent of pro
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: false,
@@ -991,7 +995,7 @@ test('should verify props when progression is in success, showing last correctio
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: false,
@@ -1362,7 +1366,7 @@ test('should verify props when progression has answered a current pendingSlide',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: true,
@@ -1470,7 +1474,7 @@ test('should verify props when progression still has a pendingSlide', t => {
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
     mode: translate('Review Title'),
-    skillName: '__agility',
+    skillName: connectedOptions.skill.name,
     steps: [
       {
         current: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
@@ -13,7 +13,11 @@ import {mapStateToSlidesProps} from '..';
 import {freeTextSlide} from './fixtures/free-text';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: '123'}
+};
 
 const state: StoreState = {
   data: {
@@ -68,7 +72,8 @@ test('should dispatch onQuitClick function via the property handleOnclick of fir
   const {dispatch, getState} = createTestStore(t, state, {services}, expectedAction);
   const props = mapStateToSlidesProps(getState(), dispatch, {
     translate,
-    onQuitClick: () => t.pass()
+    onQuitClick: () => t.pass(),
+    skill: {name: 'skill_name', ref: '123'}
   });
   const quitPopin = props.quitPopin as CMPopinProps;
   await quitPopin.firstButton.handleOnclick();

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -22,7 +22,11 @@ import {EDIT_BASIC} from '../../../actions/ui/answers';
 import {freeTextSlide} from './fixtures/free-text';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: '123'}
+};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: '_skill-ref'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
@@ -19,8 +19,11 @@ import {templateSlide} from './fixtures/template';
 import {qcmSlide} from './fixtures/qcm';
 import {sliderSlide} from './fixtures/slider';
 
-const connectedOptions = {translate, onQuitClick: identity};
-
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: '123'}
+};
 test('correction popin actions after click', async t => {
   const state: StoreState = {
     data: {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -11,7 +11,12 @@ import {EDIT_QCM_DRAG} from '../../../actions/ui/answers';
 import {QcmDrag} from '../../../types/slides';
 import {qcmDragSlide} from './fixtures/qcm-drag';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: '123'}
+};
+
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: '_skill-ref'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -11,7 +11,11 @@ import {EDIT_QCM_GRAPHIC} from '../../../actions/ui/answers';
 import {QcmGraphic} from '../../../types/slides';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: '123'}
+};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: '_skill-ref'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -11,7 +11,12 @@ import {EDIT_QCM} from '../../../actions/ui/answers';
 import {Qcm} from '../../../types/slides';
 import {qcmSlide} from './fixtures/qcm';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: '123'}
+};
+
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: '_skill-ref'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -11,7 +11,11 @@ import {EDIT_SLIDER} from '../../../actions/ui/answers';
 import {QuestionRange} from '../../../types/slides';
 import {sliderSlide} from './fixtures/slider';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: '123'}
+};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: '_skill-ref'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -11,7 +11,11 @@ import {EDIT_SLIDER} from '../../../actions/ui/answers';
 import {QuestionRange} from '../../../types/slides';
 import {sliderSlide} from './fixtures/slider';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: '123'}
+};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: '_skill-ref'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -12,7 +12,11 @@ import {EDIT_TEMPLATE} from '../../../actions/ui/answers';
 import {Template, TextTemplate} from '../../../types/slides';
 import {templateSlide} from './fixtures/template';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {
+  translate,
+  onQuitClick: identity,
+  skill: {name: 'skill_name', ref: '123'}
+};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: '_skill-ref'},


### PR DESCRIPTION
Belongs to this trello card: https://trello.com/c/swIZN13h/2800-app-review-afficher-le-nom-de-la-skill-choisie-dans-le-player

**Detailed purpose of the PR**
- Goal : get the skill name in the player review slide
- Skill added to options in app-review

**Result and observation**
![Capture d’écran 2022-10-21 à 14 30 54](https://user-images.githubusercontent.com/113359769/197196251-b8be1bd2-7295-4a63-88a3-8a9772ada34c.png)

**Testing Strategy**
- Manual testing
- Unit testing
