### PR TITLE
[review] Fixes on Correction review popin

### DIFF
--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -269,7 +269,7 @@ const getCorrectionPopinProps =
       resultLabel: isCorrect ? translate('Correct Answer') : translate('Wrong Answer'),
       information: {
         label: isCorrect ? translate('KLF') : translate('Correct Answer'),
-        message: isCorrect ? klf : join(',', correctAnswer)
+        message: isCorrect ? klf : join(', ', correctAnswer)
       },
       next: {
         'aria-label': translate('Next Question'),

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -24,7 +24,11 @@ const buildKlfButton = klf => {
         <ButtonLink {...klfButtonProps} className={style.klfButton} />
       </div>
       <div className={style.toolTip}>
-        <div className={style.tooltipText}>{klf.tooltip}</div>
+        <span
+          className={style.tooltipText}
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{__html: klf.tooltip}}
+        />
       </div>
     </div>
   );
@@ -64,9 +68,12 @@ const ReviewCorrectionPopin = props => {
                 {information.label}
               </span>
             </div>
-            <span className={style.message} aria-label={information.message}>
-              {information.message}
-            </span>
+            <span
+              className={style.message}
+              aria-label={information.message}
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{__html: information.message}}
+            />
           </div>
         </div>
         <div className={type === 'right' ? style.actions : style.actionsWrong}>

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/right.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/right.js
@@ -5,7 +5,7 @@ export default {
     information: {
       label: 'Key learning factor',
       message:
-        '17 frustrated software engineers grappling with the complexities of software development.'
+        '17 frustrated <i><font color="blue">software engineers</font></i> grappling with <b>the complexities</b> of software development.'
     },
     next: {
       label: 'Next Question',

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/wrong.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/wrong.js
@@ -9,7 +9,7 @@ export default {
     klf: {
       label: 'Key learning factor',
       tooltip:
-        '17 frustrated software engineers grappling with the complexities of software development.'
+        '17 frustrated <i><font color="blue">software engineers</font></i> grappling with the complexities of software development.'
     },
     next: {
       label: 'Next Question',

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/second-wrong.ts
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/second-wrong.ts
@@ -11,11 +11,11 @@ const qcmDrag = AnswerQCMDrag.props;
 export const correctionPopinProps: ReviewCorrectionPopinProps = {
   klf: {
     label: 'Key learning factor',
-    tooltip: 'Some tooltip info.'
+    tooltip: '17 frustrated <i><font color="blue">software engineers</font></i> grappling with.'
   },
   information: {
     label: 'Key learning factor',
-    message: 'info msg'
+    message: '17 frustrated <i><font color="blue">software engineers</font></i> grappling with.'
   },
   next: {
     label: 'Next',


### PR DESCRIPTION
https://trello.com/c/fYX2LAS4/2826-or-la-popin-de-correction-ne-supporte-pas-les-contenu-en-html
https://trello.com/c/GVgpmRC4/2825-popin-de-correction-affichage-de-r%C3%A9ponses-correctes

**Detailed purpose of the PR**

This PR add the html tag support on text shown on the correction popin, and add a blank space for the correct answers to be shown when users get a wrong answer.

**Result and observation**

### HTML SUPPORT

**Before**

<img width="304" alt="Capture d’écran 2022-11-02 à 15 28 29" src="https://user-images.githubusercontent.com/7602475/199532761-4e8e9ec5-3722-48a9-85bd-a9a63c8c1495.png">
<img width="1200" alt="Capture d’écran 2022-11-02 à 15 32 13" src="https://user-images.githubusercontent.com/7602475/199532766-f0b35c7b-a8f9-43e7-ba95-df7b65e9cacc.png">

**After**

<img width="1285" alt="Capture d’écran 2022-11-02 à 16 35 11" src="https://user-images.githubusercontent.com/7602475/199532941-7f113bdd-573e-41ec-b3ba-475ec507be38.png">
<img width="1112" alt="Capture d’écran 2022-11-02 à 16 35 23" src="https://user-images.githubusercontent.com/7602475/199532945-517d0982-95a1-448b-b934-3acdec3c60bc.png">

### SPACES BETWEEN ANSWERS

**After**

<img width="1206" alt="Capture d’écran 2022-11-02 à 17 50 51" src="https://user-images.githubusercontent.com/7602475/199551696-7c5d684e-ceb3-4e3d-b063-137c4f0e276e.png">


**Testing Strategy**

- Already covered by tests
- Manual testing
