### PR TITLE
[app-review] update mapStateToSlidesProps for button revise skill

### DIFF
--- a/packages/@coorpacademy-app-review/src/reducers/ui/test/show-congrats.test.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/ui/test/show-congrats.test.ts
@@ -1,13 +1,10 @@
 import test from 'ava';
 import reducer from '../show-congrats';
-import {
-  POST_PROGRESSION_REQUEST,
-  type FetchProgression
-} from '../../../actions/api/post-progression';
+import {POST_PROGRESSION_REQUEST} from '../../../actions/api/post-progression';
 import {NEXT_SLIDE} from '../../../actions/ui/next-slide';
 
 test('should set state to false when received action is POST_PROGRESSION_REQUEST', t => {
-  const state = reducer(true, {type: POST_PROGRESSION_REQUEST} as FetchProgression);
+  const state = reducer(true, {type: POST_PROGRESSION_REQUEST});
   t.is(state, false);
 });
 

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -321,73 +321,73 @@ const buildRankCard = (
   };
 };
 
-const buildCongratsProps =
-  (state: StoreState, dispatch: Dispatch) =>
-  (
-    onQuitClick: () => void,
-    translate: (key: string, data?: unknown) => string
-  ): ReviewCongratsProps | undefined => {
-    if (!state.ui.showCongrats) return;
+const buildCongratsProps = (
+  state: StoreState,
+  dispatch: Dispatch,
+  options: ConnectedOptions
+): ReviewCongratsProps | undefined => {
+  if (!state.ui.showCongrats) return;
 
-    const progression = state.data.progression as ProgressionFromAPI;
-    const stars = progression.state.stars;
-    const cardCongratsStar: CongratsCardProps = {
-      'aria-label': 'Review Card Congrats Container',
-      'data-name': 'card-star',
-      animationLottie: {
-        'aria-label': 'aria lottie',
-        'data-name': 'default-lottie',
-        className: undefined,
-        animationSrc: 'https://static-staging.coorpacademy.com/animations/review/star.json',
-        loop: false,
-        autoplay: undefined,
-        rendererSettings: {
-          hideOnTransparent: false
-        },
-        ie11ImageBackup:
-          'https://static-staging.coorpacademy.com/animations/review/stars_icon_congrats.svg'
-      },
-      iconAriaLabel: 'Image without information',
+  const {translate, onQuitClick} = options;
+  const progression = state.data.progression as ProgressionFromAPI;
+  const stars = progression.state.stars;
+  const cardCongratsStar: CongratsCardProps = {
+    'aria-label': 'Review Card Congrats Container',
+    'data-name': 'card-star',
+    animationLottie: {
+      'aria-label': 'aria lottie',
+      'data-name': 'default-lottie',
       className: undefined,
-      cardType: 'card-star',
-      reviewCardTitle: translate('You have won'),
-      reviewCardValue: `${stars}`,
-      timerAnimation: 200
-    };
-    const {start, end} = state.data.rank;
-    const newRank = start - end;
-    const cardCongratsRank =
-      !Number.isNaN(newRank) && newRank > 0 ? buildRankCard(end, translate) : undefined;
-
-    const skillRef = progression.content.ref;
-    const buttonRevising = state.ui.showButtonRevising
-      ? {
-          'aria-label': translate('Continue reviewing'),
-          label: translate('Continue reviewing'),
-          onClick: (): void => {
-            dispatch(postProgression(skillRef));
-          },
-          type: 'tertiary'
-        }
-      : undefined;
-    const buttonRevisingSkill = {
-      'aria-label': translate('Revise another skill'),
-      label: translate('Revise another skill'),
-      onClick: onQuitClick,
-      type: 'primary'
-    };
-
-    return {
-      'aria-label': 'Review Congratulations',
-      'data-name': 'review-congrats',
-      animationLottie: confettiAnimation,
-      title: translate('Congratulations!'),
-      cardCongratsStar,
-      cardCongratsRank,
-      buttonRevising,
-      buttonRevisingSkill
-    };
+      animationSrc: 'https://static-staging.coorpacademy.com/animations/review/star.json',
+      loop: false,
+      autoplay: undefined,
+      rendererSettings: {
+        hideOnTransparent: false
+      },
+      ie11ImageBackup:
+        'https://static-staging.coorpacademy.com/animations/review/stars_icon_congrats.svg'
+    },
+    iconAriaLabel: 'Image without information',
+    className: undefined,
+    cardType: 'card-star',
+    reviewCardTitle: translate('You have won'),
+    reviewCardValue: `${stars}`,
+    timerAnimation: 200
   };
+  const {start, end} = state.data.rank;
+  const newRank = start - end;
+  const cardCongratsRank =
+    !Number.isNaN(newRank) && newRank > 0 ? buildRankCard(end, translate) : undefined;
+
+  const skillRef = progression.content.ref;
+  const buttonRevising = state.ui.showButtonRevising
+    ? {
+        'aria-label': translate('Continue reviewing'),
+        label: translate('Continue reviewing'),
+        onClick: (): void => {
+          dispatch(postProgression(skillRef));
+        },
+        type: 'tertiary'
+      }
+    : undefined;
+  const buttonRevisingSkill = {
+    'aria-label': translate('Revise another skill'),
+    label: translate('Revise another skill'),
+    onClick: onQuitClick,
+    type: 'primary'
+  };
+
+  return {
+    'aria-label': 'Review Congratulations',
+    'data-name': 'review-congrats',
+    animationLottie: confettiAnimation,
+    title: translate('Congratulations!'),
+    cardCongratsStar,
+    cardCongratsRank,
+    buttonRevising,
+    buttonRevisingSkill
+  };
+};
 
 const isEndOfProgression = (progression: ProgressionState): boolean => {
   if (!progression) return false;
@@ -431,7 +431,7 @@ export const mapStateToSlidesProps = (
         getCorrectionPopinProps(dispatch)(isCorrect, correction.correctAnswer, klf, translate),
       endReview: endReview && state.ui.showCongrats
     },
-    congrats: buildCongratsProps(state, dispatch)(onQuitClick, translate),
+    congrats: buildCongratsProps(state, dispatch, options),
     quitPopin: showQuitPopin ? buildQuitPopinProps(dispatch)(onQuitClick, translate) : undefined
   };
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -321,66 +321,73 @@ const buildRankCard = (
   };
 };
 
