### PR TITLE
[app-review] remove correctionPopin while fetching next slide

### DIFF
--- a/packages/@coorpacademy-app-review/src/reducers/ui/slide.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/ui/slide.ts
@@ -78,7 +78,8 @@ const reducer = (
       if (nextSlideRef === 'successExitNode') return state;
       return pipe(
         set([currentSlideRef, 'animateCorrectionPopin'], false),
-        set([currentSlideRef, 'animationType'], action.payload.animationType)
+        set([currentSlideRef, 'animationType'], action.payload.animationType),
+        set([currentSlideRef, 'showCorrectionPopin'], false)
       )(state);
     }
     case POST_PROGRESSION_REQUEST: {

--- a/packages/@coorpacademy-app-review/src/reducers/ui/test/slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/ui/test/slide.test.ts
@@ -78,7 +78,7 @@ test('should set animateCorrectionPopin to false and animationType to unstack or
     '1234': {
       validateButton: false,
       animateCorrectionPopin: false,
-      showCorrectionPopin: true,
+      showCorrectionPopin: false,
       animationType: 'unstack'
     }
   });


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

This PR fix the fact of being stuck if making mistake on the last slide on the pile
https://trello.com/c/sJM2YxLj/2831-or-lorsquil-reste-une-slide-et-on-r%C3%A9pond-mal-elle-se-restock-avec-la-popin-de-correction-affich%C3%A9e-et-on-ne-peut-pas-s%C3%A9lectionner

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->
Before:
![Kapture 2022-11-16 at 17 26 06](https://user-images.githubusercontent.com/22681512/202237140-5ffa0f06-4222-4f22-8a79-c57f2b8bcb3b.gif)
After:
![Kapture 2022-11-16 at 17 28 14](https://user-images.githubusercontent.com/22681512/202237455-6f5fa64e-3d4a-415f-ae15-4f9f57d08720.gif)
