### PR TITLE
[review] fixing css for answerContainer on ReviewSlide for mobile breakpoint

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-slide/style.css
+++ b/packages/@coorpacademy-components/src/organism/review-slide/style.css
@@ -165,7 +165,7 @@ _:-ms-fullscreen, :root .correctionPopinWrapper {
 }
 
 @media mobile {
-  .questionOrigin, .question, .help, .answerContainer {
+  .questionOrigin, .question, .help {
     max-width: 90%;
   }
   
@@ -176,5 +176,11 @@ _:-ms-fullscreen, :root .correctionPopinWrapper {
     to {
       transform: translate3d(0, 0, 0);
     }
+  }
+
+  .answerContainer {
+    width: 100%;
+    max-width: unset;
+    justify-content: unset;
   }
 }


### PR DESCRIPTION
https://trello.com/c/4PdvrUpv/2841-or-bug-affichage-true-false-sur-device-mobile

**Detailed purpose of the PR**

Updates css to allow qcmGraphic slide to show its choices on mobile breakpoint

**Result and observation**

**Before**
<img width="581" alt="Capture d’écran 2022-11-18 à 16 27 07" src="https://user-images.githubusercontent.com/7602475/202740566-ffa4319d-943b-409c-8117-997e962feea4.png">


**After**
![mobile-qcmGraphic](https://user-images.githubusercontent.com/7602475/202739465-b610e079-e83e-46c9-93e8-e4c72a8605b6.gif)

**Testing Strategy**

- Already covered by tests
- Manual testing
