### PR TITLE
Update Input Search and Mooc header for desktop

### DIFF
--- a/packages/@coorpacademy-components/src/atom/input-search/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-search/style.css
@@ -1,6 +1,7 @@
 @value breakpoints: "../../variables/breakpoints.css";
 @value tablet from breakpoints;
 @value mobile from breakpoints;
+@value desktop from breakpoints;
 @value colors: "../../variables/colors.css";
 @value medium from colors;
 @value light from colors;
@@ -62,11 +63,6 @@
   background-color: white;
   background-image: none;
   color: medium;
-}
-
-.search::placeholder {
-  color: medium;
-  font-size: 14px;
 }
 
 .coorpmanager {
@@ -180,6 +176,12 @@
   line-height: 16px;
 }
 
+@media desktop {
+  .search::placeholder {
+    color: transparent;
+  }
+}
+
 @media tablet {
   .search,
   input {
@@ -188,6 +190,7 @@
 
   .search::placeholder {
     font-size: 12px;
+    color: medium;
   }
 }
 

--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -504,7 +504,7 @@
     margin: 0;
 
     /* hack for ie <= 11, limit for 1/3 of desktop breakpoint (1024px) */
-    max-width: 341px;
+    max-width: 150px;
   }
 }
 

--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -483,6 +483,10 @@
 }
 
 @media desktop {
+  .item {
+    padding: 0 11px;
+  }
+
   .logoWrapper {
     height: 100%;
     background-color: white;

--- a/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
@@ -5,8 +5,9 @@ const research = SearchBar.props;
 export default {
   props: {
     logo: {
-      src: 'https://static.coorpacademy.com/content/up/raw/logo_coorp-1491561426926.svg',
-      srcMobile: 'https://static.coorpacademy.com/content/up/raw/logo-generique-teams-mobile.png',
+      src: 'https://api.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/onboarding/raw/coorp_logo-1522333286516.svg&h=80&w=600&q=90&m=contain',
+      srcMobile:
+        'https://api.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/onboarding/raw/coorp_logo_infinite-1553079705037.png&h=80&w=600&q=90&m=contain',
       href: '#',
       'aria-label': 'brand logo up.coorpacademy.com',
       'button-aria-label': 'brand logo used to open menu'
@@ -44,12 +45,22 @@ export default {
     pages: {
       displayed: [
         {
-          title: 'Explore',
+          title: 'Catalogue',
           href: '#',
           selected: true
         },
         {
           title: 'Battles',
+          href: '#',
+          selected: false
+        },
+        {
+          title: 'Certifications',
+          href: '#',
+          selected: false
+        },
+        {
+          title: 'Review',
           href: '#',
           selected: false
         }


### PR DESCRIPTION
https://trello.com/c/G6LMbLJt/2846-or-header-nouveau-break-point-nouvel-onglet-revision

**Detailed purpose of the PR**

This PR aims to update the logo, the input search and the items shown on the mooc header, for the desktop media query. If the screen is between 960 and 1280px, it should

- Set logo max-width to 150px
- Set padding between menu items to 24
- Hide the placeholder on the Input search

**Result and observation**

**Before**
![header-mooc](https://user-images.githubusercontent.com/7602475/203321501-a4c14778-7029-4cbf-bc9f-a0ff3976bae0.gif)


**After**
![header-input-search-modif](https://user-images.githubusercontent.com/7602475/203320099-9ffbf730-c952-4fe4-a185-fc75cab2a210.gif)


**Testing Strategy**

- Already covered by tests
- Manual testing