### PR TITLE
Fix slide writable on post answer

### DIFF
--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-correction.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-correction.test.ts
@@ -43,7 +43,8 @@ const initialState: StoreState = {
       [freeTextSlide.universalRef]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slides-to-review-by-skill-ref.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slides-to-review-by-skill-ref.test.ts
@@ -54,22 +54,26 @@ const state: StoreState = {
       [freeTextSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       },
       [qcmGraphicSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       },
       [qcmSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       },
       [sliderSlide._id]: {
         validateButton: true,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,

--- a/packages/@coorpacademy-app-review/src/actions/api/test/post-answer.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/post-answer.test.ts
@@ -89,7 +89,8 @@ const initialState: StoreState = {
       [freeTextSlide._id]: {
         validateButton: true,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,
@@ -285,27 +286,32 @@ test('should dispatch post-answer, fetch-correction, fetch-end-rank and fetch-sl
         [freeTextSlide._id]: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: true
         },
         [qcmGraphicSlide._id]: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         },
         [qcmSlide._id]: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         },
         [sliderSlide._id]: {
           validateButton: true,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         },
         [templateSlide._id]: {
           validateButton: true,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,

--- a/packages/@coorpacademy-app-review/src/actions/api/test/post-answer.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/post-answer.test.ts
@@ -183,7 +183,8 @@ test('should dispatch post-answer, fetch-slide and fetch-correction and fetch-st
   t.deepEqual(state.ui.slide[freeTextSlide._id], {
     validateButton: false,
     animateCorrectionPopin: true,
-    showCorrectionPopin: true
+    showCorrectionPopin: true,
+    pendingAnswerRequest: true
   });
 });
 
@@ -355,7 +356,8 @@ test('should dispatch post-answer, fetch-correction, fetch-end-rank and fetch-sl
   t.deepEqual(state.ui.slide[templateSlide._id], {
     validateButton: false,
     animateCorrectionPopin: true,
-    showCorrectionPopin: true
+    showCorrectionPopin: true,
+    pendingAnswerRequest: true
   });
 });
 

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/next-slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/next-slide.test.ts
@@ -41,7 +41,8 @@ const state: StoreState = {
       [freeTextSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: true,
-        showCorrectionPopin: true
+        showCorrectionPopin: true,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,

--- a/packages/@coorpacademy-app-review/src/reducers/ui/slide.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/ui/slide.ts
@@ -49,7 +49,8 @@ const reducer = (
         set([action.meta.slideRef], {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         })
       )(state);
     }

--- a/packages/@coorpacademy-app-review/src/reducers/ui/slide.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/ui/slide.ts
@@ -24,6 +24,7 @@ export type UISlide = {
   animateCorrectionPopin: boolean;
   showCorrectionPopin: boolean;
   animationType?: SlideUIAnimations;
+  pendingAnswerRequest: boolean;
 };
 
 export type UISlideState = Record<string, UISlide>;
@@ -65,7 +66,10 @@ const reducer = (
       );
     }
     case POST_ANSWER_REQUEST: {
-      return set([action.meta.slideRef, 'validateButton'], false, state);
+      return pipe(
+        set([action.meta.slideRef, 'validateButton'], false),
+        set([action.meta.slideRef, 'pendingAnswerRequest'], true)
+      )(state);
     }
     case CORRECTION_FETCH_SUCCESS: {
       return pipe(

--- a/packages/@coorpacademy-app-review/src/reducers/ui/test/slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/ui/test/slide.test.ts
@@ -7,14 +7,21 @@ import {SLIDE_FETCH_REQUEST} from '../../../actions/api/fetch-slide';
 import {NEXT_SLIDE} from '../../../actions/ui/next-slide';
 import {POST_PROGRESSION_REQUEST} from '../../../actions/api/post-progression';
 
-test('should set validateButton, animateCorrectionPopin and showCorrectionPopin to false if SLIDE_FETCH_REQUEST is received', t => {
+// UPDATE TESTS HERE AND MAYBE ADD ONE FOR PENDINGANSWERREQUEST
+// 'should set pendingAnswerRequest to true if POST_ANSWER_REQUEST is received'
+test('should set validateButton, animateCorrectionPopin, showCorrectionPopin and pendingAnswerRequest to false if SLIDE_FETCH_REQUEST is received', t => {
   const state = reducer(undefined, {
     type: SLIDE_FETCH_REQUEST,
     meta: {slideRef: '1234'}
   });
   t.truthy(state);
   t.deepEqual(state, {
-    '1234': {validateButton: false, animateCorrectionPopin: false, showCorrectionPopin: false}
+    '1234': {
+      validateButton: false,
+      animateCorrectionPopin: false,
+      showCorrectionPopin: false,
+      pendingAnswerRequest: false
+    }
   });
 });
 
@@ -40,7 +47,7 @@ test('should set validateButton to false if POST_ANSWER_REQUEST is received', t 
     meta: {slideRef: '1234'}
   });
   t.truthy(state);
-  t.deepEqual(state, {'1234': {validateButton: false}});
+  t.deepEqual(state, {'1234': {validateButton: false, pendingAnswerRequest: true}});
 });
 
 test('should set animateCorrectionPopin to true if CORRECTION_FETCH_SUCCESS is received', t => {
@@ -80,7 +87,8 @@ test('should set animateCorrectionPopin to false and animationType to unstack or
       validateButton: false,
       animateCorrectionPopin: false,
       showCorrectionPopin: false,
-      animationType: 'unstack'
+      animationType: 'unstack',
+      pendingAnswerRequest: false
     }
   });
 });

--- a/packages/@coorpacademy-app-review/src/reducers/ui/test/slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/ui/test/slide.test.ts
@@ -7,8 +7,6 @@ import {SLIDE_FETCH_REQUEST} from '../../../actions/api/fetch-slide';
 import {NEXT_SLIDE} from '../../../actions/ui/next-slide';
 import {POST_PROGRESSION_REQUEST} from '../../../actions/api/post-progression';
 
-// UPDATE TESTS HERE AND MAYBE ADD ONE FOR PENDINGANSWERREQUEST
-// 'should set pendingAnswerRequest to true if POST_ANSWER_REQUEST is received'
 test('should set validateButton, animateCorrectionPopin, showCorrectionPopin and pendingAnswerRequest to false if SLIDE_FETCH_REQUEST is received', t => {
   const state = reducer(undefined, {
     type: SLIDE_FETCH_REQUEST,
@@ -41,7 +39,7 @@ test('should set validateButton to true if answers are found when an EditAnswerA
   t.deepEqual(state, {'1234': {validateButton: true}});
 });
 
-test('should set validateButton to false if POST_ANSWER_REQUEST is received', t => {
+test('should set validateButton to false and pendingAnswerRequest to true if POST_ANSWER_REQUEST is received', t => {
   const state = reducer(undefined, {
     type: POST_ANSWER_REQUEST,
     meta: {slideRef: '1234'}

--- a/packages/@coorpacademy-app-review/src/reducers/ui/test/slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/ui/test/slide.test.ts
@@ -59,7 +59,8 @@ test('should set animateCorrectionPopin to false and animationType to unstack or
       '1234': {
         validateButton: false,
         animateCorrectionPopin: true,
-        showCorrectionPopin: true
+        showCorrectionPopin: true,
+        pendingAnswerRequest: false
       }
     },
     {
@@ -94,7 +95,8 @@ test('should return same state when nextContent is successExitNode', t => {
     '1234': {
       validateButton: false,
       animateCorrectionPopin: true,
-      showCorrectionPopin: true
+      showCorrectionPopin: true,
+      pendingAnswerRequest: false
     }
   };
   const state = reducer(_initialState, {
@@ -117,31 +119,36 @@ test('should set the initial value when POST_PROGRESSION_REQUEST action is recei
         validateButton: false,
         animateCorrectionPopin: false,
         showCorrectionPopin: false,
-        animationType: 'unstack'
+        animationType: 'unstack',
+        pendingAnswerRequest: false
       },
       sli_VkSQroQnx: {
         validateButton: false,
         animateCorrectionPopin: false,
         showCorrectionPopin: false,
-        animationType: 'unstack'
+        animationType: 'unstack',
+        pendingAnswerRequest: false
       },
       sli_N1XACJobn: {
         validateButton: false,
         animateCorrectionPopin: false,
         showCorrectionPopin: false,
-        animationType: 'unstack'
+        animationType: 'unstack',
+        pendingAnswerRequest: false
       },
       sli_VkAzsCLKb: {
         validateButton: false,
         animateCorrectionPopin: false,
         showCorrectionPopin: false,
-        animationType: 'unstack'
+        animationType: 'unstack',
+        pendingAnswerRequest: false
       },
       'sli_N13-hG3kX': {
         validateButton: false,
         animateCorrectionPopin: true,
         showCorrectionPopin: false,
-        animationType: 'unstack'
+        animationType: 'unstack',
+        pendingAnswerRequest: false
       }
     },
     {type: POST_PROGRESSION_REQUEST}

--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -142,12 +142,12 @@ const buildStackSlides = (
       const answers = getOr([], ['ui', 'answers', slideRef], state);
       const {questionText, answerUI} = mapApiSlideToUi(dispatch, translate)(slideFromAPI, answers);
       const {title: parentContentTitle, type: parentContentType} = slideFromAPI.parentContentTitle;
-
       const isCurrentSlideRef = currentSlideRef === slideRef;
       const slideUI = get(['ui', 'slide', slideRef], state);
       const animateCorrectionPopin = isCurrentSlideRef && slideUI.animateCorrectionPopin;
       const showCorrectionPopin = isCurrentSlideRef && slideUI.showCorrectionPopin;
       const animationType = lastAnsweredSlideRef ? slideUI.animationType : undefined;
+      const disabledContent = get(['ui', 'slide', slideRef, 'pendingAnswerRequest'], state);
 
       const updatedUiSlide = {
         ...uiSlide,
@@ -157,6 +157,7 @@ const buildStackSlides = (
         loading: false,
         questionText,
         answerUI,
+        disabledContent,
         parentContentTitle: translate('Content Parent Title', {
           contentTitle: parentContentTitle,
           contentType: parentContentType

--- a/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
@@ -68,31 +68,36 @@ const state: StoreState = {
         validateButton: false,
         animateCorrectionPopin: false,
         showCorrectionPopin: false,
-        animationType: 'unstack'
+        animationType: 'unstack',
+        pendingAnswerRequest: false
       },
       sli_VkSQroQnx: {
         validateButton: false,
         animateCorrectionPopin: false,
         showCorrectionPopin: false,
-        animationType: 'unstack'
+        animationType: 'unstack',
+        pendingAnswerRequest: false
       },
       sli_N1XACJobn: {
         validateButton: false,
         animateCorrectionPopin: false,
         showCorrectionPopin: false,
-        animationType: 'unstack'
+        animationType: 'unstack',
+        pendingAnswerRequest: false
       },
       sli_VkAzsCLKb: {
         validateButton: false,
         animateCorrectionPopin: false,
         showCorrectionPopin: false,
-        animationType: 'unstack'
+        animationType: 'unstack',
+        pendingAnswerRequest: false
       },
       'sli_N13-hG3kX': {
         validateButton: false,
         animateCorrectionPopin: true,
         showCorrectionPopin: false,
-        animationType: 'unstack'
+        animationType: 'unstack',
+        pendingAnswerRequest: false
       }
     }
   }

--- a/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
@@ -32,7 +32,8 @@ const state: StoreState = {
       sli_N1XACJobn: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -50,7 +50,8 @@ test('should create initial props when fetched slide is not still received', t =
         sli_N1XACJobn: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -146,7 +147,8 @@ test('should create props when first slide is on the state', t => {
         sli_VJYjJnJhg: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -198,6 +200,7 @@ test('should create props when first slide is on the state', t => {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:
@@ -258,7 +261,8 @@ test('should create props when slide is on the state and user has selected answe
         sli_VJYjJnJhg: {
           validateButton: true,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: true
         }
       },
       showQuitPopin: false,
@@ -310,6 +314,7 @@ test('should create props when slide is on the state and user has selected answe
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: true,
     position: 0,
     loading: false,
     parentContentTitle:
@@ -371,12 +376,14 @@ test('should verify props when first slide was answered correctly and next slide
         sli_VJYjJnJhg: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -428,6 +435,7 @@ test('should verify props when first slide was answered correctly and next slide
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:
@@ -493,12 +501,14 @@ test('should verify props when first slide was answered with error and next slid
         sli_VJYjJnJhg: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -571,12 +581,14 @@ test('should verify props when first slide was answered, next slide is fetched &
         sli_VJYjJnJhg: {
           validateButton: false,
           animateCorrectionPopin: true,
-          showCorrectionPopin: true
+          showCorrectionPopin: true,
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -639,6 +651,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     animationType: undefined,
     animateCorrectionPopin: true,
     showCorrectionPopin: true,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:
@@ -658,6 +671,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 1,
     loading: false,
     parentContentTitle:
@@ -708,12 +722,14 @@ test('should verify props when first slide was answered incorrectly, next slide 
         sli_VJYjJnJhg: {
           validateButton: false,
           animateCorrectionPopin: true,
-          showCorrectionPopin: true
+          showCorrectionPopin: true,
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -779,6 +795,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     animationType: undefined,
     animateCorrectionPopin: true,
     showCorrectionPopin: true,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:
@@ -798,6 +815,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 1,
     loading: false,
     parentContentTitle:
@@ -852,12 +870,14 @@ test('should verify props when currentSlideRef has changed to nextContent of pro
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: true,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -970,30 +990,35 @@ test('should verify props when progression is in success, showing last correctio
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_N1XACJobn: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_VkAzsCLKb: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         'sli_N13-hG3kX': {
           validateButton: false,
           animateCorrectionPopin: true,
-          showCorrectionPopin: true
+          showCorrectionPopin: true,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -1096,31 +1121,36 @@ test('should verify props showing congrats', t => {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_N1XACJobn: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_VkAzsCLKb: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         'sli_N13-hG3kX': {
           validateButton: false,
           animateCorrectionPopin: true,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         }
       }
     }
@@ -1239,31 +1269,36 @@ test('should verify props showing congrats, with only stars card, if user has no
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_N1XACJobn: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_VkAzsCLKb: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         'sli_N13-hG3kX': {
           validateButton: false,
           animateCorrectionPopin: true,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         }
       }
     }
@@ -1353,31 +1388,36 @@ test('should verify props when progression has answered a current pendingSlide',
         sli_VJYjJnJhg: {
           validateButton: false,
           animateCorrectionPopin: true,
-          showCorrectionPopin: true
+          showCorrectionPopin: true,
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_N1XACJobn: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'restack'
+          animationType: 'restack',
+          pendingAnswerRequest: false
         },
         sli_VkAzsCLKb: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         'sli_N13-hG3kX': {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -1463,30 +1503,35 @@ test('should verify props when progression still has a pendingSlide', t => {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_N1XACJobn: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         },
         sli_VkAzsCLKb: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         'sli_N13-hG3kX': {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -1554,7 +1599,8 @@ test('should verify that props quitPopin is not undefined when popin is displaye
         sli_N1XACJobn: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: true,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
@@ -39,12 +39,14 @@ const state: StoreState = {
       sli_VJYjJnJhg: {
         validateButton: false,
         animateCorrectionPopin: true,
-        showCorrectionPopin: true
+        showCorrectionPopin: true,
+        pendingAnswerRequest: false
       },
       sli_VkSQroQnx: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: true,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -68,7 +68,8 @@ const initialState: StoreState = {
       [freeTextSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,
@@ -108,6 +109,7 @@ test('should dispatch EDIT_BASIC action via the property onChange of a Free Text
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
@@ -48,12 +48,14 @@ test('correction popin actions after click', async t => {
         sli_VJYjJnJhg: {
           validateButton: false,
           animateCorrectionPopin: true,
-          showCorrectionPopin: true
+          showCorrectionPopin: true,
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
-          showCorrectionPopin: false
+          showCorrectionPopin: false,
+          pendingAnswerRequest: false
         }
       },
       showQuitPopin: false,
@@ -126,30 +128,35 @@ test('correction popin actions after click when progression is finished', async 
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_VkSQroQnx: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_N1XACJobn: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         sli_VkAzsCLKb: {
           validateButton: false,
           animateCorrectionPopin: false,
           showCorrectionPopin: false,
-          animationType: 'unstack'
+          animationType: 'unstack',
+          pendingAnswerRequest: false
         },
         'sli_N13-hG3kX': {
           validateButton: false,
           animateCorrectionPopin: true,
-          showCorrectionPopin: true
+          showCorrectionPopin: true,
+          pendingAnswerRequest: false
         }
       }
     }

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -57,7 +57,8 @@ const initialState: StoreState = {
       [qcmDragSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,
@@ -82,6 +83,7 @@ test('should dispatch EDIT_QCM_DRAG action via the property onClick of a QCM Dra
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -57,7 +57,8 @@ const initialState: StoreState = {
       [qcmGraphicSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,
@@ -82,6 +83,7 @@ test('should dispatch EDIT_QCM_GRAPHIC action via the property onClick of a QCM 
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -57,7 +57,8 @@ const initialState: StoreState = {
       [qcmSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,
@@ -84,6 +85,7 @@ test('should dispatch EDIT_QCM action via the property onClick of a QCM slide', 
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -57,7 +57,8 @@ const initialState: StoreState = {
       [sliderSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,
@@ -81,6 +82,7 @@ test('should dispatch EDIT_SLIDER action via the property onChange of a Slider s
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
+    disabledContent: false,
     showCorrectionPopin: false,
     position: 0,
     loading: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -57,7 +57,8 @@ const initialState: StoreState = {
       [sliderSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,
@@ -83,6 +84,7 @@ test('should dispatch EDIT_SLIDER action via the property onSliderChange of a Sl
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -58,7 +58,8 @@ const initialState: StoreState = {
       [templateSlide._id]: {
         validateButton: false,
         animateCorrectionPopin: false,
-        showCorrectionPopin: false
+        showCorrectionPopin: false,
+        pendingAnswerRequest: false
       }
     },
     showQuitPopin: false,
@@ -80,6 +81,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:
@@ -112,6 +114,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
+    disabledContent: false,
     position: 0,
     loading: false,
     parentContentTitle:

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.js
@@ -132,6 +132,7 @@ const ReviewSlide = props => {
     loadingAriaLabel,
     parentContentTitle,
     questionText,
+    disabledContent,
     answerUI,
     showCorrectionPopin,
     animateCorrectionPopin
@@ -147,7 +148,7 @@ const ReviewSlide = props => {
             questionOrigin={parentContentTitle}
             questionText={questionText}
             answerUI={answerUI}
-            disableContent={showCorrectionPopin}
+            disableContent={disabledContent}
             key="question-container"
           />,
           <ValidateButton

--- a/packages/@coorpacademy-components/src/organism/review-slide/prop-types.ts
+++ b/packages/@coorpacademy-components/src/organism/review-slide/prop-types.ts
@@ -12,6 +12,7 @@ export const SlidePropsTypes = PropTypes.shape({
   isCorrect: PropTypes.bool,
   animateCorrectionPopin: PropTypes.bool,
   showCorrectionPopin: PropTypes.bool,
+  disableContent: PropTypes.bool,
   parentContentTitle: PropTypes.string,
   questionText: PropTypes.string,
   answerUI: PropTypes.shape(AnswerPropTypes)


### PR DESCRIPTION
Fix this trello card : [[OR] Bug modification réponse avant validation](https://trello.com/c/Rlp52e1L/2840-or-bug-modification-r%C3%A9ponse-avant-validation)

**Detailed purpose of the PR**
When the answer is sent and correctionPopin is not yet displayed, the answer can be edited.

**Result and observation**
### Before
![Kapture 2022-11-22 at 17 49 53](https://user-images.githubusercontent.com/113359769/203373484-d7fe52e3-d929-47ad-a2b9-d3e056e849e1.gif)

### After
![Kapture 2022-11-22 at 17 53 31](https://user-images.githubusercontent.com/113359769/203374289-0acd121f-dee9-45f7-95d3-95342b6262f5.gif)




**Testing Strategy**
- Already covered by tests
- Unit testing
