### PR TITLE
[Progression Engine] fix wrong behavior when answering last slide badly

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/compute-next-step.js
@@ -403,8 +403,8 @@ export const computeNextStepForReview = (
   const action = extendPartialAction(partialAction, _state);
   const isCorrect = !!action && action.type === 'answer' && !!action.payload.isCorrect;
   const state = !_state || !action ? _state : updateState(config, _state, [action]);
-
   const correctAnswers = state ? filter(a => a.isCorrect, state.allAnswers) : [];
+
   if (correctAnswers.length === config.slidesToComplete) {
     return {
       nextContent: {
@@ -431,8 +431,20 @@ export const computeNextStepForReview = (
         state.pendingSlides
       );
 
-      // all other questions have been already right answered, so we close the progression
+      // all other questions have been already right answered BUT you fail the last question
+      if (!pendingSlide && !isCorrect) {
+        return {
+          nextContent: {
+            type: 'slide',
+            ref: state.nextContent.ref
+          },
+          instructions: null,
+          isCorrect
+        };
+      }
+
       if (!pendingSlide) {
+        // all other questions have been already right answered, so we close the progression
         return null;
       }
 

--- a/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.js
+++ b/packages/@coorpacademy-progression-engine/src/compute-next-step/test/compute-next-step.js
@@ -328,6 +328,86 @@ test('computeNextStepForReview --> should return the next slide', t => {
   });
 });
 
+test('computeNextStepForReview --> should return the same slide if you fail the last question', t => {
+  const state: State = Object.freeze({
+    livesDisabled: true,
+    isCorrect: true,
+    slides: ['1.A1.1', '1.A1.2', '1.A1.3', '1.A1.4'],
+    lives: 0,
+    step: {
+      current: 5
+    },
+    stars: 32,
+    requestedClues: [],
+    viewedResources: [],
+    remainingLifeRequests: 0,
+    hasViewedAResourceAtThisStep: false,
+    content: {
+      ref: '1.A1.4',
+      type: 'slide'
+    },
+    nextContent: {
+      ref: '1.A1.5',
+      type: 'slide'
+    },
+    allAnswers: [
+      {
+        slideRef: '1.A1.1',
+        isCorrect: true,
+        answer: ['d']
+      },
+      {
+        slideRef: '1.A1.2',
+        isCorrect: true,
+        answer: ['d']
+      },
+      {
+        slideRef: '1.A1.3',
+        isCorrect: true,
+        answer: ['d']
+      },
+      {
+        slideRef: '1.A1.4',
+        isCorrect: true,
+        answer: ['d']
+      }
+    ],
+    pendingSlides: [],
+    variables: {}
+  });
+  const _config: Config = getConfig({ref: 'review', version: '1'});
+
+  const _availableContent: AvailableContent = [
+    {
+      ref: 'skill_ref',
+      slides: [],
+      rules: null
+    }
+  ];
+
+  const result = computeNextStepForReview(_config, state, _availableContent, {
+    type: 'answer',
+    payload: {
+      answer: ['answer'],
+      content: {
+        ref: '1.A1.5',
+        type: 'slide'
+      },
+      godMode: false,
+      isCorrect: false
+    }
+  });
+
+  t.deepEqual(result, {
+    nextContent: {
+      type: 'slide',
+      ref: '1.A1.5'
+    },
+    instructions: null,
+    isCorrect: false
+  });
+});
+
 test('computeNextStepForReview --> should avoid to return the already answered slide if there are lag on review lambda and available content are not updated', t => {
   const state: State = Object.freeze({
     livesDisabled: true,


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

https://trello.com/c/RnqM7Pxa/2847-when-making-a-mistake-on-the-last-slide-you-go-to-congrats-page-anyway

This PR fix the fact that you arrive on congratulation page even if you make a mistake while replying  to the last slide

Before:
![Kapture 2022-11-18 at 14 44 52](https://user-images.githubusercontent.com/22681512/202719033-f01bc80f-d111-4c7d-8100-5497a1e3d17c.gif)

After:
![Kapture 2022-11-18 at 14 39 42](https://user-images.githubusercontent.com/22681512/202718563-c6b967bc-19eb-46b0-b39f-aa9dfb801c14.gif)

<!--What existing problem does the PR solve?/
What is the current behavior? -->