### PR TITLE
[mobile] add Popin component

### DIFF
--- a/packages/@coorpacademy-components/src/atom/text/index.native.tsx
+++ b/packages/@coorpacademy-components/src/atom/text/index.native.tsx
@@ -8,6 +8,7 @@ export type Props = {
   testID?: string;
   numberOfLines?: number;
   allowFontScaling?: boolean;
+  accessibilityLabel?: string;
 };
 
 export const DEFAULT_STYLE = {
@@ -25,7 +26,14 @@ const styles = StyleSheet.create({
 });
 
 const Text = (props: Props) => {
-  const {children, style, testID, numberOfLines, allowFontScaling = true} = props;
+  const {
+    children,
+    style,
+    testID,
+    numberOfLines,
+    allowFontScaling = true,
+    accessibilityLabel
+  } = props;
 
   return (
     <TextBase
@@ -33,6 +41,7 @@ const Text = (props: Props) => {
       style={[styles.text, style]}
       testID={testID}
       numberOfLines={numberOfLines}
+      accessibilityLabel={accessibilityLabel}
     >
       {children}
     </TextBase>

--- a/packages/@coorpacademy-components/src/atom/text/test/fixtures/default.tsx
+++ b/packages/@coorpacademy-components/src/atom/text/test/fixtures/default.tsx
@@ -7,7 +7,8 @@ type Fixture = {props: Props};
 const fixture: Fixture = {
   props: {
     testID: 'basic-text',
-    children: <Text>Basic text</Text>
+    children: <Text>Basic text</Text>,
+    accessibilityLabel: 'basic-text'
   }
 };
 

--- a/packages/@coorpacademy-components/src/hoc/touchable/index.native.tsx
+++ b/packages/@coorpacademy-components/src/hoc/touchable/index.native.tsx
@@ -41,7 +41,7 @@ export type Props = {
   isWithoutFeedback?: boolean;
   // for TouchableOpacity
   activeOpacity?: number;
-  style?: ViewStyle;
+  style?: ViewStyle | (ViewStyle | null)[];
   // Analytics
   analytics?: Analytics;
   analyticsID?: string;

--- a/packages/@coorpacademy-components/src/hoc/touchable/index.native.tsx
+++ b/packages/@coorpacademy-components/src/hoc/touchable/index.native.tsx
@@ -21,6 +21,7 @@ const hitSlop = {
 };
 
 export type Props = {
+  accessibilityLabel?: string;
   accessible?: boolean;
   children?: React.ReactNode;
   delayLongPress?: number;

--- a/packages/@coorpacademy-components/src/hoc/touchable/index.native.tsx
+++ b/packages/@coorpacademy-components/src/hoc/touchable/index.native.tsx
@@ -41,7 +41,7 @@ export type Props = {
   isWithoutFeedback?: boolean;
   // for TouchableOpacity
   activeOpacity?: number;
-  style?: ViewStyle | (ViewStyle | null)[];
+  style?: ViewStyle;
   // Analytics
   analytics?: Analytics;
   analyticsID?: string;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -10,7 +10,7 @@ import {Theme} from '../../variables/theme.native';
 import Text from '../../atom/text/index.native';
 import Touchable from '../../hoc/touchable/index.native';
 import {useTemplateContext} from '../../template/app-review/template-context';
-import {ReviewCorrectionPopinProps} from './prop-types';
+import {ReviewCorrectionPopinKLFProps, ReviewCorrectionPopinProps} from './prop-types';
 
 interface StyleSheetType {
   wrapper: ViewStyle;
@@ -186,7 +186,7 @@ const KlfButton = ({
   klf,
   styleSheet
 }: {
-  klf: NonNullable<ReviewCorrectionPopinProps['klf']>;
+  klf: ReviewCorrectionPopinKLFProps;
   styleSheet: StyleSheetType;
 }) => {
   const [displayTooltip, setDisplayTooltip] = useState(false);
@@ -248,7 +248,7 @@ const KlfButton = ({
         <View style={triangleTooltip} />
       </Animated.View>
       <Touchable
-        style={[buttonKlf, displayTooltip ? buttonKlfActive : null]}
+        style={displayTooltip ? {...buttonKlf, ...buttonKlfActive} : buttonKlf}
         accessibilityLabel={`aria-label-${label}`}
         onPress={handlePressKey}
         testID="button-klf"

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -30,7 +30,6 @@ interface StyleSheetType {
   iconKey: ViewStyle;
   containerTooltip: ViewStyle;
   buttonTooltip: ViewStyle;
-  textTooltip: TextStyle;
   containerButtonKlf: ViewStyle;
   triangleTooltip: ViewStyle;
 }
@@ -162,13 +161,6 @@ const createStyleSheet = (theme: Theme, type: string): StyleSheetType =>
       right: -15,
       zIndex: 20
     },
-    textTooltip: {
-      color: theme.colors.text.primary,
-      fontSize: 16,
-      fontWeight: '600',
-      lineHeight: 22,
-      textAlign: 'center'
-    },
     triangleTooltip: {
       width: 0,
       height: 0,
@@ -232,11 +224,14 @@ const KlfButton = ({
     containerTooltip,
     buttonTooltip,
     iconKey,
-    textTooltip,
     triangleTooltip
   } = styleSheet;
 
   const {label, tooltip} = klf;
+
+  const tooltipMessage = {
+    html: `<p style='color:#06265B; font-size:16; font-weight:600; line-height:22; text-align:center;'>${tooltip}</p>`
+  };
 
   return (
     <View style={containerButtonKlf}>
@@ -248,7 +243,7 @@ const KlfButton = ({
           onPress={handlePressKey}
           testID="button-tooltip"
         >
-          <Text style={textTooltip}>{tooltip}</Text>
+          <RenderHTML source={tooltipMessage} />
         </Touchable>
         <View style={triangleTooltip} />
       </Animated.View>
@@ -282,8 +277,8 @@ const ReviewCorrectionPopin = ({
   const [styleSheet, setStylesheet] = useState<StyleSheetType | null>(null);
   const {theme} = templateContext;
   const handlePressNext = next.onClick;
-  const source = {
-    html: `<p aria-label='${information.message}' style='color:white; font-size:16; font-weight:600; line-height:19;'>${information.message}</p>`
+  const infoMessage = {
+    html: `<p style='color:white; font-size:16; font-weight:600; line-height:19;'>${information.message}</p>`
   };
   const ICONS = {
     right: RightIcon,
@@ -318,7 +313,7 @@ const ReviewCorrectionPopin = ({
               {information.label}
             </Text>
           </View>
-          <RenderHTML source={source} systemFonts={['Gilroy']} />
+          <RenderHTML source={infoMessage} />
         </View>
         {isWrongType(klf, type) ? <KlfButton styleSheet={styleSheet} klf={klf} /> : null}
         <Touchable

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -1,11 +1,11 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {Animated, Easing, TextStyle, StyleSheet, View, ViewStyle} from 'react-native';
-import RenderHTML from 'react-native-render-html';
 import {
   NovaCompositionCoorpacademyCheck as RightIcon,
   NovaSolidStatusClose as WrongIcon,
   NovaLineLoginKey1 as KlfIcon
 } from '@coorpacademy/nova-icons';
+import Html from '../../atom/html/index.native';
 import {Theme} from '../../variables/theme.native';
 import Text from '../../atom/text/index.native';
 import Touchable from '../../hoc/touchable/index.native';
@@ -22,6 +22,7 @@ interface StyleSheetType {
   feedbackSection: ViewStyle;
   labelContainer: ViewStyle;
   label: TextStyle;
+  htmlInfoMessage: TextStyle;
   button: ViewStyle;
   buttonText: TextStyle;
   buttonKlf: ViewStyle;
@@ -32,6 +33,7 @@ interface StyleSheetType {
   buttonTooltip: ViewStyle;
   containerButtonKlf: ViewStyle;
   triangleTooltip: ViewStyle;
+  htmlTooltipText: TextStyle;
 }
 
 const createStyleSheet = (theme: Theme, type: string): StyleSheetType =>
@@ -89,7 +91,8 @@ const createStyleSheet = (theme: Theme, type: string): StyleSheetType =>
       backgroundColor: 'rgba(255, 255, 255, 0.3)',
       borderRadius: 56,
       paddingHorizontal: theme.spacing.tiny,
-      paddingVertical: theme.spacing.micro
+      paddingVertical: theme.spacing.micro,
+      marginBottom: 8
     },
     label: {
       color: theme.colors.white,
@@ -97,6 +100,12 @@ const createStyleSheet = (theme: Theme, type: string): StyleSheetType =>
       fontWeight: theme.fontWeight.extraBold,
       lineHeight: 17,
       wordBreak: 'break-word'
+    },
+    htmlInfoMessage: {
+      color: theme.colors.white,
+      fontSize: 16,
+      fontWeight: '600',
+      lineHeight: 19
     },
     button: {
       alignSelf: 'stretch',
@@ -161,6 +170,13 @@ const createStyleSheet = (theme: Theme, type: string): StyleSheetType =>
       right: -15,
       zIndex: 20
     },
+    htmlTooltipText: {
+      color: theme.colors.text.primary,
+      fontSize: 16,
+      fontWeight: '600',
+      lineHeight: 22,
+      textAlign: 'center'
+    },
     triangleTooltip: {
       width: 0,
       height: 0,
@@ -223,15 +239,12 @@ const KlfButton = ({
     containerButtonKlf,
     containerTooltip,
     buttonTooltip,
+    htmlTooltipText,
     iconKey,
     triangleTooltip
   } = styleSheet;
 
   const {label, tooltip} = klf;
-
-  const tooltipMessage = {
-    html: `<p style='color:#06265B; font-size:16; font-weight:600; line-height:22; text-align:center;'>${tooltip}</p>`
-  };
 
   return (
     <View style={containerButtonKlf}>
@@ -243,7 +256,7 @@ const KlfButton = ({
           onPress={handlePressKey}
           testID="button-tooltip"
         >
-          <RenderHTML source={tooltipMessage} />
+          <Html style={htmlTooltipText}>{tooltip}</Html>
         </Touchable>
         <View style={triangleTooltip} />
       </Animated.View>
@@ -264,7 +277,7 @@ const KlfButton = ({
 const isWrongType = (
   klf: ReviewCorrectionPopinProps['klf'],
   type: ReviewCorrectionPopinProps['type']
-): klf is NonNullable<ReviewCorrectionPopinProps['klf']> => type === 'wrong';
+): klf is ReviewCorrectionPopinKLFProps => type === 'wrong';
 
 const ICONS = {
   right: RightIcon,
@@ -282,9 +295,6 @@ const ReviewCorrectionPopin = ({
   const [styleSheet, setStylesheet] = useState<StyleSheetType | null>(null);
   const {theme} = templateContext;
   const handlePressNext = next.onClick;
-  const infoMessage = {
-    html: `<p style='color:white; font-size:16; font-weight:600; line-height:19;'>${information.message}</p>`
-  };
 
   const Icon = ICONS[type];
 
@@ -315,7 +325,7 @@ const ReviewCorrectionPopin = ({
               {information.label}
             </Text>
           </View>
-          <RenderHTML source={infoMessage} />
+          <Html style={styleSheet.htmlInfoMessage}>{information.message}</Html>
         </View>
         {isWrongType(klf, type) ? <KlfButton styleSheet={styleSheet} klf={klf} /> : null}
         <Touchable

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -195,7 +195,7 @@ const KlfButton = ({
   styleSheet
 }: {
   klf: NonNullable<ReviewCorrectionPopinProps['klf']>;
-  styleSheet: StyleSheetType | null;
+  styleSheet: StyleSheetType;
 }) => {
   const [displayTooltip, setDisplayTooltip] = useState(false);
 
@@ -223,8 +223,6 @@ const KlfButton = ({
     setDisplayTooltip(!displayTooltip);
     !displayTooltip ? fadeIn() : fadeOut();
   }, [displayTooltip, fadeIn, fadeOut]);
-
-  if (!styleSheet) return null;
 
   const {
     buttonKlf,

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -1,104 +1,154 @@
-import React from 'react';
-import {Text, StyleSheet, View} from 'react-native';
+import React, {useEffect, useState} from 'react';
+import {TextStyle, StyleSheet, View, ViewStyle} from 'react-native';
 import RenderHTML from 'react-native-render-html';
 import {NovaCompositionCoorpacademyCheck as RightIcon} from '@coorpacademy/nova-icons';
 import {COLORS} from '../../variables/colors';
+import {Theme} from '../../variables/theme.native';
+import Text from '../../atom/text/index.native';
+import Touchable from '../../hoc/touchable/index.native';
+import {useTemplateContext} from '../../template/app-review/template-context';
+import {ReviewCorrectionPopinProps} from './prop-types';
 
-const styles = StyleSheet.create({
-  wrapper: {
-    height: 'auto',
-    fontFamily: 'Gilroy',
-    color: 'white',
-    display: 'flex'
-  },
-  popin: {
-    padding: 32,
-    borderRadius: 16,
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'flex-start'
-  },
-  right: {
-    backgroundColor: COLORS.positive,
-    shadowRadius: 28,
-    shadowColor: COLORS.positive,
-    shadowOpacity: 0.4
-  },
-  correctionSection: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    width: '80%'
-  },
-  iconCircle: {
-    width: 60,
-    minWidth: 60,
-    height: 60,
-    minHeight: 60,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: 'white',
-    opacity: 0.7,
-    borderRadius: 50
-  },
-  icon: {
-    height: 30,
-    width: 30
-  },
-  resultLabel: {
-    color: 'white',
-    fontSize: 24,
-    fontWeight: '600',
-    lineHeight: 24,
-    marginLeft: 12,
-    textTransform: 'uppercase',
-    wordBreak: 'break-word'
-  },
-  feedbackSection: {
-    marginTop: 32
-  },
-  labelContainer: {
-    alignSelf: 'flex-start',
-    backgroundColor: 'rgba(255, 255, 255, 0.3)',
-    borderRadius: 56,
-    paddingHorizontal: 8,
-    paddingVertical: 4
-  },
-  label: {
-    color: 'white',
-    fontSize: 14,
-    fontWeight: '900',
-    lineHeight: 17,
-    wordBreak: 'break-word'
-  }
-});
+type StyleSheetType = {
+  wrapper: ViewStyle;
+  popinRight: ViewStyle;
+  correctionSection: ViewStyle;
+  iconCircle: ViewStyle;
+  icon: ViewStyle;
+  resultLabel: TextStyle;
+  feedbackSection: ViewStyle;
+  labelContainer: ViewStyle;
+  label: TextStyle;
+  button: ViewStyle;
+  buttonText: TextStyle;
+};
+const createStyleSheet = (theme: Theme): StyleSheetType =>
+  StyleSheet.create({
+    wrapper: {
+      height: 'auto',
+      color: theme.colors.white,
+      display: 'flex'
+    },
+    popinRight: {
+      padding: theme.spacing.medium,
+      borderRadius: 16, // TODO
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      backgroundColor: theme.colors.positive,
+      shadowRadius: 28,
+      shadowColor: theme.colors.positive,
+      shadowOpacity: 0.4
+    },
+    correctionSection: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      width: '80%'
+    },
+    iconCircle: {
+      width: 60,
+      height: 60,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.white,
+      opacity: 0.7,
+      borderRadius: 50
+    },
+    icon: {
+      height: 30,
+      width: 30
+    },
+    resultLabel: {
+      color: theme.colors.white,
+      fontSize: 24,
+      fontWeight: '600',
+      lineHeight: 24,
+      marginLeft: 12,
+      textTransform: 'uppercase',
+      wordBreak: 'break-word'
+    },
+    feedbackSection: {
+      marginVertical: theme.spacing.medium
+    },
+    labelContainer: {
+      alignSelf: 'flex-start',
+      backgroundColor: 'rgba(255, 255, 255, 0.3)',
+      borderRadius: 56,
+      paddingHorizontal: theme.spacing.tiny,
+      paddingVertical: theme.spacing.micro
+    },
+    label: {
+      color: theme.colors.white,
+      fontSize: 14,
+      fontWeight: theme.fontWeight.extraBold,
+      lineHeight: 17,
+      wordBreak: 'break-word'
+    },
+    button: {
+      alignSelf: 'stretch',
+      backgroundColor: theme.colors.white,
+      borderRadius: 7,
+      paddingHorizontal: theme.spacing.base,
+      paddingVertical: theme.spacing.small
+    },
+    buttonText: {
+      color: theme.colors.cta,
+      fontSize: 14,
+      fontWeight: theme.fontWeight.bold,
+      lineHeight: 20,
+      textAlign: 'center'
+    }
+  });
 
-const popinRight = StyleSheet.compose(styles.popin, styles.right);
-
-const ReviewCorrectionPopin = props => {
-  const {information, resultLabel} = props;
+const ReviewCorrectionPopin = ({
+  information,
+  klf,
+  next,
+  type,
+  resultLabel
+}: ReviewCorrectionPopinProps) => {
+  const templateContext = useTemplateContext();
+  const [styleSheet, setStylesheet] = useState<StyleSheetType | null>(null);
+  const {theme} = templateContext;
+  const handlePressNext = next.onClick;
   const source = {
     html: `<p aria-label='${information.message}' style='color:white; font-size:16; font-weight:600; line-height:19;'>${information.message}</p>`
   };
 
+  useEffect(() => {
+    const _stylesheet = createStyleSheet(theme);
+    setStylesheet(_stylesheet);
+  }, [theme]);
+
+  if (!styleSheet) {
+    return null;
+  }
+
   return (
-    <View style={styles.wrapper}>
-      <View style={popinRight}>
-        <View style={styles.correctionSection}>
-          <View style={styles.iconCircle}>
-            <RightIcon style={styles.icon} color={COLORS.positive} />
+    <View style={styleSheet.wrapper}>
+      <View style={styleSheet.popinRight}>
+        <View style={styleSheet.correctionSection}>
+          <View style={styleSheet.iconCircle}>
+            <RightIcon style={styleSheet.icon} color={COLORS.positive} />
           </View>
-          <Text accessibilityLabel={resultLabel} style={styles.resultLabel}>
-            {resultLabel}
-          </Text>
+          <Text style={styleSheet.resultLabel}>{resultLabel}</Text>
         </View>
-        <View style={styles.feedbackSection} accessibilityLabel="answer-information">
-          <View style={styles.labelContainer} needsOffscreenAlphaCompositing>
-            <Text accessibilityLabel={information.label} style={styles.label}>
+        <View style={styleSheet.feedbackSection} accessibilityLabel="answer-information">
+          <View style={styleSheet.labelContainer} needsOffscreenAlphaCompositing>
+            <Text accessibilityLabel={information.label} style={styleSheet.label}>
               {information.label}
             </Text>
           </View>
-          <RenderHTML source={source} />
+          <RenderHTML source={source} systemFonts={['Gilroy']} />
         </View>
+        <Touchable
+          style={styleSheet.button}
+          onPress={handlePressNext}
+          accessibilityLabel={next['aria-label']}
+          testID={next['data-name']}
+        >
+          <Text style={styleSheet.buttonText}>{next.label}</Text>
+        </Touchable>
       </View>
     </View>
   );

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -1,17 +1,20 @@
 import React, {useEffect, useState} from 'react';
 import {TextStyle, StyleSheet, View, ViewStyle} from 'react-native';
 import RenderHTML from 'react-native-render-html';
-import {NovaCompositionCoorpacademyCheck as RightIcon} from '@coorpacademy/nova-icons';
-import {COLORS} from '../../variables/colors';
+import {
+  NovaCompositionCoorpacademyCheck as RightIcon,
+  NovaSolidStatusClose as WrongIcon,
+  NovaLineLoginKey1 as KlfIcon
+} from '@coorpacademy/nova-icons';
 import {Theme} from '../../variables/theme.native';
 import Text from '../../atom/text/index.native';
 import Touchable from '../../hoc/touchable/index.native';
 import {useTemplateContext} from '../../template/app-review/template-context';
 import {ReviewCorrectionPopinProps} from './prop-types';
 
-type StyleSheetType = {
+interface StyleSheetType {
   wrapper: ViewStyle;
-  popinRight: ViewStyle;
+  popin: ViewStyle;
   correctionSection: ViewStyle;
   iconCircle: ViewStyle;
   icon: ViewStyle;
@@ -21,23 +24,31 @@ type StyleSheetType = {
   label: TextStyle;
   button: ViewStyle;
   buttonText: TextStyle;
-};
-const createStyleSheet = (theme: Theme): StyleSheetType =>
+  buttonKlf: ViewStyle;
+  buttonKlfText: TextStyle;
+  iconKey: ViewStyle;
+  containerTooltip: ViewStyle;
+  textTooltip: TextStyle;
+  containerButtonKlf: ViewStyle;
+  triangleTooltip: ViewStyle;
+}
+
+const createStyleSheet = (theme: Theme, type: string): StyleSheetType =>
   StyleSheet.create({
     wrapper: {
       height: 'auto',
       color: theme.colors.white,
       display: 'flex'
     },
-    popinRight: {
+    popin: {
       padding: theme.spacing.medium,
-      borderRadius: 16, // TODO
+      borderRadius: 16,
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'flex-start',
-      backgroundColor: theme.colors.positive,
+      backgroundColor: type === 'wrong' ? theme.colors.negative : theme.colors.positive,
       shadowRadius: 28,
-      shadowColor: theme.colors.positive,
+      shadowColor: type === 'wrong' ? theme.colors.negative : theme.colors.positive,
       shadowOpacity: 0.4
     },
     correctionSection: {
@@ -97,8 +108,102 @@ const createStyleSheet = (theme: Theme): StyleSheetType =>
       fontWeight: theme.fontWeight.bold,
       lineHeight: 20,
       textAlign: 'center'
+    },
+    containerButtonKlf: {
+      width: '100%'
+    },
+    buttonKlf: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'rgba(255, 255, 255, 0.1)',
+      borderRadius: 7,
+      paddingHorizontal: theme.spacing.base,
+      paddingVertical: theme.spacing.small,
+      marginBottom: theme.spacing.tiny
+    },
+    buttonKlfText: {
+      color: 'white',
+      fontSize: 14,
+      fontWeight: theme.fontWeight.bold,
+      lineHeight: 20,
+      textAlign: 'center'
+    },
+    iconKey: {
+      width: 12,
+      height: 12,
+      marginRight: theme.spacing.tiny
+    },
+    containerTooltip: {
+      flexDirection: 'column',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.white,
+      borderRadius: 15,
+      padding: theme.spacing.small,
+      width: '112%',
+      position: 'absolute',
+      bottom: 4,
+      right: -15
+    },
+    textTooltip: {
+      color: theme.colors.text.primary,
+      fontSize: 16,
+      fontWeight: '600',
+      lineHeight: 22,
+      textAlign: 'center'
+    },
+    triangleTooltip: {
+      width: 0,
+      height: 0,
+      backgroundColor: 'transparent',
+      borderStyle: 'solid',
+      borderLeftWidth: 20,
+      borderRightWidth: 20,
+      borderBottomWidth: 20,
+      borderLeftColor: 'transparent',
+      borderRightColor: 'transparent',
+      borderBottomColor: theme.colors.white,
+      transform: [{rotate: '180deg'}],
+      position: 'absolute',
+      left: 105,
+      top: -12
     }
   });
+
+const KlfButton = (klf: ReviewCorrectionPopinProps['klf'], styleSheet: StyleSheetType) => {
+  const {
+    buttonKlf,
+    buttonKlfText,
+    containerButtonKlf,
+    containerTooltip,
+    iconKey,
+    textTooltip,
+    triangleTooltip
+  } = styleSheet;
+  const {label} = klf;
+
+  return (
+    <View style={containerButtonKlf}>
+      <View>
+        <Touchable
+          style={containerTooltip}
+          accessibilityLabel={`aria-label-tooltip`}
+          testID="tooltip"
+        >
+          <Text style={textTooltip}>
+            17 frustrated software engineers grappling with the complexities of software
+            development.
+          </Text>
+        </Touchable>
+        <View style={triangleTooltip} />
+      </View>
+      <Touchable style={buttonKlf} accessibilityLabel={`aria-label-${label}`} testID={label}>
+        <KlfIcon style={iconKey} color="white" />
+        <Text style={buttonKlfText}>{label}</Text>
+      </Touchable>
+    </View>
+  );
+};
 
 const ReviewCorrectionPopin = ({
   information,
@@ -114,22 +219,31 @@ const ReviewCorrectionPopin = ({
   const source = {
     html: `<p aria-label='${information.message}' style='color:white; font-size:16; font-weight:600; line-height:19;'>${information.message}</p>`
   };
+  const ICONS = {
+    right: RightIcon,
+    wrong: WrongIcon
+  };
+  const Icon = ICONS[type];
 
   useEffect(() => {
-    const _stylesheet = createStyleSheet(theme);
+    const _stylesheet = createStyleSheet(theme, type);
     setStylesheet(_stylesheet);
   }, [theme]);
 
   if (!styleSheet) {
     return null;
   }
+  const cta = type === 'wrong' ? KlfButton(klf, styleSheet) : null;
 
   return (
     <View style={styleSheet.wrapper}>
-      <View style={styleSheet.popinRight}>
+      <View style={styleSheet.popin}>
         <View style={styleSheet.correctionSection}>
           <View style={styleSheet.iconCircle}>
-            <RightIcon style={styleSheet.icon} color={COLORS.positive} />
+            <Icon
+              style={styleSheet.icon}
+              color={type === 'wrong' ? theme.colors.negative : theme.colors.positive}
+            />
           </View>
           <Text style={styleSheet.resultLabel}>{resultLabel}</Text>
         </View>
@@ -141,6 +255,7 @@ const ReviewCorrectionPopin = ({
           </View>
           <RenderHTML source={source} systemFonts={['Gilroy']} />
         </View>
+        {cta}
         <Touchable
           style={styleSheet.button}
           onPress={handlePressNext}

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -194,35 +194,35 @@ const KlfButton = ({
   klf,
   styleSheet
 }: {
-  klf: ReviewCorrectionPopinProps['klf'];
+  klf: NonNullable<ReviewCorrectionPopinProps['klf']>;
   styleSheet: StyleSheetType | null;
 }) => {
   const [displayTooltip, setDisplayTooltip] = useState(false);
 
   const fadeAnim = useRef(new Animated.Value(0)).current;
 
-  const fadeIn = () => {
+  const fadeIn = useCallback(() => {
     Animated.timing(fadeAnim, {
       toValue: 1,
       duration: 1000,
       easing: Easing.bezier(0.25, 1, 0.5, 1),
       useNativeDriver: true
     }).start();
-  };
+  }, [fadeAnim]);
 
-  const fadeOut = () => {
+  const fadeOut = useCallback(() => {
     Animated.timing(fadeAnim, {
       toValue: 0,
       duration: 500,
       easing: Easing.bezier(0.25, 1, 0.5, 1),
       useNativeDriver: true
     }).start();
-  };
+  }, [fadeAnim]);
 
   const handlePressKey = useCallback(() => {
     setDisplayTooltip(!displayTooltip);
     !displayTooltip ? fadeIn() : fadeOut();
-  }, [setDisplayTooltip, displayTooltip]);
+  }, [displayTooltip, fadeIn, fadeOut]);
 
   if (!styleSheet) return null;
 
@@ -248,6 +248,7 @@ const KlfButton = ({
           accessibilityLabel={`aria-label-tooltip`}
           isHighlight
           onPress={handlePressKey}
+          testID="button-tooltip"
         >
           <Text style={textTooltip}>{tooltip}</Text>
         </Touchable>
@@ -257,6 +258,7 @@ const KlfButton = ({
         style={[buttonKlf, displayTooltip ? buttonKlfActive : null]}
         accessibilityLabel={`aria-label-${label}`}
         onPress={handlePressKey}
+        testID="button-klf"
       >
         <KlfIcon style={iconKey} color="white" />
         <Text style={buttonKlfText}>{label}</Text>
@@ -264,6 +266,12 @@ const KlfButton = ({
     </View>
   );
 };
+
+// Type narrowing function
+const isWrongType = (
+  klf: ReviewCorrectionPopinProps['klf'],
+  type: ReviewCorrectionPopinProps['type']
+): klf is NonNullable<ReviewCorrectionPopinProps['klf']> => type === 'wrong';
 
 const ReviewCorrectionPopin = ({
   information,
@@ -314,7 +322,7 @@ const ReviewCorrectionPopin = ({
           </View>
           <RenderHTML source={source} systemFonts={['Gilroy']} />
         </View>
-        {type === 'wrong' ? <KlfButton styleSheet={styleSheet} klf={klf} /> : null}
+        {isWrongType(klf, type) ? <KlfButton styleSheet={styleSheet} klf={klf} /> : null}
         <Touchable
           style={styleSheet.button}
           onPress={handlePressNext}

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -273,12 +273,6 @@ const KlfButton = ({
   );
 };
 
-// Type narrowing function
-const isWrongType = (
-  klf: ReviewCorrectionPopinProps['klf'],
-  type: ReviewCorrectionPopinProps['type']
-): klf is ReviewCorrectionPopinKLFProps => type === 'wrong';
-
 const ICONS = {
   right: RightIcon,
   wrong: WrongIcon
@@ -327,7 +321,7 @@ const ReviewCorrectionPopin = ({
           </View>
           <Html style={styleSheet.htmlInfoMessage}>{information.message}</Html>
         </View>
-        {isWrongType(klf, type) ? <KlfButton styleSheet={styleSheet} klf={klf} /> : null}
+        {klf && type === 'wrong' ? <KlfButton styleSheet={styleSheet} klf={klf} /> : null}
         <Touchable
           style={styleSheet.button}
           onPress={handlePressNext}

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {Text, StyleSheet, View} from 'react-native';
+import {NovaCompositionCoorpacademyCheck as RightIcon} from '@coorpacademy/nova-icons';
+import {COLORS} from '../../variables/colors';
+
+const styles = StyleSheet.create({
+  wrapper: {
+    height: 'auto',
+    fontFamily: 'Gilroy',
+    color: 'white',
+    display: 'flex'
+  },
+  popin: {
+    padding: 32,
+    borderRadius: 16,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start'
+  },
+  right: {
+    backgroundColor: COLORS.positive,
+    shadowRadius: 28,
+    shadowColor: COLORS.positive,
+    shadowOpacity: 0.4
+  },
+  correctionSection: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: '80%'
+  },
+  iconCircle: {
+    width: 60,
+    minWidth: 60,
+    height: 60,
+    minHeight: 60,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'white',
+    opacity: 0.7,
+    borderRadius: 50
+  },
+  icon: {
+    width: 30,
+    height: 30
+  },
+  resultLabel: {
+    color: 'white',
+    fontSize: 24,
+    fontWeight: '600',
+    lineHeight: 24,
+    textTransform: 'uppercase',
+    wordBreak: 'break-word',
+    marginLeft: 12
+  }
+});
+
+const popinRight = StyleSheet.compose(styles.popin, styles.right);
+
+const ReviewCorrectionPopin = props => {
+  const {resultLabel} = props;
+  return (
+    <View style={styles.wrapper}>
+      <View style={popinRight}>
+        <View style={styles.correctionSection}>
+          <View style={styles.iconCircle}>
+            <RightIcon style={styles.icon} color={COLORS.positive} />
+          </View>
+          <Text aria-label={resultLabel} style={styles.resultLabel}>
+            {resultLabel}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default ReviewCorrectionPopin;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -266,6 +266,11 @@ const isWrongType = (
   type: ReviewCorrectionPopinProps['type']
 ): klf is NonNullable<ReviewCorrectionPopinProps['klf']> => type === 'wrong';
 
+const ICONS = {
+  right: RightIcon,
+  wrong: WrongIcon
+};
+
 const ReviewCorrectionPopin = ({
   information,
   klf,
@@ -280,10 +285,7 @@ const ReviewCorrectionPopin = ({
   const infoMessage = {
     html: `<p style='color:white; font-size:16; font-weight:600; line-height:19;'>${information.message}</p>`
   };
-  const ICONS = {
-    right: RightIcon,
-    wrong: WrongIcon
-  };
+
   const Icon = ICONS[type];
 
   useEffect(() => {

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -224,8 +224,6 @@ const KlfButton = ({
     !displayTooltip ? fadeIn() : fadeOut();
   }, [setDisplayTooltip, displayTooltip]);
 
-  console.log('displayTooltip', displayTooltip);
-
   if (!styleSheet) return null;
 
   const {
@@ -248,7 +246,6 @@ const KlfButton = ({
         <Touchable
           style={buttonTooltip}
           accessibilityLabel={`aria-label-tooltip`}
-          testID="tooltip"
           isHighlight
           onPress={handlePressKey}
         >
@@ -259,7 +256,6 @@ const KlfButton = ({
       <Touchable
         style={[buttonKlf, displayTooltip ? buttonKlfActive : null]}
         accessibilityLabel={`aria-label-${label}`}
-        testID={label}
         onPress={handlePressKey}
       >
         <KlfIcon style={iconKey} color="white" />

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.native.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Text, StyleSheet, View} from 'react-native';
+import RenderHTML from 'react-native-render-html';
 import {NovaCompositionCoorpacademyCheck as RightIcon} from '@coorpacademy/nova-icons';
 import {COLORS} from '../../variables/colors';
 
@@ -40,24 +41,45 @@ const styles = StyleSheet.create({
     borderRadius: 50
   },
   icon: {
-    width: 30,
-    height: 30
+    height: 30,
+    width: 30
   },
   resultLabel: {
     color: 'white',
     fontSize: 24,
     fontWeight: '600',
     lineHeight: 24,
+    marginLeft: 12,
     textTransform: 'uppercase',
-    wordBreak: 'break-word',
-    marginLeft: 12
+    wordBreak: 'break-word'
+  },
+  feedbackSection: {
+    marginTop: 32
+  },
+  labelContainer: {
+    alignSelf: 'flex-start',
+    backgroundColor: 'rgba(255, 255, 255, 0.3)',
+    borderRadius: 56,
+    paddingHorizontal: 8,
+    paddingVertical: 4
+  },
+  label: {
+    color: 'white',
+    fontSize: 14,
+    fontWeight: '900',
+    lineHeight: 17,
+    wordBreak: 'break-word'
   }
 });
 
 const popinRight = StyleSheet.compose(styles.popin, styles.right);
 
 const ReviewCorrectionPopin = props => {
-  const {resultLabel} = props;
+  const {information, resultLabel} = props;
+  const source = {
+    html: `<p aria-label='${information.message}' style='color:white; font-size:16; font-weight:600; line-height:19;'>${information.message}</p>`
+  };
+
   return (
     <View style={styles.wrapper}>
       <View style={popinRight}>
@@ -65,9 +87,17 @@ const ReviewCorrectionPopin = props => {
           <View style={styles.iconCircle}>
             <RightIcon style={styles.icon} color={COLORS.positive} />
           </View>
-          <Text aria-label={resultLabel} style={styles.resultLabel}>
+          <Text accessibilityLabel={resultLabel} style={styles.resultLabel}>
             {resultLabel}
           </Text>
+        </View>
+        <View style={styles.feedbackSection} accessibilityLabel="answer-information">
+          <View style={styles.labelContainer} needsOffscreenAlphaCompositing>
+            <Text accessibilityLabel={information.label} style={styles.label}>
+              {information.label}
+            </Text>
+          </View>
+          <RenderHTML source={source} />
         </View>
       </View>
     </View>

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
@@ -19,11 +19,13 @@ const propTypes = {
   })
 };
 
+export type ReviewCorrectionPopinKLFProps = {
+  label: string;
+  tooltip: string;
+};
+
 export type ReviewCorrectionPopinProps = {
-  klf?: {
-    label: string;
-    tooltip: string;
-  };
+  klf?: ReviewCorrectionPopinKLFProps;
   information: {
     label: string;
     message: string;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
@@ -20,8 +20,10 @@ const propTypes = {
 };
 
 export type ReviewCorrectionPopinProps = {
-  type: 'right' | 'wrong';
-  resultLabel: string;
+  klf?: {
+    label: string;
+    tooltip: string;
+  };
   information: {
     label: string;
     message: string;
@@ -32,10 +34,8 @@ export type ReviewCorrectionPopinProps = {
     'data-name'?: string;
     'aria-label': string;
   };
-  klf?: {
-    label: string;
-    tooltip: string;
-  };
+  resultLabel: string;
+  type: 'right' | 'wrong';
 };
 
 export default propTypes;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
@@ -20,10 +20,8 @@ const propTypes = {
 };
 
 export type ReviewCorrectionPopinProps = {
-  klf?: {
-    label: string;
-    tooltip: string;
-  };
+  type: 'right' | 'wrong';
+  resultLabel: string;
   information: {
     label: string;
     message: string;
@@ -31,10 +29,13 @@ export type ReviewCorrectionPopinProps = {
   next: {
     label: string;
     onClick: () => void;
+    'data-name': string;
     'aria-label'?: string;
   };
-  resultLabel: string;
-  type: 'right' | 'wrong';
+  klf: {
+    label?: string;
+    tooltip?: string;
+  };
 };
 
 export default propTypes;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import {GestureResponderEvent} from 'react-native';
 
 const propTypes = {
   type: PropTypes.oneOf(['right', 'wrong']),
@@ -29,7 +28,7 @@ export type ReviewCorrectionPopinProps = {
   };
   next: {
     label: string;
-    onClick: (event: GestureResponderEvent) => void;
+    onClick: () => void;
     'data-name'?: string;
     'aria-label': string;
   };

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
@@ -33,9 +33,9 @@ export type ReviewCorrectionPopinProps = {
     'data-name': string;
     'aria-label'?: string;
   };
-  klf: {
-    label?: string;
-    tooltip?: string;
+  klf?: {
+    label: string;
+    tooltip: string;
   };
 };
 

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
@@ -30,8 +30,8 @@ export type ReviewCorrectionPopinProps = {
   next: {
     label: string;
     onClick: (event: GestureResponderEvent) => void;
-    'data-name': string;
-    'aria-label'?: string;
+    'data-name'?: string;
+    'aria-label': string;
   };
   klf?: {
     label: string;

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/prop-types.ts
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import {GestureResponderEvent} from 'react-native';
 
 const propTypes = {
   type: PropTypes.oneOf(['right', 'wrong']),
@@ -28,7 +29,7 @@ export type ReviewCorrectionPopinProps = {
   };
   next: {
     label: string;
-    onClick: () => void;
+    onClick: (event: GestureResponderEvent) => void;
     'data-name': string;
     'aria-label'?: string;
   };

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/wrong.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/fixtures/wrong.js
@@ -13,6 +13,8 @@ export default {
     },
     next: {
       label: 'Next Question',
+      'aria-label': 'next question button',
+      'data-name': 'next-question-button',
       onClick: () => console.log('Next Question')
     }
   }

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/on-press.test.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/on-press.test.tsx
@@ -1,7 +1,6 @@
 import test from 'ava';
 import React from 'react';
 import {render, fireEvent} from '@testing-library/react-native';
-import {GestureResponderEvent} from 'react-native';
 import mockedGestureEvent from '../../../test/helpers/mocked-gesture-event';
 import ReviewCorrectionPopin from '../index.native';
 import fixturesRight from './fixtures/right';
@@ -10,12 +9,8 @@ import fixturesWrong from './fixtures/wrong';
 test('should handle onPress on next button', t => {
   t.plan(1);
 
-  const onClick = (event: GestureResponderEvent) => {
-    t.is(event, mockedGestureEvent);
-  };
-
   const props = fixturesRight.props;
-  const next = {...props.next, onClick};
+  const next = {...props.next, onClick: () => t.pass()};
 
   const component = (
     <ReviewCorrectionPopin
@@ -32,7 +27,7 @@ test('should handle onPress on next button', t => {
   fireEvent.press(buttonNext, mockedGestureEvent);
 });
 
-test('test', t => {
+test('should handle onPress on button klf', t => {
   const props = fixturesWrong.props;
   const component = (
     <ReviewCorrectionPopin
@@ -47,6 +42,6 @@ test('test', t => {
 
   const buttonKlf = getByTestId('button-klf');
   t.notThrows(() => fireEvent.press(buttonKlf, mockedGestureEvent));
-
+  t.notThrows(() => fireEvent.press(buttonKlf, mockedGestureEvent));
   t.pass();
 });

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/on-press.test.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/on-press.test.tsx
@@ -22,7 +22,6 @@ test('should handle onPress on next button', t => {
       information={props.information}
       next={next}
       resultLabel={props.resultLabel}
-      klf={{}}
     />
   );
 

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/on-press.test.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/on-press.test.tsx
@@ -1,0 +1,33 @@
+import test from 'ava';
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react-native';
+import {GestureResponderEvent} from 'react-native';
+import mockedGestureEvent from '../../../test/helpers/mocked-gesture-event';
+import ReviewCorrectionPopin from '../index.native';
+import fixturesRight from './fixtures/right';
+
+test('should handle onPress on next button', t => {
+  t.plan(1);
+
+  const onClick = (event: GestureResponderEvent) => {
+    t.is(event, mockedGestureEvent);
+  };
+
+  const props = fixturesRight.props;
+  const next = {...props.next, onClick};
+
+  const component = (
+    <ReviewCorrectionPopin
+      type="right"
+      information={props.information}
+      next={next}
+      resultLabel={props.resultLabel}
+      klf={{}}
+    />
+  );
+
+  const {getByTestId} = render(component);
+  const buttonNext = getByTestId('next-question-button');
+
+  fireEvent.press(buttonNext, mockedGestureEvent);
+});

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/on-press.test.tsx
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/test/on-press.test.tsx
@@ -5,6 +5,7 @@ import {GestureResponderEvent} from 'react-native';
 import mockedGestureEvent from '../../../test/helpers/mocked-gesture-event';
 import ReviewCorrectionPopin from '../index.native';
 import fixturesRight from './fixtures/right';
+import fixturesWrong from './fixtures/wrong';
 
 test('should handle onPress on next button', t => {
   t.plan(1);
@@ -29,4 +30,23 @@ test('should handle onPress on next button', t => {
   const buttonNext = getByTestId('next-question-button');
 
   fireEvent.press(buttonNext, mockedGestureEvent);
+});
+
+test('test', t => {
+  const props = fixturesWrong.props;
+  const component = (
+    <ReviewCorrectionPopin
+      type="wrong"
+      information={props.information}
+      next={props.next}
+      resultLabel={props.resultLabel}
+      klf={props.klf}
+    />
+  );
+  const {getByTestId} = render(component);
+
+  const buttonKlf = getByTestId('button-klf');
+  t.notThrows(() => fireEvent.press(buttonKlf, mockedGestureEvent));
+
+  t.pass();
 });

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.native.tsx
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.native.tsx
@@ -4,7 +4,6 @@ import get from 'lodash/fp/get';
 import getOr from 'lodash/fp/getOr';
 import Text from '../../atom/text/index.native';
 import Answer from '../../molecule/answer/index.native';
-// import Loader from '../../atom/loader';
 import ReviewCorrectionPopin from '../../molecule/review-correction-popin/index.native';
 import {useTemplateContext} from '../../template/app-review/template-context';
 import {Theme} from '../../variables/theme.native';

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.native.tsx
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.native.tsx
@@ -4,8 +4,8 @@ import get from 'lodash/fp/get';
 import getOr from 'lodash/fp/getOr';
 import Text from '../../atom/text/index.native';
 import Answer from '../../molecule/answer/index.native';
-// import Loader from '../../atom/loader';
-// import ReviewCorrectionPopin from '../../molecule/review-correction-popin';
+// import Loader from '.r./../atom/loader';
+import ReviewCorrectionPopin from '../../molecule/review-correction-popin/index.native';
 import {useTemplateContext} from '../../template/app-review/template-context';
 import {Theme} from '../../variables/theme.native';
 import Touchable from '../../hoc/touchable/index.native';
@@ -20,25 +20,24 @@ type PopinProps = {
   animateCorrectionPopin: unknown;
 };
 
-const CorrectionPopin = ({
-  correctionPopinProps,
-  slideIndex,
-  showCorrectionPopin,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  animateCorrectionPopin
-}: PopinProps) => {
-  if (!showCorrectionPopin) return null;
+const styles = StyleSheet.create({
+  correctionPopinWrapper: {
+    position: 'absolute',
+    bottom: 16,
+    width: '105%',
+    zIndex: 100
+  }
+});
 
+const CorrectionPopin = ({correctionPopinProps, slideIndex}: PopinProps) => {
   const klf = getOr({}, 'klf', correctionPopinProps);
   const information = getOr({label: '', message: ''}, 'information', correctionPopinProps);
   const next = get('next', correctionPopinProps);
+  const onClick = get(['next', 'onClick'], correctionPopinProps);
 
   const _correctionPopinProps = {
     next: {
-      onClick: () => {
-        // eslint-disable-next-line no-console
-        console.log('Next Slide');
-      },
+      onClick,
       label: next && next.label,
       'data-name': `next-question-button-${slideIndex}`,
       'aria-label': next && next['aria-label']
@@ -50,8 +49,9 @@ const CorrectionPopin = ({
   };
 
   return (
-    <Text>@todo ReviewCorrectionPopin {_correctionPopinProps.toString()}</Text>
-    // <ReviewCorrectionPopin {..._correctionPopinProps} />
+    <View style={styles.correctionPopinWrapper}>
+      <ReviewCorrectionPopin {..._correctionPopinProps} />
+    </View>
   );
 };
 

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.native.tsx
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.native.tsx
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
 });
 
 const CorrectionPopin = ({correctionPopinProps, slideIndex}: PopinProps) => {
-  const klf = getOr({}, 'klf', correctionPopinProps);
+  const klf = getOr(undefined, 'klf', correctionPopinProps);
   const information = getOr({label: '', message: ''}, 'information', correctionPopinProps);
   const next = get('next', correctionPopinProps);
   const onClick = get(['next', 'onClick'], correctionPopinProps);

--- a/packages/@coorpacademy-components/src/organism/review-slide/index.native.tsx
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.native.tsx
@@ -4,7 +4,7 @@ import get from 'lodash/fp/get';
 import getOr from 'lodash/fp/getOr';
 import Text from '../../atom/text/index.native';
 import Answer from '../../molecule/answer/index.native';
-// import Loader from '.r./../atom/loader';
+// import Loader from '../../atom/loader';
 import ReviewCorrectionPopin from '../../molecule/review-correction-popin/index.native';
 import {useTemplateContext} from '../../template/app-review/template-context';
 import {Theme} from '../../variables/theme.native';
@@ -24,8 +24,7 @@ const styles = StyleSheet.create({
   correctionPopinWrapper: {
     position: 'absolute',
     bottom: 16,
-    width: '105%',
-    zIndex: 100
+    width: '105%'
   }
 });
 

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/choices-selected.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/choices-selected.js
@@ -17,7 +17,6 @@ export default {
       label: 'Validate',
       onClick: () => console.log('onValidateClick'),
       disabled: false
-    },
-    correctionPopinProps: {}
+    }
   }
 };

--- a/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/initial-state.js
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/fixtures/initial-state.js
@@ -23,7 +23,6 @@ export default {
       label: 'Validate',
       onClick: () => console.log('onValidateClick'),
       disabled: true
-    },
-    correctionPopinProps: {}
+    }
   }
 };

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/all-ok.ts
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/all-ok.ts
@@ -19,6 +19,7 @@ export const correctionPopinProps: ReviewCorrectionPopinProps = {
   },
   next: {
     label: 'Next',
+    'aria-label': 'next question button',
     onClick: () => {
       console.log('Load next slide');
     }

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/first-correct.ts
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/first-correct.ts
@@ -19,6 +19,7 @@ export const correctionPopinProps: ReviewCorrectionPopinProps = {
   },
   next: {
     label: 'Next',
+    'aria-label': 'next question button',
     onClick: () => {
       console.log('Load next slide');
     }

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/restack.ts
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/restack.ts
@@ -28,6 +28,7 @@ export const correctionPopinProps: ReviewCorrectionPopinProps = {
   },
   next: {
     label: 'Next',
+    'aria-label': 'next question button',
     onClick: () => {
       console.log('Load next slide');
     }

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/second-wrong.ts
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/second-wrong.ts
@@ -19,6 +19,7 @@ export const correctionPopinProps: ReviewCorrectionPopinProps = {
   },
   next: {
     label: 'Next',
+    'aria-label': 'next question button',
     onClick: () => {
       console.log('Load next slide');
     }

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/unstack.ts
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/unstack.ts
@@ -21,6 +21,7 @@ export const correctionPopinProps: ReviewCorrectionPopinProps = {
   },
   next: {
     label: 'Next',
+    'aria-label': 'next question button',
     onClick: () => {
       console.log('Load next slide');
     }

--- a/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/wrong.ts
+++ b/packages/@coorpacademy-components/src/organism/review-stacked-slides/test/fixtures/wrong.ts
@@ -19,6 +19,7 @@ export const correctionPopinProps: ReviewCorrectionPopinProps = {
   },
   next: {
     label: 'Next',
+    'aria-label': 'next question button',
     onClick: () => {
       console.log('Load next slide');
     }


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR adds `ReviewCorrectionPopin` component for app mobile. 
-> https://trello.com/c/TvURbKSx/2855-or-correction-popin-mobile

**Result and observation**
<img width="286" alt="image" src="https://user-images.githubusercontent.com/79636283/204304621-8254274d-9128-408c-be3b-8fab0c3b0428.png">

![Kapture 2022-11-28 at 15 34 24](https://user-images.githubusercontent.com/79636283/204304262-9a46ac89-0a21-49c4-a3f4-fc41de670854.gif)

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [x] Unit testing
