### PR TITLE
Replace broken Url media template slide

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/template.ts
+++ b/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/template.ts
@@ -25,12 +25,13 @@ const fixture: Fixture = {
     model: {
       type: 'template',
       template,
-      answers
+      answers,
+      title: 'coucou'
     },
     help: '',
     media: {
       type: 'img',
-      url: 'https://api-staging.coorpacademy.com/api-service/medias?h=400&w=400&q=90&url=http://europeantrips.org/wp-content/uploads/2012/03/Eiffel-Tower.jpg'
+      url: 'https://api-staging.coorpacademy.com/api-service/medias?h=400&w=400&q=90&url=https://static.coorpacademy.com/content/CoorpAcademy/content-global-exam/cockpit-global-exam/default/global-exam-profesional-exchanges-light-1589383172179.jpg'
     }
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/template.ts
+++ b/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/template.ts
@@ -25,7 +25,7 @@ const fixture: Fixture = {
     model: {
       type: 'template',
       template,
-      answers,
+      answers
     },
     help: '',
     media: {

--- a/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/template.ts
+++ b/packages/@coorpacademy-components/src/molecule/answer/test/fixtures/template.ts
@@ -26,7 +26,6 @@ const fixture: Fixture = {
       type: 'template',
       template,
       answers,
-      title: 'coucou'
     },
     help: '',
     media: {


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**


https://trello.com/c/vgAtLg9I/2860-fix-template-slide-broken-layout

This PR fix the broken layout on Storybook for the Template slide

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

Before:
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/22681512/203096670-b642eccf-309a-4523-b46d-6a3194e18f5e.png">

After:
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/22681512/203096209-66a68797-5852-4ff6-9e7a-43672f314a18.png">
