### PR TITLE
[app-review] Fix restack slides

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/style.css
@@ -99,16 +99,17 @@
 
 @keyframes slideOutAndIn {
   0% {
+    width: 100%;
     z-index: 55;
     transform: translate(0, 0);
   }
   50% {
-    width: 100%;
+    width: 97%;
     z-index: 50;
     transform: translate(0, 1000px);
   }
   60% {
-    width: 92%;
+    width: 95%;
     z-index: 30;
     transform: translate(3.2%, 900px);
   }
@@ -121,12 +122,12 @@
 
 .slideOutHideAndIn {
   pointer-events: none;
-  animation: slideOutHideAndSlideIn 3s ease forwards;
+  animation: slideOutHideAndSlideIn 2s ease forwards;
 }
 
 .slideOutAndIn {
   pointer-events: none;
-  animation: slideOutAndIn 3s ease forwards;
+  animation: slideOutAndIn 2s ease forwards;
 }
 
 .hiddenSlide {


### PR DESCRIPTION
https://trello.com/c/uaF7zA1N/2821-or-bug-animation-slide-bad-answer

**Detailed purpose of the PR**

On desktop mode, when a slide was answered incorrectly and it is restack, its width is modified to above 60-80% of its original size. Like this

![resize-unstack](https://user-images.githubusercontent.com/7602475/199041856-4a22a006-1ff9-4011-9602-865d9bf22fdb.gif)


This PR fixes this behavior. It also sets the animation duration to 2 seconds.

**Result and observation**

![restack-2s](https://user-images.githubusercontent.com/7602475/199041891-58ad25c0-9599-4697-a817-8422861173e2.gif)

**Testing Strategy**

- Already covered by tests
- Manual testing
