### PR TITLE
Fetch skill action

### DIFF
--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-skill.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-skill.ts
@@ -8,14 +8,14 @@ export const SKILL_FETCH_REQUEST = '@@skill/FETCH_REQUEST' as const;
 export const SKILL_FETCH_SUCCESS = '@@skill/FETCH_SUCCESS' as const;
 export const SKILL_FETCH_FAILURE = '@@skill/FETCH_FAILURE' as const;
 
-export type fetchSkillAction = {
+export type ReceivedSkill = {
   type: typeof SKILL_FETCH_SUCCESS;
   payload: Skill;
 };
 
 export const fetchSkill =
   (skillRef: string) =>
-  (dispatch: Dispatch, getState: () => StoreState, {services}: ThunkOptions): fetchSkillAction => {
+  (dispatch: Dispatch, getState: () => StoreState, {services}: ThunkOptions): ReceivedSkill => {
     const action = buildTask({
       types: [SKILL_FETCH_REQUEST, SKILL_FETCH_SUCCESS, SKILL_FETCH_FAILURE],
       task: () => {

--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-skill.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-skill.ts
@@ -1,0 +1,28 @@
+import {Dispatch} from 'redux';
+import get from 'lodash/fp/get';
+import buildTask from '@coorpacademy/redux-task';
+import type {StoreState} from '../../reducers';
+import type {Skill, ThunkOptions} from '../../types/common';
+
+export const SKILL_FETCH_REQUEST = '@@skill/FETCH_REQUEST' as const;
+export const SKILL_FETCH_SUCCESS = '@@skill/FETCH_SUCCESS' as const;
+export const SKILL_FETCH_FAILURE = '@@skill/FETCH_FAILURE' as const;
+
+export type fetchSkillAction = {
+  type: typeof SKILL_FETCH_SUCCESS;
+  payload: Skill;
+};
+
+export const fetchSkill =
+  (skillRef: string) =>
+  (dispatch: Dispatch, getState: () => StoreState, {services}: ThunkOptions): fetchSkillAction => {
+    const action = buildTask({
+      types: [SKILL_FETCH_REQUEST, SKILL_FETCH_SUCCESS, SKILL_FETCH_FAILURE],
+      task: () => {
+        const state = getState();
+        const token = get(['data', 'token'], state);
+        return services.fetchSkill(skillRef, token);
+      }
+    });
+    return dispatch(action);
+  };

--- a/packages/@coorpacademy-app-review/src/actions/api/post-progression.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/post-progression.ts
@@ -4,6 +4,7 @@ import get from 'lodash/fp/get';
 import type {ThunkOptions, ProgressionFromAPI} from '../../types/common';
 import type {StoreState} from '../../reducers';
 import {fetchSlide} from './fetch-slide';
+import {fetchSkill} from './fetch-skill';
 
 export const POST_PROGRESSION_REQUEST = '@@progression/POST_REQUEST' as const;
 export const POST_PROGRESSION_SUCCESS = '@@progression/POST_SUCCESS' as const;
@@ -37,5 +38,6 @@ export const postProgression =
       const progression = response.payload;
       const slideRef = progression.state.nextContent.ref;
       await dispatch(fetchSlide(slideRef));
+      await dispatch(fetchSkill(skillRef));
     }
   };

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skill.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skill.test.ts
@@ -1,6 +1,53 @@
-import {Skill} from '../../../types/common';
+import test from 'ava';
+import {createTestStore} from '../../test/create-test-store';
+import {Services} from '../../../types/common';
+import {services as mockedServices} from '../../../test/util/services.mock';
+import type {StoreState} from '../../../reducers';
+import {
+  fetchSkill,
+  SKILL_FETCH_FAILURE,
+  SKILL_FETCH_REQUEST,
+  SKILL_FETCH_SUCCESS
+} from '../fetch-skill';
 
-const initialState: Skill = {
-  ref: 'skill_NyxtYFYir',
-  name: 'Digital Awareness'
+const initialState: StoreState = {
+  data: {
+    progression: null,
+    slides: {},
+    skills: [],
+    token: '1234',
+    corrections: {},
+    rank: {start: Number.NaN, end: Number.NaN}
+  },
+  ui: {
+    showCongrats: false,
+    positions: [0, 1, 2, 3, 4],
+    currentSlideRef: '',
+    navigation: [],
+    answers: {},
+    slide: {},
+    showQuitPopin: false,
+    showButtonRevising: false
+  }
 };
+
+test('should dispatch FETCH_SKILL_SUCCESS when fetch skill is call with the correct skill', async t => {
+  t.plan(4);
+  const services: Services = {
+    ...mockedServices,
+    fetchSkill: (skillRef, token) => {
+      t.is(token, '1234');
+      t.is(skillRef, 'skill_NyxtYFYir');
+      return Promise.resolve({ref: 'skill_NyxtYFYir', name: 'Digital Awareness'});
+    }
+  };
+
+  const expectedActions = [
+    {type: SKILL_FETCH_REQUEST},
+    {type: SKILL_FETCH_SUCCESS, payload: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}},
+    {type: SKILL_FETCH_FAILURE, payload: new Error('Fetch skill action failed')}
+  ];
+  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+
+  await dispatch(fetchSkill('skill_NyxtYFYir'));
+});

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skill.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skill.test.ts
@@ -1,0 +1,6 @@
+import {Skill} from '../../../types/common';
+
+const initialState: Skill = {
+  ref: 'skill_NyxtYFYir',
+  name: 'Digital Awareness'
+};

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skill.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skill.test.ts
@@ -44,10 +44,29 @@ test('should dispatch FETCH_SKILL_SUCCESS when fetch skill is call with the corr
 
   const expectedActions = [
     {type: SKILL_FETCH_REQUEST},
-    {type: SKILL_FETCH_SUCCESS, payload: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}},
-    {type: SKILL_FETCH_FAILURE, payload: new Error('Fetch skill action failed')}
+    {type: SKILL_FETCH_SUCCESS, payload: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}}
   ];
   const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
 
   await dispatch(fetchSkill('skill_NyxtYFYir'));
+});
+
+test('should dispatch FETCH_SKILL_FAILURE when fetch skill failed', async t => {
+  t.plan(4);
+  const services: Services = {
+    ...mockedServices,
+    fetchSkill: (skillRef, token) => {
+      t.is(token, '1234');
+      t.is(skillRef, '123');
+      return Promise.reject(new Error('Fetch skill action failed'));
+    }
+  };
+
+  const expectedActions = [
+    {type: SKILL_FETCH_REQUEST},
+    {type: SKILL_FETCH_FAILURE, payload: new Error('Fetch skill action failed'), error: true}
+  ];
+
+  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  await dispatch(fetchSkill('123'));
 });

--- a/packages/@coorpacademy-app-review/src/actions/api/test/post-progression.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/post-progression.test.ts
@@ -12,6 +12,7 @@ import type {StoreState} from '../../../reducers';
 import {SLIDE_FETCH_REQUEST, SLIDE_FETCH_SUCCESS} from '../fetch-slide';
 import {SET_CURRENT_SLIDE} from '../../ui/slides';
 import {createTestStore} from '../../test/create-test-store';
+import {SKILL_FETCH_FAILURE, SKILL_FETCH_REQUEST, SKILL_FETCH_SUCCESS} from '../fetch-skill';
 
 const initialState: StoreState = {
   data: {
@@ -35,7 +36,7 @@ const initialState: StoreState = {
 };
 
 test('should dispatch POST_PROGRESSION_SUCCESS and SLIDE_FETCH_REQUEST actions when postProgression returns a progression', async t => {
-  t.plan(9);
+  t.plan(11);
   const progression: ProgressionFromAPI = {
     _id: '62b1d1087aa12f00253f40ee',
     content: {
@@ -65,7 +66,7 @@ test('should dispatch POST_PROGRESSION_SUCCESS and SLIDE_FETCH_REQUEST actions w
     ...mockedServices,
     postProgression: (skillRef, token) => {
       t.is(token, '1234');
-      t.is(skillRef, 'skill_12345');
+      t.is(skillRef, 'skill_NyxtYFYir');
       return Promise.resolve(progression);
     },
     fetchSlide: (slideRef, token) => {
@@ -94,12 +95,14 @@ test('should dispatch POST_PROGRESSION_SUCCESS and SLIDE_FETCH_REQUEST actions w
       },
       payload: freeTextSlide
     },
-    {type: SET_CURRENT_SLIDE, payload: freeTextSlide}
+    {type: SET_CURRENT_SLIDE, payload: freeTextSlide},
+    {type: SKILL_FETCH_REQUEST},
+    {type: SKILL_FETCH_SUCCESS, payload: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}}
   ];
 
   const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
 
-  await dispatch(postProgression('skill_12345'));
+  await dispatch(postProgression('skill_NyxtYFYir'));
 });
 
 test('should dispatch POST_PROGRESSION_FAILURE action when postProgression fails', async t => {
@@ -119,7 +122,9 @@ test('should dispatch POST_PROGRESSION_FAILURE action when postProgression fails
       type: POST_PROGRESSION_FAILURE,
       payload: new Error('error'),
       error: true
-    }
+    },
+    {type: SKILL_FETCH_REQUEST},
+    {type: SKILL_FETCH_FAILURE, payload: new Error('Fetch skill action failed'), error: true}
   ];
 
   const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -61,10 +61,16 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
     const token = get('token', options);
     if (store === null || isEmpty(token)) return;
 
+    store.dispatch(storeToken(token));
+  }, [options, store]);
+
+  useEffect(() => {
+    const isTokenPresent = store && !isEmpty(store.getState().data.token);
+
+    if (!isTokenPresent) return;
+
     const skillRef = get('skillRef', options);
     skillRef && store.dispatch(fetchSkill(skillRef));
-
-    store.dispatch(storeToken(token));
   }, [options, store]);
 
   useEffect(() => {

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -63,15 +63,6 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
     store.dispatch(storeToken(token));
   }, [options, store]);
 
-  // useEffect(() => {
-  //   const isTokenPresent = store && !isEmpty(store.getState().data.token);
-
-  //   if (!isTokenPresent) return;
-
-  //   const skillRef = get('skillRef', options);
-  //   skillRef && store.dispatch(fetchSkill(skillRef));
-  // }, [options, store]);
-
   useEffect(() => {
     const token = get('token', options);
     if (store === null || isEmpty(token)) return;

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -18,7 +18,6 @@ import {fetchSkills} from './actions/api/fetch-skills';
 import {postProgression} from './actions/api/post-progression';
 import {mapStateToSkillsProps} from './views/skills';
 import {mapStateToSlidesProps} from './views/slides';
-import {fetchSkill} from './actions/api/fetch-skill';
 
 const ConnectedApp = (options: ConnectedOptions): JSX.Element => {
   const dispatch = useDispatch();
@@ -64,14 +63,14 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
     store.dispatch(storeToken(token));
   }, [options, store]);
 
-  useEffect(() => {
-    const isTokenPresent = store && !isEmpty(store.getState().data.token);
+  // useEffect(() => {
+  //   const isTokenPresent = store && !isEmpty(store.getState().data.token);
 
-    if (!isTokenPresent) return;
+  //   if (!isTokenPresent) return;
 
-    const skillRef = get('skillRef', options);
-    skillRef && store.dispatch(fetchSkill(skillRef));
-  }, [options, store]);
+  //   const skillRef = get('skillRef', options);
+  //   skillRef && store.dispatch(fetchSkill(skillRef));
+  // }, [options, store]);
 
   useEffect(() => {
     const token = get('token', options);

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -60,6 +60,10 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
   useEffect(() => {
     const token = get('token', options);
     if (store === null || isEmpty(token)) return;
+
+    const skillRef = get('skillRef', options);
+    skillRef && store.dispatch(fetchSkill(skillRef));
+
     store.dispatch(storeToken(token));
   }, [options, store]);
 
@@ -72,13 +76,6 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
     /* ThunkAction is not assignable to parameter of type 'AnyAction'
       ts problem is described here = https://github.com/reduxjs/redux-thunk/issues/333 */
     skillRef ? store.dispatch(postProgression(skillRef)) : store.dispatch(fetchSkills);
-  }, [options, store]);
-
-  useEffect(() => {
-    const token = get('token', options);
-    if (store === null || isEmpty(token)) return;
-    const skillRef = get('skillRef', options);
-    skillRef && store.dispatch(fetchSkill(skillRef));
   }, [options, store]);
 
   useEffect(() => {

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -18,6 +18,7 @@ import {fetchSkills} from './actions/api/fetch-skills';
 import {postProgression} from './actions/api/post-progression';
 import {mapStateToSkillsProps} from './views/skills';
 import {mapStateToSlidesProps} from './views/slides';
+import {fetchSkill} from './actions/api/fetch-skill';
 
 const ConnectedApp = (options: ConnectedOptions): JSX.Element => {
   const dispatch = useDispatch();
@@ -71,6 +72,13 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
     /* ThunkAction is not assignable to parameter of type 'AnyAction'
       ts problem is described here = https://github.com/reduxjs/redux-thunk/issues/333 */
     skillRef ? store.dispatch(postProgression(skillRef)) : store.dispatch(fetchSkills);
+  }, [options, store]);
+
+  useEffect(() => {
+    const token = get('token', options);
+    if (store === null || isEmpty(token)) return;
+    const skillRef = get('skillRef', options);
+    skillRef && store.dispatch(fetchSkill(skillRef));
   }, [options, store]);
 
   useEffect(() => {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import identity from 'lodash/fp/identity';
 import {ReviewCongratsProps} from '@coorpacademy/components/es/organism/review-congrats/prop-types';
+import {SKILL_FETCH_REQUEST, SKILL_FETCH_SUCCESS} from '../../../actions/api/fetch-skill';
 import {createTestStore} from '../../../actions/test/create-test-store';
 import {
   POST_PROGRESSION_REQUEST,
@@ -139,7 +140,9 @@ test('should dispatch POST_PROGRESSION_REQUEST action via the property onclick o
       },
       payload: freeTextSlide
     },
-    {type: SET_CURRENT_SLIDE, payload: freeTextSlide}
+    {type: SET_CURRENT_SLIDE, payload: freeTextSlide},
+    {type: SKILL_FETCH_REQUEST},
+    {type: SKILL_FETCH_SUCCESS, payload: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}}
   ];
   const {dispatch, getState} = createTestStore(t, state, {services}, expectedActions);
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);


### PR DESCRIPTION
Part of this trello card : https://trello.com/c/swIZN13h/2800-app-review-afficher-le-nom-de-la-skill-choisie-dans-le-player

**Detailed purpose of the PR**
- add actions types : @skill/FETCH_REQUEST, @skill/FETCH_SUCCESS, @skill/FETCH_FAILURE
- Add unit test for fetch skill action

**Result and observation**
<img width="1680" alt="Capture d’écran 2022-10-26 à 18 08 48" src="https://user-images.githubusercontent.com/113359769/198078290-b540bffe-ef22-4f9d-a098-fb5cedec53c9.png">

**Testing Strategy**
- Unit testing
