### PR TITLE
Add placeholder translation in app-review 

### DIFF
--- a/packages/@coorpacademy-app-review/sandbox/index.tsx
+++ b/packages/@coorpacademy-app-review/sandbox/index.tsx
@@ -24,6 +24,8 @@ declare global {
 }
 
 const translate = (key: string, data?: unknown): string => {
+  // eslint-disable-next-line no-console
+  console.log('type of data', typeof data);
   try {
     return createTranslate({
       ...localesAppReview,

--- a/packages/@coorpacademy-app-review/sandbox/index.tsx
+++ b/packages/@coorpacademy-app-review/sandbox/index.tsx
@@ -9,7 +9,7 @@ import {identity} from 'lodash/fp';
 import localesComponents from '@coorpacademy/components/locales/en/global.json';
 import localesAppReview from '../locales/en/review.json';
 import AppReview from '../src';
-import type {AppOptions} from '../src/types/common';
+import type {AppOptions, Translate} from '../src/types/common';
 import {services} from '../src/test/util/services.mock';
 
 type SandboxOptions = {
@@ -23,9 +23,7 @@ declare global {
   }
 }
 
-const translate = (key: string, data?: unknown): string => {
-  // eslint-disable-next-line no-console
-  console.log('type of data', typeof data);
+const translate: Translate = (key: string, data?: Record<string, string>): string => {
   try {
     return createTranslate({
       ...localesAppReview,

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -1,5 +1,9 @@
 export type ViewName = 'skills' | 'onboarding' | 'slides' | 'loader';
 
+export interface Translate {
+  (key: string, data?: Record<string, string>): string;
+}
+
 export type ChoiceFromAPI = {
   _id: string;
   id?: string;
@@ -184,7 +188,7 @@ export type Options = {
 };
 
 export type ConnectedOptions = {
-  translate: (key: string, data?: unknown) => string;
+  translate: Translate;
   onQuitClick: () => void;
 };
 

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -138,7 +138,7 @@ const buildStackSlides = (
       if (!slideFromAPI) return set(index, {...uiSlide, position}, acc);
 
       const answers = getOr([], ['ui', 'answers', slideRef], state);
-      const {questionText, answerUI} = mapApiSlideToUi(dispatch)(slideFromAPI, answers);
+      const {questionText, answerUI} = mapApiSlideToUi(dispatch, translate)(slideFromAPI, answers);
       const {title: parentContentTitle, type: parentContentType} = slideFromAPI.parentContentTitle;
 
       const isCurrentSlideRef = currentSlideRef === slideRef;

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -20,7 +20,8 @@ import type {
   ConnectedOptions,
   ProgressionAnswerItem,
   ProgressionFromAPI,
-  SlideContent
+  SlideContent,
+  Translate
 } from '../../types/common';
 import type {StoreState} from '../../reducers';
 import type {AnswerUI} from '../../types/slides';
@@ -257,7 +258,7 @@ const getCorrectionPopinProps =
     isCorrect: boolean,
     correctAnswer: string[],
     klf: string,
-    translate: (key: string, data?: unknown) => string
+    translate: Translate
   ): ReviewCorrectionPopinProps => {
     return {
       klf: isCorrect
@@ -284,7 +285,7 @@ const getCorrectionPopinProps =
 
 const buildQuitPopinProps =
   (dispatch: Dispatch) =>
-  (onQuitClick: () => void, translate: (key: string, data?: unknown) => string): CMPopinProps => {
+  (onQuitClick: () => void, translate: Translate): CMPopinProps => {
     return {
       content: translate('Quit Title'),
       icon: `MoonRocket`,
@@ -310,10 +311,7 @@ const buildQuitPopinProps =
     };
   };
 
-const buildRankCard = (
-  rank: number,
-  translate: (key: string, data?: unknown) => string
-): CongratsCardProps => {
+const buildRankCard = (rank: number, translate: Translate): CongratsCardProps => {
   return {
     'aria-label': 'Review Card Congrats Container',
     'data-name': 'card-rank',

--- a/packages/@coorpacademy-app-review/src/views/slides/map-api-slide-to-ui.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/map-api-slide-to-ui.ts
@@ -42,7 +42,8 @@ import {
   Question,
   SlideFromAPI,
   SliderQuestion,
-  TemplateQuestion
+  TemplateQuestion,
+  Translate
 } from '../../types/common';
 import {editAnswer} from '../../actions/ui/answers';
 
@@ -117,7 +118,7 @@ const updateTemplateAnswer = (
 
 const templateTextProps = (
   dispatch: Dispatch,
-  translate: (key: string, data?: unknown) => string,
+  translate: Translate,
   answers: string[],
   choice: ChoiceFromAPI,
   index: number,
@@ -137,7 +138,7 @@ const templateTextProps = (
 
 const templateSelectProps = (
   dispatch: Dispatch,
-  translate: (key: string, data?: unknown) => string,
+  translate: Translate,
   answers: string[],
   choice: ChoiceFromAPI,
   index: number,
@@ -172,7 +173,7 @@ const templateSelectProps = (
 };
 
 const templateProps =
-  (dispatch: Dispatch, translate: (key: string, data?: unknown) => string) =>
+  (dispatch: Dispatch, translate: Translate) =>
   (answers: string[], question: TemplateQuestion): Template => {
     const choices = question.content.choices;
     const maxLength = size(choices);
@@ -251,7 +252,7 @@ const getAnswerUIModel = (
   question: Question,
   answers: string[],
   dispatch: Dispatch,
-  translate: (key: string, data?: unknown) => string
+  translate: Translate
 ): AnswerUI['model'] => {
   const type = getQuestionType(question);
   switch (type) {
@@ -279,7 +280,7 @@ const getAnswerUIModel = (
 };
 
 export const mapApiSlideToUi =
-  (dispatch: Dispatch, translate: (key: string, data?: unknown) => string) =>
+  (dispatch: Dispatch, translate: Translate) =>
   (slide: SlideFromAPI, answers: string[]): {questionText: string; answerUI: AnswerUI} => {
     const questionText = getOr('', 'question.header', slide);
 

--- a/packages/@coorpacademy-app-review/src/views/slides/map-api-slide-to-ui.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/map-api-slide-to-ui.ts
@@ -117,6 +117,7 @@ const updateTemplateAnswer = (
 
 const templateTextProps = (
   dispatch: Dispatch,
+  translate: (key: string, data?: unknown) => string,
   answers: string[],
   choice: ChoiceFromAPI,
   index: number,
@@ -125,7 +126,7 @@ const templateTextProps = (
   return {
     type: 'text',
     name: getOr('', 'name', choice),
-    placeholder: 'Type here',
+    placeholder: translate('Type here'),
     value: get(index, answers),
     onChange: (text: string): void => {
       const newAnswers = updateTemplateAnswer(text, answers, index, maxLength);
@@ -136,6 +137,7 @@ const templateTextProps = (
 
 const templateSelectProps = (
   dispatch: Dispatch,
+  translate: (key: string, data?: unknown) => string,
   answers: string[],
   choice: ChoiceFromAPI,
   index: number,
@@ -143,7 +145,7 @@ const templateSelectProps = (
 ): SelectionTemplate => {
   const answer = get(index, answers);
   const temporaryOption = {
-    name: 'Select an answer', // TODO translate
+    name: translate('Select an answer'),
     value: '',
     validOption: false,
     selected: true
@@ -170,7 +172,7 @@ const templateSelectProps = (
 };
 
 const templateProps =
-  (dispatch: Dispatch) =>
+  (dispatch: Dispatch, translate: (key: string, data?: unknown) => string) =>
   (answers: string[], question: TemplateQuestion): Template => {
     const choices = question.content.choices;
     const maxLength = size(choices);
@@ -179,8 +181,8 @@ const templateProps =
       template: get('content.template', question),
       answers: choices.map((choice, index) =>
         choice.type === 'text'
-          ? templateTextProps(dispatch, answers, choice, index, maxLength)
-          : templateSelectProps(dispatch, answers, choice, index, maxLength)
+          ? templateTextProps(dispatch, translate, answers, choice, index, maxLength)
+          : templateSelectProps(dispatch, translate, answers, choice, index, maxLength)
       )
     };
   };
@@ -248,7 +250,8 @@ const getHelp = (slide: SlideFromAPI): string => get('question.explanation', sli
 const getAnswerUIModel = (
   question: Question,
   answers: string[],
-  dispatch: Dispatch
+  dispatch: Dispatch,
+  translate: (key: string, data?: unknown) => string
 ): AnswerUI['model'] => {
   const type = getQuestionType(question);
   switch (type) {
@@ -265,7 +268,7 @@ const getAnswerUIModel = (
       return basicProps(dispatch)(answers, question as BasicQuestion);
 
     case 'template':
-      return templateProps(dispatch)(answers, question as TemplateQuestion);
+      return templateProps(dispatch, translate)(answers, question as TemplateQuestion);
 
     case 'slider':
       return sliderProps(dispatch)(answers, question as SliderQuestion);
@@ -276,12 +279,15 @@ const getAnswerUIModel = (
 };
 
 export const mapApiSlideToUi =
-  (dispatch: Dispatch) =>
+  (dispatch: Dispatch, translate: (key: string, data?: unknown) => string) =>
   (slide: SlideFromAPI, answers: string[]): {questionText: string; answerUI: AnswerUI} => {
     const questionText = getOr('', 'question.header', slide);
 
     return {
       questionText,
-      answerUI: {model: getAnswerUIModel(slide.question, answers, dispatch), help: getHelp(slide)}
+      answerUI: {
+        model: getAnswerUIModel(slide.question, answers, dispatch, translate),
+        help: getHelp(slide)
+      }
     };
   };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/map-api-slide-to-ui.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/map-api-slide-to-ui.test.ts
@@ -10,7 +10,7 @@ import {qcmGraphicUISlide, qcmGraphicSlide} from './fixtures/qcm-graphic';
 import {templateSlide, templateUISlide} from './fixtures/template';
 import {sliderSlide, sliderUISlide} from './fixtures/slider';
 
-const _mapApiSlideToUi = mapApiSlideToUi(identity);
+const _mapApiSlideToUi = mapApiSlideToUi(identity, identity);
 
 const macro = test.macro({
   title(providedTitle) {


### PR DESCRIPTION
Trello card : [[OR] Placeholder des questions en EN sur des questions FR](https://trello.com/c/UXtgG9On/2829-or-placeholder-des-questions-en-en-sur-des-questions-fr)

**Detailed purpose of the PR**
In FR or other language, answer's placeholders are always displayed in english.
This PR add the translate function in the part components builder functions.

**Result and observation**
### Before
- FR language
<img width="1680" alt="Capture d’écran 2022-11-08 à 18 53 59" src="https://user-images.githubusercontent.com/113359769/200639610-1ae5ff91-7a08-4bdf-8d58-a3dbe83b8cad.png">

### After
Screenshot environment :
- language : FR
- mocked value of "Select an answer" key
- Real values  when translate files are available.
<img width="1680" alt="Capture d’écran 2022-11-08 à 18 46 58" src="https://user-images.githubusercontent.com/113359769/200638437-ea316064-d3ec-4f16-9454-d91b0202c6d4.png">

**Testing Strategy**
- [x] Manual testing
- [x] Unit testing
