### PR TITLE
[app-review] Fix restack sizing of cards

### DIFF
--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -28,6 +28,7 @@ import {postAnswer} from '../../actions/api/post-answer';
 import {postProgression} from '../../actions/api/post-progression';
 import {nextSlide} from '../../actions/ui/next-slide';
 import {ProgressionState} from '../../reducers/data/progression';
+import {UISlide} from '../../reducers/ui/slide';
 import {mapApiSlideToUi} from './map-api-slide-to-ui';
 
 const ICON_VALUES = {
@@ -105,6 +106,10 @@ const getCurrentSlideRef = (state: StoreState): string => {
   return content.ref;
 };
 
+const isLastSlideAnswered = (slidesRef: string[], slideRef: string): boolean => {
+  return last(slidesRef) === slideRef;
+};
+
 const buildStackSlides = (
   state: StoreState,
   dispatch: Dispatch,
@@ -121,11 +126,12 @@ const buildStackSlides = (
   const stack = reduce.convert({cap: false})(
     (acc: SlidesStack, uiSlide: ReviewSlide, _index: string): SlidesStack => {
       const index = toInteger(_index);
+      const slideRef = slideRefs[index];
+      const lastAnsweredSlideRef = isLastSlideAnswered(progression.state.slides, slideRef);
 
       const positions = state.ui.positions;
-      const position = positions[index];
+      const position = lastAnsweredSlideRef && positions[index] === -1 ? 0 : positions[index];
 
-      const slideRef = slideRefs[index];
       if (!slideRef) return set(index, {...uiSlide, position}, acc);
       const slideFromAPI = get(slideRef, state.data.slides);
       if (!slideFromAPI) return set(index, {...uiSlide, position}, acc);
@@ -138,7 +144,7 @@ const buildStackSlides = (
       const slideUI = get(['ui', 'slide', slideRef], state);
       const animateCorrectionPopin = isCurrentSlideRef && slideUI.animateCorrectionPopin;
       const showCorrectionPopin = isCurrentSlideRef && slideUI.showCorrectionPopin;
-      const animationType = slideUI.animationType;
+      const animationType = lastAnsweredSlideRef ? slideUI.animationType : undefined;
 
       const updatedUiSlide = {
         ...uiSlide,

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -28,7 +28,6 @@ import {postAnswer} from '../../actions/api/post-answer';
 import {postProgression} from '../../actions/api/post-progression';
 import {nextSlide} from '../../actions/ui/next-slide';
 import {ProgressionState} from '../../reducers/data/progression';
-import {UISlide} from '../../reducers/ui/slide';
 import {mapApiSlideToUi} from './map-api-slide-to-ui';
 
 const ICON_VALUES = {
@@ -130,6 +129,8 @@ const buildStackSlides = (
       const lastAnsweredSlideRef = isLastSlideAnswered(progression.state.slides, slideRef);
 
       const positions = state.ui.positions;
+      // when unstack the last answered slide (position -1), we set the position to 0 only during the animation
+      // to avoid to hide the slide (caused by the position -1).
       const position = lastAnsweredSlideRef && positions[index] === -1 ? 0 : positions[index];
 
       if (!slideRef) return set(index, {...uiSlide, position}, acc);

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -891,7 +891,7 @@ test('should verify props when currentSlideRef has changed to nextContent of pro
     loading: false,
     animateCorrectionPopin: false,
     animationType: 'unstack',
-    position: -1
+    position: 0
   });
   t.deepEqual(pick(propsToCheck, props.stack.slides[1]), {
     loading: false,

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/index.js
@@ -15,14 +15,22 @@ const stylesByPosition = {
   4: style.position4
 };
 
+const unstackByPosition = {
+  0: style.slideOutAndIn0,
+  1: style.slideOutAndIn1,
+  2: style.slideOutAndIn2,
+  3: style.slideOutAndIn3,
+  4: style.slideOutAndIn4
+};
+
 const getSlideAnimation = (action, position) => {
   switch (action) {
     case 'unstack':
       return style.slideOutHideAndIn;
     case 'restack':
-      return style.slideOutAndIn;
+      return unstackByPosition[position];
     default:
-      return position < 0 ? style.hiddenSlide : stylesByPosition[position];
+      return null;
   }
 };
 
@@ -40,6 +48,7 @@ const StackedSlides = ({slides, endReview, validateButton, correctionPopinProps}
         className={classnames(
           style.slideBase,
           getSlideAnimation(animationType, position),
+          position < 0 ? style.hiddenSlide : stylesByPosition[position],
           endReview ? style.endReview : null
         )}
       >

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/style.css
@@ -43,7 +43,6 @@
   width: 100%;
   transform: translate(0, 0);
   transition: transform 0.5s ease-in;
-  
 }
 
 .position1 {
@@ -97,7 +96,12 @@
   }
 }
 
-@keyframes slideOutAndIn {
+.slideOutHideAndIn {
+  pointer-events: none;
+  animation: slideOutHideAndSlideIn 2s ease forwards;
+}
+
+@keyframes slideOutAndInPosition4 {
   0% {
     width: 100%;
     z-index: 55;
@@ -120,14 +124,121 @@
   }
 }
 
-.slideOutHideAndIn {
+.slideOutAndIn4 {
   pointer-events: none;
-  animation: slideOutHideAndSlideIn 2s ease forwards;
+  animation: slideOutAndInPosition4 2s ease forwards;
 }
 
-.slideOutAndIn {
+@keyframes slideOutAndInPosition3 {
+  0% {
+    width: 100%;
+    z-index: 55;
+    transform: translate(0, 0);
+  }
+  50% {
+    width: 97%;
+    z-index: 50;
+    transform: translate(0, 1000px);
+  }
+  60% {
+    width: 95%;
+    z-index: 30;
+    transform: translate(3.2%, 900px);
+  }
+  100% {
+    z-index: 35;
+    width: 94%;
+    transform: translate(2.4%, -24px);
+  }
+}
+
+.slideOutAndIn3 {
   pointer-events: none;
-  animation: slideOutAndIn 2s ease forwards;
+  animation: slideOutAndInPosition3 2s ease forwards;
+}
+
+@keyframes slideOutAndInPosition2 {
+  0% {
+    width: 100%;
+    z-index: 55;
+    transform: translate(0, 0);
+  }
+  50% {
+    width: 97%;
+    z-index: 50;
+    transform: translate(0, 1000px);
+  }
+  60% {
+    width: 95%;
+    z-index: 30;
+    transform: translate(3.2%, 900px);
+  }
+  100% {
+    z-index: 40;
+    width: 96%;
+    transform: translate(1.6%, -16px);
+  }
+}
+
+.slideOutAndIn2 {
+  pointer-events: none;
+  animation: slideOutAndInPosition2 2s ease forwards;
+}
+
+@keyframes slideOutAndInPosition1 {
+  0% {
+    width: 100%;
+    z-index: 55;
+    transform: translate(0, 0);
+  }
+  50% {
+    width: 97%;
+    z-index: 50;
+    transform: translate(0, 1000px);
+  }
+  60% {
+    width: 95%;
+    z-index: 30;
+    transform: translate(3.2%, 900px);
+  }
+  100% {
+    z-index: 45;
+    width: 98%;
+    transform: translate(0.8%, -8px);
+  }
+}
+
+.slideOutAndIn1 {
+  pointer-events: none;
+  animation: slideOutAndInPosition1 2s ease forwards;
+}
+
+@keyframes slideOutAndInPosition0 {
+  0% {
+    width: 100%;
+    z-index: 55;
+    transform: translate(0, 0);
+  }
+  50% {
+    width: 97%;
+    z-index: 50;
+    transform: translate(0, 1000px);
+  }
+  60% {
+    width: 95%;
+    z-index: 30;
+    transform: translate(3.2%, 900px);
+  }
+  100% {
+    z-index: 55;
+    width: 100%;
+    transform: translate(0, 0);
+  }
+}
+
+.slideOutAndIn0 {
+  pointer-events: none;
+  animation: slideOutAndInPosition0 2s ease forwards;
 }
 
 .hiddenSlide {

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/restack.ts
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/restack.ts
@@ -41,33 +41,41 @@ const fixture: Fixture = {
     endReview: false,
     slides: {
       0: {
-        position: 4,
+        position: -1,
         loading: false,
         parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 1',
         answerUI: qcmDrag,
-        isCorrect: false,
-        showCorrectionPopin: true,
-        animateCorrectionPopin: false,
-        animationType: 'restack'
+        isCorrect: true
       },
       1: {
-        position: 0,
         loading: false,
         parentContentTitle: 'From "Master Design Thinking to become more agile" course',
         questionText: 'Question 2',
-        answerUI: qcmGraphic
+        position: 2,
+        answerUI: qcmGraphic,
+        isCorrect: false
       },
       2: {
-        position: 1,
-        loading: false
+        loading: false,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
+        questionText: 'Question 3',
+        position: 3,
+        answerUI: qcmDrag,
+        showCorrectionPopin: true,
+        animateCorrectionPopin: false,
+        animationType: 'restack',
+        isCorrect: false
       },
       3: {
-        position: 2,
-        loading: false
+        loading: false,
+        parentContentTitle: 'From "Master Design Thinking to become more agile" course',
+        questionText: 'Question 4',
+        answerUI: qcmGraphic,
+        position: 0
       },
       4: {
-        position: 3,
+        position: 1,
         loading: false
       }
     },


### PR DESCRIPTION
https://trello.com/c/lBI3nb2V/2822-or-re-stack-des-slides

**Detailed purpose of the PR**

Wrong answered slide are all sent to the last position (CSS class `position 4`). 

![bad-slides-position-4](https://user-images.githubusercontent.com/7602475/199273251-9c98b656-fed6-42e5-9077-762ce17a65d5.gif)

The problem is that when intermediary slides are answered correctly, this should not be the position for the last slide. This PR creates new CSS classes to be applied to to the restacked slides according to their position to avoid to send the question systematically to the `position 4`.
It also forces the unstacked slide to be in position 0 during `unstack` animation, even if their position where modified to -1 in order to be hidden.

**Result and observation**

![slides-position-fixed](https://user-images.githubusercontent.com/7602475/199283871-15be7114-a996-4541-9715-874363aa100a.gif)


**Testing Strategy**

- Already covered by tests
- Manual testing
