### PR TITLE
add z-index to correctionPopinWrapper class to fix overlap

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-slide/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-slide/style.css
@@ -112,6 +112,7 @@ _:-ms-fullscreen, :root .validateButtonWrapper {
   border-radius: 7px;
   margin: 0 15px 15px;
   width: 95%;
+  z-index: 100;
 }
 
 .popinAnimation {

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-ok-template.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-ok-template.js
@@ -3,8 +3,10 @@ import Template from '../../../../molecule/answer/test/fixtures/template';
 import RightCorrectionPopin from '../../../../molecule/review-correction-popin/test/fixtures/right';
 
 const templateProps = Template.props;
+const templateContext = Template.mobileContext;
 
 export default {
+  mobileContext: templateContext,
   props: {
     slide: {
       hidden: false,

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-ok-template.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/correction-ok-template.js
@@ -1,0 +1,26 @@
+import Template from '../../../../molecule/answer/test/fixtures/template';
+
+import RightCorrectionPopin from '../../../../molecule/review-correction-popin/test/fixtures/right';
+
+const templateProps = Template.props;
+
+export default {
+  props: {
+    slide: {
+      hidden: false,
+      position: 0,
+      loading: false,
+      parentContentTitle: 'From "Master Design Thinking to become more agile" course',
+      questionText: 'Question 1',
+      answerUI: templateProps,
+      animateCorrectionPopin: false,
+      showCorrectionPopin: true
+    },
+    validateButton: {
+      label: 'Validate',
+      onClick: () => console.log('onValidateClick'),
+      disabled: true
+    },
+    correctionPopinProps: RightCorrectionPopin.props
+  }
+};

--- a/packages/@coorpacademy-components/src/template/app-review/player/style.css
+++ b/packages/@coorpacademy-components/src/template/app-review/player/style.css
@@ -46,7 +46,7 @@
 }
 
 .quitPopin {
-  z-index: 50;
+  z-index: 150;
 }
 
 /* ie fallback */
@@ -59,5 +59,5 @@
 :-ms-fullscreen,
 .quitPopin {
   position: absolute;
-  z-index: 80;
+  z-index: 150;
 }


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

https://trello.com/c/ie2ZBhHu/2827-or-popin-correction-derri%C3%A8re-la-question-template-basic-select

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

This PR solve the issue of overlap with select component & the correctionPopin


**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

Added also a Fixture to show the CorrectionPopin with the Template questions

Before:
![image](https://user-images.githubusercontent.com/22681512/199706297-b7346639-b1c1-4af0-9cd4-de32d386c8e9.png)

After:
<img width="612" alt="image" src="https://user-images.githubusercontent.com/22681512/199706380-43711bb8-dc77-4a16-9820-aa4a8167f51a.png">


- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
