### PR TITLE
Set primary skin color quit popin

### DIFF
--- a/packages/@coorpacademy-app-review/sandbox/index.tsx
+++ b/packages/@coorpacademy-app-review/sandbox/index.tsx
@@ -11,6 +11,7 @@ import localesAppReview from '../locales/en/review.json';
 import AppReview from '../src';
 import type {AppOptions, Translate} from '../src/types/common';
 import {services} from '../src/test/util/services.mock';
+import {skin} from '../src/views/slides/test/fixtures/skin';
 
 type SandboxOptions = {
   container: string;
@@ -46,11 +47,6 @@ const createSandbox = (options: SandboxOptions): void => {
     console.error('[AppReview sandbox] Requires a container.');
   } else {
     const container = document.getElementById(options.container);
-    const skin = {
-      common: {
-        primary: '#248e59'
-      }
-    };
     // mode mobile/web
     const appOptions: AppOptions = {
       token: process.env.API_TEST_TOKEN || '',

--- a/packages/@coorpacademy-app-review/sandbox/index.tsx
+++ b/packages/@coorpacademy-app-review/sandbox/index.tsx
@@ -46,7 +46,11 @@ const createSandbox = (options: SandboxOptions): void => {
     console.error('[AppReview sandbox] Requires a container.');
   } else {
     const container = document.getElementById(options.container);
-
+    const skin = {
+      common: {
+        primary: '#248e59'
+      }
+    };
     // mode mobile/web
     const appOptions: AppOptions = {
       token: process.env.API_TEST_TOKEN || '',
@@ -55,14 +59,9 @@ const createSandbox = (options: SandboxOptions): void => {
       translate,
       onQuitClick: () => {
         location.reload();
-      }
+      },
+      skin
     };
-    const skin = {
-      common: {
-        primary: '#248e59'
-      }
-    };
-
     render(
       <WebContext skin={skin} translate={identity}>
         <AppReview options={appOptions} />

--- a/packages/@coorpacademy-app-review/src/index.tsx
+++ b/packages/@coorpacademy-app-review/src/index.tsx
@@ -38,7 +38,7 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
   const [store, setStore] = useState<Store<StoreState, AnyAction> | null>(null);
   const [isProgressionCreated, setIsProgressionCreated] = useState(false);
 
-  const {translate, onQuitClick} = options;
+  const {translate, onQuitClick, skin} = options;
 
   useEffect(() => {
     if (store) return;
@@ -92,7 +92,7 @@ const AppReview = ({options}: {options: AppOptions}): JSX.Element | null => {
 
   return (
     <Provider store={store}>
-      <ConnectedApp onQuitClick={onQuitClick} translate={translate} />
+      <ConnectedApp onQuitClick={onQuitClick} translate={translate} skin={skin} />
     </Provider>
   );
 };

--- a/packages/@coorpacademy-app-review/src/test/index.test.tsx
+++ b/packages/@coorpacademy-app-review/src/test/index.test.tsx
@@ -62,7 +62,12 @@ const appOptions: AppOptions = {
   skillRef: 'skill_NJC0jFKoH',
   services,
   onQuitClick: identity,
-  translate: key => key
+  translate: key => key,
+  skin: {
+    common: {
+      primary: '#248e59'
+    }
+  }
 };
 
 test('should show the loader while the app is fetching the data', async t => {

--- a/packages/@coorpacademy-app-review/src/test/util/services.mock.ts
+++ b/packages/@coorpacademy-app-review/src/test/util/services.mock.ts
@@ -474,4 +474,5 @@ export const services: Services = {
   fetchSlidesToReviewBySkillRef: () => Promise.resolve(fetchSlidesToReviewBySkillRefResponse)
 };
 
-export const translate = (key: string, data?: unknown): string => mockTranslate(key, data);
+export const translate = (key: string, data?: Record<string, string>): string =>
+  mockTranslate(key, data);

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -190,7 +190,7 @@ export type Options = {
 export type ConnectedOptions = {
   translate: Translate;
   onQuitClick: () => void;
-  skin: PrimarySkin;
+  skin: Skin;
 };
 
 export type AppOptions = ConnectedOptions & {
@@ -220,7 +220,7 @@ export type WithRequired<T, K extends keyof T> = T & {
   [P in K]-?: T[P];
 };
 
-export type PrimarySkin = {
+export type Skin = {
   common: {
     primary: string;
   };

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -190,6 +190,7 @@ export type Options = {
 export type ConnectedOptions = {
   translate: Translate;
   onQuitClick: () => void;
+  skin: PrimarySkin;
 };
 
 export type AppOptions = ConnectedOptions & {
@@ -217,4 +218,10 @@ export type JWT = {
 export type WithRequired<T, K extends keyof T> = T & {
   // the "-" is a Mapping Modifier, removes optionality from a prop
   [P in K]-?: T[P];
+};
+
+export type PrimarySkin = {
+  common: {
+    primary: string;
+  };
 };

--- a/packages/@coorpacademy-app-review/src/views/skills/test/skills.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/skills/test/skills.test.ts
@@ -5,8 +5,9 @@ import omit from 'lodash/fp/omit';
 import {StoreState} from '../../../reducers';
 import {mapStateToSkillsProps} from '..';
 import {translate} from '../../../test/util/services.mock';
+import {skin} from '../../slides/test/fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 
 test('should create initial props when there are no skills on the state', t => {
   const state: StoreState = {

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -18,6 +18,7 @@ import {closeQuitPopin, openQuitPopin} from '../../actions/ui/quit-popin';
 import {getProgressionSlidesRefs} from '../../common';
 import type {
   ConnectedOptions,
+  PrimarySkin,
   ProgressionAnswerItem,
   ProgressionFromAPI,
   SlideContent,
@@ -287,7 +288,7 @@ const getCorrectionPopinProps =
 
 const buildQuitPopinProps =
   (dispatch: Dispatch) =>
-  (onQuitClick: () => void, translate: Translate): CMPopinProps => {
+  (onQuitClick: () => void, translate: Translate, skin: PrimarySkin): CMPopinProps => {
     return {
       content: translate('Quit Title'),
       icon: `MoonRocket`,
@@ -297,7 +298,7 @@ const buildQuitPopinProps =
         label: translate('Stop learning'),
         type: 'tertiary',
         customStyle: {
-          color: '#ED3436'
+          color: skin.common.primary
         },
         handleOnclick: onQuitClick,
         'aria-label': translate('Stop learning')
@@ -414,7 +415,7 @@ export const mapStateToSlidesProps = (
   dispatch: Dispatch,
   options: ConnectedOptions
 ): ReviewPlayerProps => {
-  const {translate, onQuitClick} = options;
+  const {translate, onQuitClick, skin} = options;
   const currentSlideRef = getCurrentSlideRef(state);
   const endReview = isEndOfProgression(state.data.progression);
   const correction = get(['data', 'corrections', currentSlideRef], state);
@@ -454,6 +455,8 @@ export const mapStateToSlidesProps = (
       endReview: endReview && state.ui.showCongrats
     },
     congrats: buildCongratsProps(state, dispatch, options),
-    quitPopin: showQuitPopin ? buildQuitPopinProps(dispatch)(onQuitClick, translate) : undefined
+    quitPopin: showQuitPopin
+      ? buildQuitPopinProps(dispatch)(onQuitClick, translate, skin)
+      : undefined
   };
 };

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -18,7 +18,7 @@ import {closeQuitPopin, openQuitPopin} from '../../actions/ui/quit-popin';
 import {getProgressionSlidesRefs} from '../../common';
 import type {
   ConnectedOptions,
-  PrimarySkin,
+  Skin,
   ProgressionAnswerItem,
   ProgressionFromAPI,
   SlideContent,
@@ -288,7 +288,7 @@ const getCorrectionPopinProps =
 
 const buildQuitPopinProps =
   (dispatch: Dispatch) =>
-  (onQuitClick: () => void, translate: Translate, skin: PrimarySkin): CMPopinProps => {
+  (onQuitClick: () => void, translate: Translate, skin: Skin): CMPopinProps => {
     return {
       content: translate('Quit Title'),
       icon: `MoonRocket`,

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -306,13 +306,13 @@ const buildQuitPopinProps =
       secondButton: {
         label: translate('Continue learning'),
         type: 'primary',
+        customStyle: {
+          backgroundColor: skin.common.primary
+        },
         handleOnclick: (): void => {
           dispatch(closeQuitPopin);
         },
-        'aria-label': translate('Continue learning'),
-        customStyle: {
-          color: skin.common.primary
-        }
+        'aria-label': translate('Continue learning')
       }
     };
   };

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -298,7 +298,7 @@ const buildQuitPopinProps =
         label: translate('Stop learning'),
         type: 'tertiary',
         customStyle: {
-          color: skin.common.primary
+          color: '#ED3436'
         },
         handleOnclick: onQuitClick,
         'aria-label': translate('Stop learning')
@@ -309,7 +309,10 @@ const buildQuitPopinProps =
         handleOnclick: (): void => {
           dispatch(closeQuitPopin);
         },
-        'aria-label': translate('Continue learning')
+        'aria-label': translate('Continue learning'),
+        customStyle: {
+          color: skin.common.primary
+        }
       }
     };
   };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
@@ -23,8 +23,9 @@ import {qcmSlide} from './fixtures/qcm';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 import {sliderSlide} from './fixtures/slider';
 import {templateSlide} from './fixtures/template';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 
 const state: StoreState = {
   data: {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
@@ -24,7 +24,7 @@ import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 import {sliderSlide} from './fixtures/slider';
 import {templateSlide} from './fixtures/template';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 
 const state: StoreState = {
   data: {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/skin.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/skin.ts
@@ -1,0 +1,7 @@
+import {Skin} from '../../../../types/common';
+
+export const skin: Skin = {
+  common: {
+    primary: '#248e59'
+  }
+};

--- a/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
@@ -43,12 +43,17 @@ const state: StoreState = {
 test('should dispatch OPEN_POPIN action after a click on close button in header', async t => {
   const expectedAction = [{type: OPEN_POPIN}];
   const {dispatch, getState} = createTestStore(t, state, {services}, expectedAction);
-  const props = mapStateToSlidesProps(getState(), dispatch, {translate, onQuitClick: identity});
+  const props = mapStateToSlidesProps(getState(), dispatch, {
+    translate,
+    onQuitClick: identity,
+    skin: {common: {primary: '#248e59'}}
+  });
   t.is(props.quitPopin, undefined);
   await props.header.onQuitClick();
   const updatedProps = mapStateToSlidesProps(getState(), dispatch, {
     translate,
-    onQuitClick: identity
+    onQuitClick: identity,
+    skin: {common: {primary: '#248e59'}}
   });
   t.not(updatedProps.quitPopin, undefined);
   t.pass();

--- a/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
@@ -9,6 +9,7 @@ import {
 import {StoreState} from '../../../reducers';
 import {OPEN_POPIN} from '../../../actions/ui/quit-popin';
 import {mapStateToSlidesProps} from '..';
+import {skin} from './fixtures/skin';
 
 const state: StoreState = {
   data: {
@@ -46,14 +47,14 @@ test('should dispatch OPEN_POPIN action after a click on close button in header'
   const props = mapStateToSlidesProps(getState(), dispatch, {
     translate,
     onQuitClick: identity,
-    skin: {common: {primary: '#248e59'}}
+    skin
   });
   t.is(props.quitPopin, undefined);
   await props.header.onQuitClick();
   const updatedProps = mapStateToSlidesProps(getState(), dispatch, {
     translate,
     onQuitClick: identity,
-    skin: {common: {primary: '#248e59'}}
+    skin
   });
   t.not(updatedProps.quitPopin, undefined);
   t.pass();

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -23,7 +23,7 @@ import {templateSlide} from './fixtures/template';
 import {qcmSlide} from './fixtures/qcm';
 import {sliderSlide} from './fixtures/slider';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 
 test('should create initial props when fetched slide is not still received', t => {
   // SCENARIO : @@progression/POST_SUCCESS ok and @@slides/FETCH_REQUEST, (the slide is being fetched)

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -22,8 +22,9 @@ import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 import {templateSlide} from './fixtures/template';
 import {qcmSlide} from './fixtures/qcm';
 import {sliderSlide} from './fixtures/slider';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 
 test('should create initial props when fetched slide is not still received', t => {
   // SCENARIO : @@progression/POST_SUCCESS ok and @@slides/FETCH_REQUEST, (the slide is being fetched)

--- a/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
@@ -13,7 +13,7 @@ import {mapStateToSlidesProps} from '..';
 import {freeTextSlide} from './fixtures/free-text';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 
 const state: StoreState = {
   data: {
@@ -69,7 +69,8 @@ test('should dispatch onQuitClick function via the property handleOnclick of fir
   const {dispatch, getState} = createTestStore(t, state, {services}, expectedAction);
   const props = mapStateToSlidesProps(getState(), dispatch, {
     translate,
-    onQuitClick: () => t.pass()
+    onQuitClick: () => t.pass(),
+    skin: {common: {primary: '#248e59'}}
   });
   const quitPopin = props.quitPopin as CMPopinProps;
   await quitPopin.firstButton.handleOnclick();

--- a/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
@@ -12,8 +12,9 @@ import {StoreState} from '../../../reducers';
 import {mapStateToSlidesProps} from '..';
 import {freeTextSlide} from './fixtures/free-text';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 
 const state: StoreState = {
   data: {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
@@ -71,7 +71,7 @@ test('should dispatch onQuitClick function via the property handleOnclick of fir
   const props = mapStateToSlidesProps(getState(), dispatch, {
     translate,
     onQuitClick: () => t.pass(),
-    skin: {common: {primary: '#248e59'}}
+    skin
   });
   const quitPopin = props.quitPopin as CMPopinProps;
   await quitPopin.firstButton.handleOnclick();

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -22,7 +22,7 @@ import {EDIT_BASIC} from '../../../actions/ui/answers';
 import {freeTextSlide} from './fixtures/free-text';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -21,8 +21,9 @@ import {StoreState} from '../../../reducers';
 import {EDIT_BASIC} from '../../../actions/ui/answers';
 import {freeTextSlide} from './fixtures/free-text';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
@@ -18,8 +18,9 @@ import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 import {templateSlide} from './fixtures/template';
 import {qcmSlide} from './fixtures/qcm';
 import {sliderSlide} from './fixtures/slider';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 
 test('correction popin actions after click', async t => {
   const state: StoreState = {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
@@ -19,7 +19,7 @@ import {templateSlide} from './fixtures/template';
 import {qcmSlide} from './fixtures/qcm';
 import {sliderSlide} from './fixtures/slider';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 
 test('correction popin actions after click', async t => {
   const state: StoreState = {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -11,7 +11,7 @@ import {EDIT_QCM_DRAG} from '../../../actions/ui/answers';
 import {QcmDrag} from '../../../types/slides';
 import {qcmDragSlide} from './fixtures/qcm-drag';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: '_skill-ref'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -10,8 +10,9 @@ import {StoreState} from '../../../reducers';
 import {EDIT_QCM_DRAG} from '../../../actions/ui/answers';
 import {QcmDrag} from '../../../types/slides';
 import {qcmDragSlide} from './fixtures/qcm-drag';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: '_skill-ref'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -10,8 +10,9 @@ import {StoreState} from '../../../reducers';
 import {EDIT_QCM_GRAPHIC} from '../../../actions/ui/answers';
 import {QcmGraphic} from '../../../types/slides';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -11,7 +11,7 @@ import {EDIT_QCM_GRAPHIC} from '../../../actions/ui/answers';
 import {QcmGraphic} from '../../../types/slides';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -11,7 +11,7 @@ import {EDIT_QCM} from '../../../actions/ui/answers';
 import {Qcm} from '../../../types/slides';
 import {qcmSlide} from './fixtures/qcm';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -10,8 +10,9 @@ import {StoreState} from '../../../reducers';
 import {EDIT_QCM} from '../../../actions/ui/answers';
 import {Qcm} from '../../../types/slides';
 import {qcmSlide} from './fixtures/qcm';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -11,7 +11,7 @@ import {EDIT_SLIDER} from '../../../actions/ui/answers';
 import {QuestionRange} from '../../../types/slides';
 import {sliderSlide} from './fixtures/slider';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -10,8 +10,9 @@ import {StoreState} from '../../../reducers';
 import {EDIT_SLIDER} from '../../../actions/ui/answers';
 import {QuestionRange} from '../../../types/slides';
 import {sliderSlide} from './fixtures/slider';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -10,8 +10,9 @@ import {createTestStore} from '../../../actions/test/create-test-store';
 import {EDIT_SLIDER} from '../../../actions/ui/answers';
 import {QuestionRange} from '../../../types/slides';
 import {sliderSlide} from './fixtures/slider';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -11,7 +11,7 @@ import {EDIT_SLIDER} from '../../../actions/ui/answers';
 import {QuestionRange} from '../../../types/slides';
 import {sliderSlide} from './fixtures/slider';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -12,7 +12,7 @@ import {EDIT_TEMPLATE} from '../../../actions/ui/answers';
 import {Template, TextTemplate} from '../../../types/slides';
 import {templateSlide} from './fixtures/template';
 
-const connectedOptions = {translate, onQuitClick: identity};
+const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -11,8 +11,9 @@ import {StoreState} from '../../../reducers';
 import {EDIT_TEMPLATE} from '../../../actions/ui/answers';
 import {Template, TextTemplate} from '../../../types/slides';
 import {templateSlide} from './fixtures/template';
+import {skin} from './fixtures/skin';
 
-const connectedOptions = {translate, onQuitClick: identity, skin: {common: {primary: '#248e59'}}};
+const connectedOptions = {translate, onQuitClick: identity, skin};
 const progression: ProgressionFromAPI = {
   _id: '123456789123',
   content: {type: 'skill', ref: 'skill_NyxtYFYir'},

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/index.js
@@ -169,6 +169,7 @@ const CMPopin = props => {
                 data-name={`cm-popin-cta-${secondButton.type}`}
                 aria-label={secondButton['aria-label']}
                 type={secondButton.type}
+                customStyle={secondButton.customStyle}
               />
             </div>
           ) : null}

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/on-review-quit.ts
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/on-review-quit.ts
@@ -23,6 +23,9 @@ const fixture: Fixture = {
     secondButton: {
       label: `Continuer d'apprendre`,
       type: 'primary',
+      customStyle: {
+        backgroundColor: '#0061FF'
+      },
       'aria-label': 'Continue review',
       handleOnclick: noop
     }

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/on-review-quit.ts
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/on-review-quit.ts
@@ -24,6 +24,9 @@ const fixture: Fixture = {
       label: `Continuer d'apprendre`,
       type: 'primary',
       'aria-label': 'Continue review',
+      customStyle: {
+        backgroundColor: '#248e59'
+      },
       handleOnclick: noop
     }
   }

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/on-review-quit.ts
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/on-review-quit.ts
@@ -24,9 +24,6 @@ const fixture: Fixture = {
       label: `Continuer d'apprendre`,
       type: 'primary',
       'aria-label': 'Continue review',
-      customStyle: {
-        backgroundColor: '#248e59'
-      },
       handleOnclick: noop
     }
   }

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/types.ts
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/types.ts
@@ -44,7 +44,8 @@ type QuitPopinButton = {
   label: string;
   type: string;
   customStyle?: {
-    color: string;
+    backgroundColor?: string;
+    color?: string;
   };
   handleOnclick: () => void;
 };


### PR DESCRIPTION
Trello card : [[OR] Popin "Quit session" CTA Primary color](https://trello.com/c/fvlw8l35/2815-or-popin-quit-session-cta-primary-color)

**Detailed purpose of the PR**
Set the color of primary quit popin button "continue learning" to the primary skin color of the platform.

**Result and observation**

### Before

### After
<img width="1677" alt="Capture d’écran 2022-11-16 à 11 46 55" src="https://user-images.githubusercontent.com/113359769/202160560-352a7ec1-d4b6-4fe8-bccd-1336d4555314.png">


**Testing Strategy**
- [x] Already covered by tests
- [x] Manual testing
- [x] Unit testing
