### PR TITLE
[review] Fix compute next step for review

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
@@ -388,7 +388,7 @@ const getNextPendingSlide = (
 export const computeNextStepForReview = (
   config: Config,
   _state: State | null,
-  availableContent: AvailableContent,
+  _availableContent: AvailableContent,
   partialAction: PartialAction
 ): Result => {
   const action = extendPartialAction(partialAction, _state);
@@ -406,6 +406,17 @@ export const computeNextStepForReview = (
       isCorrect
     };
   }
+
+  const filteredSlides = filter(
+    slideRef => (state ? !state.slides.includes(slideRef) : true),
+    _availableContent[0].slides
+  );
+  const availableContent: AvailableContent = [
+    {
+      ..._availableContent[0],
+      slides: filteredSlides
+    }
+  ];
 
   const nextSlide = getNextSlide(config, state, availableContent);
   if (!nextSlide) {

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
@@ -365,7 +365,7 @@ const getNextSlide = (
 ): Slide | null => {
   if (!state) return get(['0', 'slides', '0'], availableContent);
 
-  // We filter slides in orther to exclude already answered slides.
+  // We filter slides in other to exclude already answered slides.
   // In case of lag on recallUpdate lambda that would not update the review database
   // and the getSlide lambda would return as available slide, an already proposed slide
   const answeredSlides = getOr([], 'slides', state);

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.js
@@ -8,7 +8,8 @@ import {
   computeNextStep,
   nextSlidePool,
   computeNextStepForNewChapter,
-  prepareStateToSwitchChapters
+  prepareStateToSwitchChapters,
+  computeNextStepForReview
 } from '../compute-next-step';
 import allSlides from './fixtures/slides';
 import {stateBeforeGettingNextContent, lastStepProgressionState} from './fixtures/states';
@@ -227,4 +228,177 @@ test('computeNextStepForNewChapter --> should return null when computeNextStep r
 
   const result = computeNextStepForNewChapter(config, state, chapterRule, false, availableContent);
   t.is(result, null);
+});
+
+test('computeNextStepForReview --> should return the next slide for an init state', t => {
+  const _config: Config = getConfig({ref: 'review', version: '1'});
+
+  const _availableContent: AvailableContent = [
+    {
+      ref: 'skill_ref',
+      slides: [
+        allSlides[3], // _id: '1.A1.5'
+        allSlides[4] // _id: '1.A1.4'
+      ],
+      rules: null
+    }
+  ];
+
+  const result = computeNextStepForReview(_config, null, _availableContent, null);
+  t.deepEqual(result, {
+    nextContent: {
+      type: 'slide',
+      ref: '1.A1.5'
+    },
+    instructions: null,
+    isCorrect: false
+  });
+});
+
+test('computeNextStepForReview --> should return the next slide', t => {
+  const state: State = Object.freeze({
+    livesDisabled: true,
+    isCorrect: false,
+    slides: ['1.A1.1', '1.A1.2'],
+    lives: 0,
+    step: {
+      current: 3
+    },
+    stars: 0,
+    requestedClues: [],
+    viewedResources: [],
+    remainingLifeRequests: 0,
+    hasViewedAResourceAtThisStep: false,
+    content: {
+      ref: '1.A1.2',
+      type: 'slide'
+    },
+    nextContent: {
+      ref: '1.A1.3',
+      type: 'slide'
+    },
+    allAnswers: [
+      {
+        slideRef: '1.A1.1',
+        isCorrect: true,
+        answer: ['d']
+      },
+      {
+        slideRef: '1.A1.2',
+        isCorrect: true,
+        answer: ['d']
+      }
+    ],
+    pendingSlides: [],
+    variables: {}
+  });
+  const _config: Config = getConfig({ref: 'review', version: '1'});
+
+  const _availableContent: AvailableContent = [
+    {
+      ref: 'skill_ref',
+      slides: [
+        allSlides[3], // _id: '1.A1.5'
+        allSlides[4] // _id: '1.A1.4'
+      ],
+      rules: null
+    }
+  ];
+
+  const result = computeNextStepForReview(_config, state, _availableContent, {
+    type: 'answer',
+    payload: {
+      answer: ['answer'],
+      content: {
+        ref: '1.A1.3',
+        type: 'slide'
+      },
+      godMode: false,
+      isCorrect: false
+    }
+  });
+
+  t.deepEqual(result, {
+    nextContent: {
+      type: 'slide',
+      ref: '1.A1.5'
+    },
+    instructions: null,
+    isCorrect: false
+  });
+});
+
+test('computeNextStepForReview --> should avoid to return the already answered slide if there are lag on review lambda and available content are not updated', t => {
+  const state: State = Object.freeze({
+    livesDisabled: true,
+    isCorrect: false,
+    slides: ['1.A1.1', '1.A1.2'],
+    lives: 0,
+    step: {
+      current: 3
+    },
+    stars: 0,
+    requestedClues: [],
+    viewedResources: [],
+    remainingLifeRequests: 0,
+    hasViewedAResourceAtThisStep: false,
+    content: {
+      ref: '1.A1.2',
+      type: 'slide'
+    },
+    nextContent: {
+      ref: '1.A1.3',
+      type: 'slide'
+    },
+    allAnswers: [
+      {
+        slideRef: '1.A1.1',
+        isCorrect: true,
+        answer: ['d']
+      },
+      {
+        slideRef: '1.A1.2',
+        isCorrect: true,
+        answer: ['d']
+      }
+    ],
+    pendingSlides: [],
+    variables: {}
+  });
+  const _config: Config = getConfig({ref: 'review', version: '1'});
+
+  const _availableContent: AvailableContent = [
+    {
+      ref: 'skill_ref',
+      slides: [
+        allSlides[1], // _id: '1.A1.2'
+        allSlides[2], // _id: '1.A1.3'
+        allSlides[3], // _id: '1.A1.5'
+        allSlides[4] // _id: '1.A1.4'
+      ],
+      rules: null
+    }
+  ];
+
+  const result = computeNextStepForReview(_config, state, _availableContent, {
+    type: 'answer',
+    payload: {
+      answer: ['answer'],
+      content: {
+        ref: '1.A1.3',
+        type: 'slide'
+      },
+      godMode: false,
+      isCorrect: false
+    }
+  });
+
+  t.deepEqual(result, {
+    nextContent: {
+      type: 'slide',
+      ref: '1.A1.5'
+    },
+    instructions: null,
+    isCorrect: false
+  });
 });


### PR DESCRIPTION
https://trello.com/c/xZaKvARK/2828-or-bug-double-slide-impossibilit%C3%A9-de-quitter-le-review-mode

**Detailed purpose of the PR**

When a slide is answered on the review mode, its progression it's sent via the kinesis progression stream to be handle by the `recallUpdate` lambda. This treatment should mark that the slide has a new recallDate and avoid to propose it as an available question to be answered on the review mode (it's has been already answered)

But, `recallUpdate` can lag, and make that `getSlide` lambda would propose again the already answered slide.
To avoid this problem, the group of available slides would be filter to exclude the already answered slides (on `state.slides`).

**Testing Strategy**

- Unit testing