-const buildCongratsProps = (
-  state: StoreState,
-  dispatch: Dispatch,
-  translate: (key: string, data?: unknown) => string
-): ReviewCongratsProps | undefined => {
-  if (!state.ui.showCongrats) return;
+const buildCongratsProps =
+  (state: StoreState, dispatch: Dispatch) =>
+  (
+    onQuitClick: () => void,
+    translate: (key: string, data?: unknown) => string
+  ): ReviewCongratsProps | undefined => {
+    if (!state.ui.showCongrats) return;
 
-  const progression = state.data.progression as ProgressionFromAPI;
-  const stars = progression.state.stars;
-  const cardCongratsStar: CongratsCardProps = {
-    'aria-label': 'Review Card Congrats Container',
-    'data-name': 'card-star',
-    animationLottie: {
-      'aria-label': 'aria lottie',
-      'data-name': 'default-lottie',
-      className: undefined,
-      animationSrc: 'https://static-staging.coorpacademy.com/animations/review/star.json',
-      loop: false,
-      autoplay: undefined,
-      rendererSettings: {
-        hideOnTransparent: false
-      },
-      ie11ImageBackup:
-        'https://static-staging.coorpacademy.com/animations/review/stars_icon_congrats.svg'
-    },
-    iconAriaLabel: 'Image without information',
-    className: undefined,
-    cardType: 'card-star',
-    reviewCardTitle: translate('You have won'),
-    reviewCardValue: `${stars}`,
-    timerAnimation: 200
-  };
-  const {start, end} = state.data.rank;
-  const newRank = start - end;
-  const cardCongratsRank =
-    !Number.isNaN(newRank) && newRank > 0 ? buildRankCard(end, translate) : undefined;
-
-  const skillRef = progression.content.ref;
-  const buttonRevising = state.ui.showButtonRevising
-    ? {
-        'aria-label': translate('Continue reviewing'),
-        label: translate('Continue reviewing'),
-        onClick: (): void => {
-          dispatch(postProgression(skillRef));
+    const progression = state.data.progression as ProgressionFromAPI;
+    const stars = progression.state.stars;
+    const cardCongratsStar: CongratsCardProps = {
+      'aria-label': 'Review Card Congrats Container',
+      'data-name': 'card-star',
+      animationLottie: {
+        'aria-label': 'aria lottie',
+        'data-name': 'default-lottie',
+        className: undefined,
+        animationSrc: 'https://static-staging.coorpacademy.com/animations/review/star.json',
+        loop: false,
+        autoplay: undefined,
+        rendererSettings: {
+          hideOnTransparent: false
         },
-        type: 'tertiary'
-      }
-    : undefined;
+        ie11ImageBackup:
+          'https://static-staging.coorpacademy.com/animations/review/stars_icon_congrats.svg'
+      },
+      iconAriaLabel: 'Image without information',
+      className: undefined,
+      cardType: 'card-star',
+      reviewCardTitle: translate('You have won'),
+      reviewCardValue: `${stars}`,
+      timerAnimation: 200
+    };
+    const {start, end} = state.data.rank;
+    const newRank = start - end;
+    const cardCongratsRank =
+      !Number.isNaN(newRank) && newRank > 0 ? buildRankCard(end, translate) : undefined;
 
-  return {
-    'aria-label': 'Review Congratulations',
-    'data-name': 'review-congrats',
-    animationLottie: confettiAnimation,
-    title: translate('Congratulations!'),
-    cardCongratsStar,
-    cardCongratsRank,
-    buttonRevising,
-    buttonRevisingSkill: undefined // TODO make boutons and actions
+    const skillRef = progression.content.ref;
+    const buttonRevising = state.ui.showButtonRevising
+      ? {
+          'aria-label': translate('Continue reviewing'),
+          label: translate('Continue reviewing'),
+          onClick: (): void => {
+            dispatch(postProgression(skillRef));
+          },
+          type: 'tertiary'
+        }
+      : undefined;
+    const buttonRevisingSkill = {
+      'aria-label': translate('Revise another skill'),
+      label: translate('Revise another skill'),
+      onClick: onQuitClick,
+      type: 'primary'
+    };
+
+    return {
+      'aria-label': 'Review Congratulations',
+      'data-name': 'review-congrats',
+      animationLottie: confettiAnimation,
+      title: translate('Congratulations!'),
+      cardCongratsStar,
+      cardCongratsRank,
+      buttonRevising,
+      buttonRevisingSkill
+    };
   };
-};
 
 const isEndOfProgression = (progression: ProgressionState): boolean => {
   if (!progression) return false;
@@ -424,7 +431,7 @@ export const mapStateToSlidesProps = (
         getCorrectionPopinProps(dispatch)(isCorrect, correction.correctAnswer, klf, translate),
       endReview: endReview && state.ui.showCongrats
     },
-    congrats: buildCongratsProps(state, dispatch, translate),
+    congrats: buildCongratsProps(state, dispatch)(onQuitClick, translate),
     quitPopin: showQuitPopin ? buildQuitPopinProps(dispatch)(onQuitClick, translate) : undefined
   };
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -1171,7 +1171,11 @@ test('should verify props showing congrats', t => {
     label: translate('Continue reviewing'),
     type: 'tertiary'
   });
-  t.is(buttonRevisingSkill, undefined);
+  t.deepEqual(omit(['onClick'], buttonRevisingSkill), {
+    'aria-label': translate('Revise another skill'),
+    label: translate('Revise another skill'),
+    type: 'primary'
+  });
 });
 
 test('should verify props showing congrats, with only stars card, if user has no earn positions on raking, and without the button "Continue revising", if there are no more slides to review for this skill', t => {
@@ -1282,7 +1286,11 @@ test('should verify props showing congrats, with only stars card, if user has no
   const cardCongratsRank = congrats.cardCongratsRank;
   t.is(cardCongratsRank, undefined);
   t.is(buttonRevising, undefined);
-  t.is(buttonRevisingSkill, undefined);
+  t.deepEqual(omit(['onClick'], buttonRevisingSkill), {
+    'aria-label': translate('Revise another skill'),
+    label: translate('Revise another skill'),
+    type: 'primary'
+  });
 });
 
 test('should verify props when progression has answered a current pendingSlide', t => {


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR updates `mapStateToSlidesProps` to add button 'Revise another skill'.
-> https://trello.com/c/sSB2gDPW/2785-app-reviewcongrats-bouton-continue-revising-and-revise-another-skill

**Result and observation**
![Kapture 2022-10-21 at 14 51 08](https://user-images.githubusercontent.com/79636283/197200162-bb7a7207-b923-4ca3-b790-685c23d18d6d.gif)

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
