### PR TITLE
[translate] update getTemplate function

### DIFF
--- a/packages/@coorpacademy-translate/src/translate.js
+++ b/packages/@coorpacademy-translate/src/translate.js
@@ -1,4 +1,4 @@
-import {get, has, isString, isNumber, trim, replace} from 'lodash/fp';
+import {get, getOr, has, isString, isNumber, trim, replace} from 'lodash/fp';
 
 const interpolation = /\{\{([\s\S]+?)\}\}/g;
 
@@ -8,12 +8,12 @@ function getTemplate(locales, key, count) {
     return regularTemplate;
   }
   if (count === 0) {
-    return locales[`${key}_none`] || regularTemplate;
+    return getOr(regularTemplate, `${key}_none`, locales);
   }
   if (count === 1 || Number.isNaN(count)) {
     return regularTemplate;
   }
-  return locales[`${key}_plural`] || regularTemplate;
+  return getOr(regularTemplate, `${key}_plural`, locales);
 }
 
 const createTranslate = locales => (key, data) => {


### PR DESCRIPTION
 **Detailed purpose of the PR**
This PR completes this PR https://github.com/CoorpAcademy/components/pull/2487
It modifies `getTemplate` function to get locales values regardless of the object path.
Presently, it is not possible to get values in nested object. 
<!--What existing problem does the PR solve?/
What is the current behavior? -->

BEFORE 
<img width="1437" alt="Screenshot 2022-11-15 at 11 59 01" src="https://user-images.githubusercontent.com/79636283/201903506-b8adf5c2-1b8c-4cb2-9046-e51d4c7bc4d6.png">

AFTER
<img width="1437" alt="Screenshot 2022-11-15 at 11 59 42" src="https://user-images.githubusercontent.com/79636283/201903572-abea42e9-7007-416e-9bba-3630fe96918e.png">

**Testing Strategy**
- [ ] Already covered by tests
- [x] Manual testing
- [x] Unit testing
