### PR TITLE
Fix i18n issues

### DIFF
--- a/packages/@coorpacademy-app-review/locales/en/review.json
+++ b/packages/@coorpacademy-app-review/locales/en/review.json
@@ -1,6 +1,6 @@
 {
     "Review Title": "Review Mode",
-    "Content Parent Title": "From `{{contentTitle}}` `{{contentType}}`",
+    "Content Parent Title": "From \"{{contentTitle}}\" {{contentType}} ",
     "Validate": "Validate",
     "Next Question": "Next Question",
     "KLF": "Key point",

--- a/packages/@coorpacademy-app-review/locales/en/review.json
+++ b/packages/@coorpacademy-app-review/locales/en/review.json
@@ -1,6 +1,6 @@
 {
     "Review Title": "Review Mode",
-    "Content Parent Title": "From \"{{contentTitle}}\" {{contentType}} ",
+    "Content Parent Title": "From \"{{contentTitle}}\" {{contentType}}",
     "Validate": "Validate",
     "Next Question": "Next Question",
     "KLF": "Key point",

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -131,7 +131,7 @@ const buildStackSlides = (
 
       const answers = getOr([], ['ui', 'answers', slideRef], state);
       const {questionText, answerUI} = mapApiSlideToUi(dispatch)(slideFromAPI, answers);
-      // const {title: parentContentTitle, type: parentContentType} = slideFromAPI.parentContentTitle;
+      const {title: parentContentTitle, type: parentContentType} = slideFromAPI.parentContentTitle;
 
       const isCurrentSlideRef = currentSlideRef === slideRef;
       const slideUI = get(['ui', 'slide', slideRef], state);
@@ -147,8 +147,10 @@ const buildStackSlides = (
         loading: false,
         questionText,
         answerUI,
-        // parentContentTitle: `From "${parentContentTitle}" ${parentContentType}`,
-        parentContentTitle: translate('Content Parent Title'),
+        parentContentTitle: translate('Content Parent Title', {
+          contentTitle: parentContentTitle,
+          contentType: parentContentType
+        }),
         animationType
       };
 

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -105,7 +105,11 @@ const getCurrentSlideRef = (state: StoreState): string => {
   return content.ref;
 };
 
-const buildStackSlides = (state: StoreState, dispatch: Dispatch): SlidesStack => {
+const buildStackSlides = (
+  state: StoreState,
+  dispatch: Dispatch, 
+  translate: (key: string, data?: unknown) => string
+  ): SlidesStack => {
   const currentSlideRef = getCurrentSlideRef(state);
   const progression = state.data.progression;
 
@@ -127,7 +131,7 @@ const buildStackSlides = (state: StoreState, dispatch: Dispatch): SlidesStack =>
 
       const answers = getOr([], ['ui', 'answers', slideRef], state);
       const {questionText, answerUI} = mapApiSlideToUi(dispatch)(slideFromAPI, answers);
-      const {title: parentContentTitle, type: parentContentType} = slideFromAPI.parentContentTitle;
+      // const {title: parentContentTitle, type: parentContentType} = slideFromAPI.parentContentTitle;
 
       const isCurrentSlideRef = currentSlideRef === slideRef;
       const slideUI = get(['ui', 'slide', slideRef], state);
@@ -143,7 +147,8 @@ const buildStackSlides = (state: StoreState, dispatch: Dispatch): SlidesStack =>
         loading: false,
         questionText,
         answerUI,
-        parentContentTitle: `From "${parentContentTitle}" ${parentContentType}`,
+        // parentContentTitle: `From "${parentContentTitle}" ${parentContentType}`,
+        parentContentTitle: translate('Content Parent Title'),
         animationType
       };
 
@@ -418,7 +423,7 @@ export const mapStateToSlidesProps = (
       hiddenSteps: showCongrats
     },
     stack: {
-      slides: buildStackSlides(state, dispatch),
+      slides: buildStackSlides(state, dispatch, translate),
       validateButton: {
         label: translate('Validate'),
         disabled: !get(['ui', 'slide', currentSlideRef, 'validateButton'], state),

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -108,8 +108,9 @@ const getCurrentSlideRef = (state: StoreState): string => {
 const buildStackSlides = (
   state: StoreState,
   dispatch: Dispatch,
-  translate: (key: string, data?: unknown) => string
+  options: ConnectedOptions
 ): SlidesStack => {
+  const {translate} = options;
   const currentSlideRef = getCurrentSlideRef(state);
   const progression = state.data.progression;
 
@@ -425,7 +426,7 @@ export const mapStateToSlidesProps = (
       hiddenSteps: showCongrats
     },
     stack: {
-      slides: buildStackSlides(state, dispatch, translate),
+      slides: buildStackSlides(state, dispatch, options),
       validateButton: {
         label: translate('Validate'),
         disabled: !get(['ui', 'slide', currentSlideRef, 'validateButton'], state),

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -107,9 +107,9 @@ const getCurrentSlideRef = (state: StoreState): string => {
 
 const buildStackSlides = (
   state: StoreState,
-  dispatch: Dispatch, 
+  dispatch: Dispatch,
   translate: (key: string, data?: unknown) => string
-  ): SlidesStack => {
+): SlidesStack => {
   const currentSlideRef = getCurrentSlideRef(state);
   const progression = state.data.progression;
 

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -62,7 +62,7 @@ test('should create initial props when fetched slide is not still received', t =
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {
@@ -157,7 +157,7 @@ test('should create props when first slide is on the state', t => {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {
@@ -197,7 +197,7 @@ test('should create props when first slide is on the state', t => {
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
@@ -267,7 +267,7 @@ test('should create props when slide is on the state and user has selected answe
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {
@@ -307,7 +307,7 @@ test('should create props when slide is on the state and user has selected answe
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
@@ -383,7 +383,7 @@ test('should verify props when first slide was answered correctly and next slide
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {
@@ -423,7 +423,7 @@ test('should verify props when first slide was answered correctly and next slide
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
@@ -503,7 +503,7 @@ test('should verify props when first slide was answered with error and next slid
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {
@@ -580,7 +580,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {
@@ -612,16 +612,16 @@ test('should verify props when first slide was answered, next slide is fetched &
   });
   t.is(props.stack.endReview, false);
   t.deepEqual(omit('next.onClick', props.stack.correctionPopinProps), {
-    resultLabel: translate('Correct Answer'),
+    resultLabel: '___Correct Answer',
     information: {
-      label: translate('KLF'),
+      label: '___KLF',
       message:
         'To negotiate your salary when being hired, you have to establish a benchmark beforehand. In other words, you should assess the salary to which you aspire by enquiring about the remuneration paid in the same industry, the same region and the same position.'
     },
     klf: undefined,
     next: {
-      'aria-label': translate('Next Question'),
-      label: translate('Next Question')
+      'aria-label': '___Next Question',
+      label: '___Next Question'
     },
     type: 'right'
   });
@@ -631,7 +631,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     showCorrectionPopin: true,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
@@ -649,7 +649,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     showCorrectionPopin: false,
     position: 1,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText: 'Quels sont les 4 piliers de l’apprentissage ?'
   });
   t.is(props.stack.validateButton.disabled, true);
@@ -714,7 +714,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {
@@ -746,19 +746,19 @@ test('should verify props when first slide was answered incorrectly, next slide 
   });
   t.is(props.stack.endReview, false);
   t.deepEqual(omit('next.onClick', props.stack.correctionPopinProps), {
-    resultLabel: translate('Wrong Answer'),
+    resultLabel: '___Wrong Answer',
     information: {
-      label: translate('Correct Answer'),
+      label: '___Correct Answer',
       message: 'Benchmark'
     },
     klf: {
-      label: translate('KLF'),
+      label: '___KLF',
       tooltip:
         'To negotiate your salary when being hired, you have to establish a benchmark beforehand. In other words, you should assess the salary to which you aspire by enquiring about the remuneration paid in the same industry, the same region and the same position.'
     },
     next: {
-      'aria-label': translate('Next Question'),
-      label: translate('Next Question')
+      'aria-label': '___Next Question',
+      label: '___Next Question'
     },
     type: 'wrong'
   });
@@ -768,7 +768,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     showCorrectionPopin: true,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
@@ -786,7 +786,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     showCorrectionPopin: false,
     position: 1,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText: 'Quels sont les 4 piliers de l’apprentissage ?'
   });
   t.is(props.stack.validateButton.disabled, true);
@@ -855,7 +855,7 @@ test('should verify props when currentSlideRef has changed to nextContent of pro
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {
@@ -990,7 +990,7 @@ test('should verify props when progression is in success, showing last correctio
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {
@@ -1023,16 +1023,16 @@ test('should verify props when progression is in success, showing last correctio
 
   t.deepEqual(omit(['next.onClick'], props.stack.correctionPopinProps), {
     information: {
-      label: translate('KLF'),
+      label: '___KLF',
       message:
         'L’apprenant peut aussi évaluer sa performance grâce à un classement disponible sur la vue leaderboard. Elle compare sa position par rapport à celle des autres apprenants de la plateforme.'
     },
     klf: undefined,
     next: {
-      'aria-label': translate('Next Question'),
-      label: translate('Next Question')
+      'aria-label': '___Next Question',
+      label: '___Next Question'
     },
-    resultLabel: translate('Correct Answer'),
+    resultLabel: '___Correct Answer',
     type: 'right'
   });
 });
@@ -1110,7 +1110,7 @@ test('should verify props showing congrats', t => {
 
   const props = mapStateToSlidesProps(state, identity, connectedOptions);
   const congrats = props.congrats as ReviewCongratsProps;
-  t.is(congrats.title, translate('Congratulations!'));
+  t.is(congrats.title, '___Congratulations!');
   t.is(
     congrats.animationLottie.animationSrc,
     'https://static-staging.coorpacademy.com/animations/review/confetti.json'
@@ -1135,7 +1135,7 @@ test('should verify props showing congrats', t => {
         loop: true
       },
       rankSuffix: 'th',
-      reviewCardTitle: translate('You are now'),
+      reviewCardTitle: '___You are now',
       reviewCardValue: '9'
     }
   );
@@ -1161,19 +1161,19 @@ test('should verify props showing congrats', t => {
         }
       },
       rankSuffix: undefined,
-      reviewCardTitle: translate('You have won'),
+      reviewCardTitle: '___You have won',
       reviewCardValue: '40'
     }
   );
 
   t.deepEqual(omit(['onClick'], buttonRevising), {
-    'aria-label': translate('Continue reviewing'),
-    label: translate('Continue reviewing'),
+    'aria-label': '___Continue reviewing',
+    label: '___Continue reviewing',
     type: 'tertiary'
   });
   t.deepEqual(omit(['onClick'], buttonRevisingSkill), {
-    'aria-label': translate('Revise another skill'),
-    label: translate('Revise another skill'),
+    'aria-label': '___Revise another skill',
+    label: '___Revise another skill',
     type: 'primary'
   });
 });
@@ -1251,7 +1251,7 @@ test('should verify props showing congrats, with only stars card, if user has no
 
   const props = mapStateToSlidesProps(state, identity, connectedOptions);
   const congrats = props.congrats as ReviewCongratsProps;
-  t.is(congrats.title, translate('Congratulations!'));
+  t.is(congrats.title, '___Congratulations!');
   t.is(
     congrats.animationLottie.animationSrc,
     'https://static-staging.coorpacademy.com/animations/review/confetti.json'
@@ -1279,7 +1279,7 @@ test('should verify props showing congrats, with only stars card, if user has no
         }
       },
       rankSuffix: undefined,
-      reviewCardTitle: translate('You have won'),
+      reviewCardTitle: '___You have won',
       reviewCardValue: '40'
     }
   );
@@ -1287,8 +1287,8 @@ test('should verify props showing congrats, with only stars card, if user has no
   t.is(cardCongratsRank, undefined);
   t.is(buttonRevising, undefined);
   t.deepEqual(omit(['onClick'], buttonRevisingSkill), {
-    'aria-label': translate('Revise another skill'),
-    label: translate('Revise another skill'),
+    'aria-label': '___Revise another skill',
+    label: '___Revise another skill',
     type: 'primary'
   });
 });
@@ -1369,7 +1369,7 @@ test('should verify props when progression has answered a current pendingSlide',
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {
@@ -1477,7 +1477,7 @@ test('should verify props when progression still has a pendingSlide', t => {
     'aria-label': 'aria-header-wrapper',
     closeButtonAriaLabel: 'aria-close-button',
     hiddenSteps: false,
-    mode: translate('Review Title'),
+    mode: '___Review Title',
     skillName: '__agility',
     steps: [
       {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -197,7 +197,7 @@ test('should create props when first slide is on the state', t => {
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
@@ -307,7 +307,7 @@ test('should create props when slide is on the state and user has selected answe
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
@@ -423,7 +423,7 @@ test('should verify props when first slide was answered correctly and next slide
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
@@ -631,7 +631,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     showCorrectionPopin: true,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
@@ -649,7 +649,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     showCorrectionPopin: false,
     position: 1,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText: 'Quels sont les 4 piliers de l’apprentissage ?'
   });
   t.is(props.stack.validateButton.disabled, true);
@@ -768,7 +768,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     showCorrectionPopin: true,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
@@ -786,7 +786,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     showCorrectionPopin: false,
     position: 1,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText: 'Quels sont les 4 piliers de l’apprentissage ?'
   });
   t.is(props.stack.validateButton.disabled, true);

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -108,7 +108,7 @@ test('should dispatch EDIT_BASIC action via the property onChange of a Free Text
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -108,7 +108,7 @@ test('should dispatch EDIT_BASIC action via the property onChange of a Free Text
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -82,7 +82,7 @@ test('should dispatch EDIT_QCM_DRAG action via the property onClick of a QCM Dra
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText: "Remettez dans l'ordre les quatre étapes du burn out."
   });
 

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -76,10 +76,6 @@ test('should dispatch EDIT_QCM_DRAG action via the property onClick of a QCM Dra
   const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
-  // eslint-disable-next-line no-console
-  console.log('props');
-  // eslint-disable-next-line no-console
-  console.log(props);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -76,13 +76,17 @@ test('should dispatch EDIT_QCM_DRAG action via the property onClick of a QCM Dra
   const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
+  // eslint-disable-next-line no-console
+  console.log('props');
+  // eslint-disable-next-line no-console
+  console.log(props);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Using redux" chapter',
+    parentContentTitle: translate('Content Parent Title'),
     questionText: "Remettez dans l'ordre les quatre étapes du burn out."
   });
 

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -82,7 +82,7 @@ test('should dispatch EDIT_QCM_GRAPHIC action via the property onClick of a QCM 
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText: 'Quels sont les 4 piliers de l’apprentissage ?'
   });
 

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -82,7 +82,7 @@ test('should dispatch EDIT_QCM_GRAPHIC action via the property onClick of a QCM 
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText: 'Quels sont les 4 piliers de l’apprentissage ?'
   });
 

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -84,7 +84,7 @@ test('should dispatch EDIT_QCM action via the property onClick of a QCM slide', 
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText: "Après la vente d'un NFT, son créateur peut-il toucher de l'argent ?"
   });
 

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -84,7 +84,7 @@ test('should dispatch EDIT_QCM action via the property onClick of a QCM slide', 
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText: "Après la vente d'un NFT, son créateur peut-il toucher de l'argent ?"
   });
 

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -82,7 +82,7 @@ test('should dispatch EDIT_SLIDER action via the property onChange of a Slider s
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText:
       'En combien d’années la communauté de communes du Thouarsais est-elle passée de zéro à un tiers d’énergies renouvelables ?'
   });

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -82,7 +82,7 @@ test('should dispatch EDIT_SLIDER action via the property onChange of a Slider s
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText:
       'En combien d’années la communauté de communes du Thouarsais est-elle passée de zéro à un tiers d’énergies renouvelables ?'
   });

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -83,7 +83,7 @@ test('should dispatch EDIT_SLIDER action via the property onSliderChange of a Sl
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText:
       'En combien d’années la communauté de communes du Thouarsais est-elle passée de zéro à un tiers d’énergies renouvelables ?'
   });

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -83,7 +83,7 @@ test('should dispatch EDIT_SLIDER action via the property onSliderChange of a Sl
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText:
       'En combien d’années la communauté de communes du Thouarsais est-elle passée de zéro à un tiers d’énergies renouvelables ?'
   });

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -80,7 +80,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText: 'Complétez la phrase ci-dessous.'
   });
 
@@ -111,7 +111,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: translate('Content Parent Title'),
+    parentContentTitle: '___Content Parent Title',
     questionText: 'Complétez la phrase ci-dessous.'
   });
 

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -80,7 +80,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText: 'Complétez la phrase ci-dessous.'
   });
 
@@ -111,7 +111,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
     showCorrectionPopin: false,
     position: 0,
     loading: false,
-    parentContentTitle: 'From "Developing the review app" course',
+    parentContentTitle: translate('Content Parent Title'),
     questionText: 'Complétez la phrase ci-dessous.'
   });
 


### PR DESCRIPTION
Part of this trello card : https://trello.com/c/vTce6rnR/2766-app-review-i18n

**Detailed purpose of the PR - Issues **
Fix the i18n issues in App-Review: 
1. En langue FR (ou autre), sur le l'information du cours concerné, j'ai l'indication en Anglais "From 'cours' course"
2. En langue FR (ou autre), j'ai "app-review" avant le "next question" sur le CTA

**Result and observation**
### "app-review" before "Next Question" key fixed by updating app-review version used by MOOC
<img width="1680" alt="Capture d’écran 2022-10-28 à 11 52 45" src="https://user-images.githubusercontent.com/113359769/198564357-ac88539d-81fd-4dbe-8512-e6b973417130.png">

### Updating the "Content Parent Title" key in review.json file to fix the title issue.
<img width="1680" alt="Capture d’écran 2022-10-28 à 15 53 03" src="https://user-images.githubusercontent.com/113359769/198625294-e168a140-6d76-4a76-bf60-1109b49f5ecb.png">

### In french
<img width="1680" alt="Capture d’écran 2022-10-28 à 16 03 17" src="https://user-images.githubusercontent.com/113359769/198631189-b1b18675-b371-4f2f-830d-83813c375c1c.png">

**Testing Strategy**
- Already covered by tests
- Manual testing
