### PR TITLE
Bug fix - display quit popin

### DIFF
--- a/packages/@coorpacademy-components/src/template/app-review/player/index.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import isNil from 'lodash/fp/isNil';
+import classnames from 'classnames';
 import ReviewBackground from '../../../atom/review-background';
 import ReviewCongrats from '../../../organism/review-congrats';
 import ReviewHeader from '../../../organism/review-header';
@@ -18,7 +19,13 @@ const PlayerReview = ({header, stack, reviewBackgroundAriaLabel, congrats, quitP
       <div key="player-background-container" className={style.playerBackground}>
         <ReviewBackground aria-label={reviewBackgroundAriaLabel} />
       </div>
-      <div key="review-header-wrapper" className={style.reviewHeaderContainer}>
+      <div
+        key="review-header-wrapper"
+        className={classnames(
+          style.reviewHeaderContainer,
+          congrats && style.reviewHeaderContainerCongrats
+        )}
+      >
         <ReviewHeader {...header} />
       </div>
       <StackedSlides {...stack} />

--- a/packages/@coorpacademy-components/src/template/app-review/player/style.css
+++ b/packages/@coorpacademy-components/src/template/app-review/player/style.css
@@ -53,7 +53,7 @@
 :-ms-fullscreen,
 :root .congrats {
   position: relative;
-  bottom: 20%;
+  bottom: 5%;
 }
 
 :-ms-fullscreen,

--- a/packages/@coorpacademy-components/src/template/app-review/player/style.css
+++ b/packages/@coorpacademy-components/src/template/app-review/player/style.css
@@ -25,6 +25,11 @@
   width: 100%;
 }
 
+.reviewHeaderContainerCongrats {
+  position: absolute;
+  z-index: 10
+}
+
 .congrats {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR fixes bug : the button to display quit popin can now be clicked on the congratulations page.
-> https://trello.com/c/v3ABFhnZ/2807-app-review-quit-popin-saffiche-pas-lorsquon-est-dans-congratulations

**Result and observation**
- chrome:
![Kapture 2022-10-21 at 17 12 04](https://user-images.githubusercontent.com/79636283/197238375-6db25119-21db-4a60-b77a-21efefdca312.gif)

- ie:
![Capture1](https://user-images.githubusercontent.com/79636283/197489550-6e944aa3-18f1-4d35-92d7-80fe6f6b4743.PNG)


**Testing Strategy**
Tested with:

-safari
-chrome
-mozilla
-ie

- [x] Already covered by tests
- [x] Manual testing
- [] Unit testing

