### PR TITLE
added FontRenderer for mobile choices

### DIFF
--- a/packages/@coorpacademy-components/src/atom/choice/index.native.tsx
+++ b/packages/@coorpacademy-components/src/atom/choice/index.native.tsx
@@ -1,8 +1,9 @@
 import React, {useEffect, useState} from 'react';
-import {View, StyleSheet, ViewStyle, Text, TextStyle} from 'react-native';
-import type {Media, QuestionType} from '../../molecule/questions/types';
+import {View, StyleSheet, ViewStyle, TextStyle} from 'react-native';
 
+import Html from '../html/index.native';
 import ImageBackground from '../image-background/index.native';
+import type {Media, QuestionType} from '../../molecule/questions/types';
 import getCleanUri from '../../util/get-clean-uri';
 import Touchable from '../../hoc/touchable/index.native';
 import {useTemplateContext} from '../../template/app-review/template-context';
@@ -175,7 +176,7 @@ const Choice = ({
 
         {children ? (
           <View style={textWrapperStyle}>
-            <Text style={textStyle}>{children}</Text>
+            <Html style={textStyle}>{children}</Html>
           </View>
         ) : null}
       </View>

--- a/packages/@coorpacademy-components/src/atom/html/index.native.tsx
+++ b/packages/@coorpacademy-components/src/atom/html/index.native.tsx
@@ -1,10 +1,24 @@
 import React, {useCallback, useState} from 'react';
 import {View, ViewStyle, ImageStyle, TextStyle} from 'react-native';
-import HtmlBase, {CustomRendererProps, MixedStyleRecord, TBlock} from 'react-native-render-html';
+import RenderHTML, {
+  CustomRendererProps,
+  MixedStyleRecord,
+  RenderHTMLProps,
+  TBlock
+} from 'react-native-render-html';
 
 import {HTML_ANCHOR_TEXT_COLOR} from '../../variables/theme.native';
 import {useTemplateContext} from '../../template/app-review/template-context';
 import Text, {DEFAULT_STYLE as DEFAULT_TEXT_STYLE} from '../text/index.native';
+
+interface CustomRenderHTMLProps extends RenderHTMLProps {
+  baseFontStyle?: TextStyle;
+  testID?: string;
+}
+
+const HtmlBase = (props: CustomRenderHTMLProps) => {
+  return <RenderHTML {...props} />;
+};
 
 export type Props = {
   children: string;
@@ -86,7 +100,7 @@ const Html = (props: Props) => {
     img: imageStyle || {}
   };
 
-  let baseFontStyle = {...DEFAULT_TEXT_STYLE, fontSize, color: theme.colors.black};
+  let baseFontStyle: TextStyle = {...DEFAULT_TEXT_STYLE, fontSize, color: theme.colors.black};
   if (style) {
     if (Array.isArray(style)) {
       const styleObject = style.reduce((result, child) => ({
@@ -112,18 +126,21 @@ const Html = (props: Props) => {
     [numberOfLines]
   );
 
+  interface HtmlAttrib extends CustomRendererProps<TBlock> {
+    color?: string;
+  }
+
   const FontRenderer = useCallback(
-    (htmlAttribs: CustomRendererProps<TBlock>, _children: string) => {
-      // @ts-expect-error ts(2339) --> color may actually exist on <font>
+    (htmlAttribs: HtmlAttrib, _children: string) => {
       if (htmlAttribs.color) {
         disableBaseFontStyleColor(true);
       }
+
       return (
         <Text
           key={1}
           style={{
             ...baseFontStyle,
-            // @ts-expect-error ts(2339) --> color is a string
             color: htmlAttribs.color?.replace(/ /g, '')
           }}
         >
@@ -155,10 +172,9 @@ const Html = (props: Props) => {
             : `${children}`
         }}
         tagsStyles={tagsStyles}
-        // @ts-expect-error ts(2322)
         baseFontStyle={{
           ...baseFontStyle,
-          color: isDisabledBaseFontStyleColor ? null : baseFontStyle.color
+          color: isDisabledBaseFontStyleColor ? undefined : baseFontStyle.color
         }}
         renderers={renderers}
         // this is exceptionally for the onboarding course

--- a/packages/@coorpacademy-components/src/atom/html/test/fixtures/default.tsx
+++ b/packages/@coorpacademy-components/src/atom/html/test/fixtures/default.tsx
@@ -6,8 +6,8 @@ const fixture: Fixture = {
   props: {
     fontSize: 20,
     children: `
-  Les deux adverbes ont<s>une terminaison</s> qui se <u>prononce "ament"</u>, mais leur orthographe diffère. On écrit ainsi :
-  <br/>– <i>vaill<font color="blue">a</font>mment</i>, parce que l'adverbe est formé à partir d’un <b>adjectif en <i>-ant</i></b> (<i>vaill<font color="blue">a</font>nt</i>) ;
+  Les <font color="# 654654">deux</font> adverbes ont<s>une terminaison</s> qui se <u>prononce "ament"</u>, mais leur orthographe diffère. On écrit ainsi :
+  <br/>– <i>vaill<font color="# 654654">a</font>mment</i>, parce que l'adverbe est formé à partir d’un <b>adjectif en <i>-ant</i></b> (<i>vaill<font color="#123">a</font>nt</i>) ;
   <br/>– <i>incid<font color="blue">e</font>mment</i>, parce que l'adverbe est formé à partir d’un <b>adjectif en <i>-ent</i></b> (<i>incid<font color="blue">e</font>nt</i>).
 `
   }


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

- plugged back `html` on mobile choices 
- using font-renderer and allows to handle bad formatting from content (e.g. color="#  112233")

<img width="473" alt="Screenshot 2022-11-25 at 15 19 03" src="https://user-images.githubusercontent.com/910636/204006057-276dd47c-9b2f-4cb5-9366-6d290e212083.png">

