### PR TITLE
Add skill to review type

### DIFF
--- a/packages/@coorpacademy-app-review/sandbox/index.tsx
+++ b/packages/@coorpacademy-app-review/sandbox/index.tsx
@@ -25,8 +25,6 @@ declare global {
 
 const translate = (key: string, data?: unknown): string => {
   try {
-    // eslint-disable-next-line no-console
-    console.log('data type', data);
     return createTranslate({
       ...localesAppReview,
       ...localesComponents

--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-skills.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-skills.ts
@@ -2,7 +2,7 @@ import buildTask from '@coorpacademy/redux-task';
 import get from 'lodash/fp/get';
 import type {Dispatch} from 'redux';
 import type {StoreState} from '../../reducers';
-import type {ThunkOptions, Skill} from '../../types/common';
+import type {ThunkOptions, SkillsToReview} from '../../types/common';
 
 export const SKILLS_FETCH_REQUEST = '@@skills/FETCH_REQUEST' as const;
 export const SKILLS_FETCH_SUCCESS = '@@skills/FETCH_SUCCESS' as const;
@@ -10,7 +10,7 @@ export const SKILLS_FETCH_FAILURE = '@@skills/FETCH_FAILURE' as const;
 
 export type ReceivedSkills = {
   type: typeof SKILLS_FETCH_SUCCESS;
-  payload: Skill[];
+  payload: SkillsToReview[];
 };
 
 export const fetchSkills = (

--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-skills.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-skills.ts
@@ -2,7 +2,7 @@ import buildTask from '@coorpacademy/redux-task';
 import get from 'lodash/fp/get';
 import type {Dispatch} from 'redux';
 import type {StoreState} from '../../reducers';
-import type {ThunkOptions, SkillsToReview} from '../../types/common';
+import type {ThunkOptions, SkillToReview} from '../../types/common';
 
 export const SKILLS_FETCH_REQUEST = '@@skills/FETCH_REQUEST' as const;
 export const SKILLS_FETCH_SUCCESS = '@@skills/FETCH_SUCCESS' as const;
@@ -10,7 +10,7 @@ export const SKILLS_FETCH_FAILURE = '@@skills/FETCH_FAILURE' as const;
 
 export type ReceivedSkills = {
   type: typeof SKILLS_FETCH_SUCCESS;
-  payload: SkillsToReview[];
+  payload: SkillToReview[];
 };
 
 export const fetchSkills = (

--- a/packages/@coorpacademy-app-review/src/reducers/data/skills.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/data/skills.ts
@@ -1,7 +1,7 @@
-import {SkillsToReview} from '../../types/common';
+import {SkillToReview} from '../../types/common';
 import {ReceivedSkills, SKILLS_FETCH_SUCCESS} from '../../actions/api/fetch-skills';
 
-export type SkillsState = SkillsToReview[];
+export type SkillsState = SkillToReview[];
 
 const initialState: SkillsState = [];
 

--- a/packages/@coorpacademy-app-review/src/reducers/data/skills.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/data/skills.ts
@@ -1,7 +1,7 @@
-import {Skill} from '../../types/common';
+import {SkillsToReview} from '../../types/common';
 import {ReceivedSkills, SKILLS_FETCH_SUCCESS} from '../../actions/api/fetch-skills';
 
-export type SkillsState = Skill[];
+export type SkillsState = SkillsToReview[];
 
 const initialState: SkillsState = [];
 

--- a/packages/@coorpacademy-app-review/src/services/fetch-skills.ts
+++ b/packages/@coorpacademy-app-review/src/services/fetch-skills.ts
@@ -1,14 +1,14 @@
 import crossFetch from 'cross-fetch';
 import decode from 'jwt-decode';
 
-import {JWT, Skill} from '../types/common';
+import {JWT, SkillsToReview} from '../types/common';
 import {toJSON} from './tools/fetch-responses';
 
-export const fetchSkills = async (token: string): Promise<Skill[]> => {
+export const fetchSkills = async (token: string): Promise<SkillsToReview[]> => {
   const {user: userId, host}: JWT = decode(token);
   const response = await crossFetch(`${host}/api/v2/skills/review/user/${userId}`, {
     headers: {authorization: token}
   });
 
-  return toJSON<Skill[]>(response);
+  return toJSON<SkillsToReview[]>(response);
 };

--- a/packages/@coorpacademy-app-review/src/services/fetch-skills.ts
+++ b/packages/@coorpacademy-app-review/src/services/fetch-skills.ts
@@ -1,14 +1,14 @@
 import crossFetch from 'cross-fetch';
 import decode from 'jwt-decode';
 
-import {JWT, SkillsToReview} from '../types/common';
+import {JWT, SkillToReview} from '../types/common';
 import {toJSON} from './tools/fetch-responses';
 
-export const fetchSkills = async (token: string): Promise<SkillsToReview[]> => {
+export const fetchSkills = async (token: string): Promise<SkillToReview[]> => {
   const {user: userId, host}: JWT = decode(token);
   const response = await crossFetch(`${host}/api/v2/skills/review/user/${userId}`, {
     headers: {authorization: token}
   });
 
-  return toJSON<SkillsToReview[]>(response);
+  return toJSON<SkillToReview[]>(response);
 };

--- a/packages/@coorpacademy-app-review/src/services/test/fetch-skills.test.ts
+++ b/packages/@coorpacademy-app-review/src/services/test/fetch-skills.test.ts
@@ -1,9 +1,9 @@
 import test from 'ava';
 import nock from 'nock';
-import {SkillsToReview} from '../../types/common';
+import {SkillToReview} from '../../types/common';
 import {fetchSkills} from '../fetch-skills';
 
-const result: SkillsToReview[] = [
+const result: SkillToReview[] = [
   {
     slidesToReview: 1,
     name: 'skill-test',

--- a/packages/@coorpacademy-app-review/src/services/test/fetch-skills.test.ts
+++ b/packages/@coorpacademy-app-review/src/services/test/fetch-skills.test.ts
@@ -1,9 +1,9 @@
 import test from 'ava';
 import nock from 'nock';
-import {Skill} from '../../types/common';
+import {SkillsToReview} from '../../types/common';
 import {fetchSkills} from '../fetch-skills';
 
-const result: Skill[] = [
+const result: SkillsToReview[] = [
   {
     slidesToReview: 1,
     name: 'skill-test',

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -154,6 +154,11 @@ export type SkillsToReview = {
   name: string;
 };
 
+export type Skill = {
+  name: string;
+  skillRef: string;
+};
+
 export type Services = {
   fetchSkills(token: string): Promise<SkillsToReview[]>;
   fetchSlide(slideRef: string, token: string): Promise<SlideFromAPI | void>;

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -147,7 +147,7 @@ export type CorrectionFromAPI = {
   corrections: CorrectedChoice[];
 };
 
-export type Skill = {
+export type SkillsToReview = {
   skillRef: string;
   slidesToReview: number;
   custom: boolean;
@@ -155,7 +155,7 @@ export type Skill = {
 };
 
 export type Services = {
-  fetchSkills(token: string): Promise<Skill[]>;
+  fetchSkills(token: string): Promise<SkillsToReview[]>;
   fetchSlide(slideRef: string, token: string): Promise<SlideFromAPI | void>;
   postProgression(skillRef: string, token: string): Promise<ProgressionFromAPI>;
   postAnswer(

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -147,7 +147,7 @@ export type CorrectionFromAPI = {
   corrections: CorrectedChoice[];
 };
 
-export type SkillsToReview = {
+export type SkillToReview = {
   skillRef: string;
   slidesToReview: number;
   custom: boolean;
@@ -160,7 +160,7 @@ export type Skill = {
 };
 
 export type Services = {
-  fetchSkills(token: string): Promise<SkillsToReview[]>;
+  fetchSkills(token: string): Promise<SkillToReview[]>;
   fetchSlide(slideRef: string, token: string): Promise<SlideFromAPI | void>;
   postProgression(skillRef: string, token: string): Promise<ProgressionFromAPI>;
   postAnswer(


### PR DESCRIPTION
Part of this trello card : https://trello.com/c/swIZN13h/2800-app-review-afficher-le-nom-de-la-skill-choisie-dans-le-player

The goal is to get the skill name in player review slide.
Skills in dashboard used in skills views are returned by api-review.
For this card, the required skill will be requested to an existed endpoint in mooc.
So new type has been created with the required properties skillRef and name.

**Detailed purpose of the PR**
Add new types to app-review and refacto Skill type

- Skill change to SkillsToReview
- New Skill type only have skillRef and name. This type will be used to get the name in player review slide.

**Result and observation**
New type Skill and refacto SkillsToReview

**Testing Strategy**
- Already covered by tests

