### PR TITLE
Forcing width/height on mobile logo, for svg

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -571,9 +571,9 @@
   }
 
   .navMobile img {
-    height: auto;
+    height: 100%;
     max-height: 50px;
-    width: auto;
+    width: 100%;
     max-width: 100px;
     display: block;
     align-self: center;


### PR DESCRIPTION
https://trello.com/c/G6LMbLJt/2846-or-header-nouveau-break-point-nouvel-onglet-revision

**Detailed purpose of the PR**

Svg logos are not shown.

**Before**
<img width="727" alt="Capture d’écran 2022-11-29 à 11 38 53" src="https://user-images.githubusercontent.com/7602475/204589046-57aa67ff-b4ae-4c00-a58a-9cc2bc363d7d.png">


**After**
<img width="734" alt="Capture d’écran 2022-11-29 à 11 39 15" src="https://user-images.githubusercontent.com/7602475/204589077-cdcf3dbe-ff2e-4568-a172-dfb831304fd6.png">
