### PR TITLE
[app-review] services are not mandatory to set on the app-review. If they're not set, the real services take over

### DIFF
--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -191,7 +191,7 @@ export type ConnectedOptions = {
 export type AppOptions = ConnectedOptions & {
   token: string;
   skillRef?: string;
-  services: Services;
+  services?: Services;
   callbackOnViewChanged?: (viewName: ViewName) => void;
 };
 


### PR DESCRIPTION
https://trello.com/c/2RnSKAFg/2832-stabilisation-projet-mobile

This is necessary to set match the type on the mobile app, where services are not defined yet.