### PR TITLE
put answer prefix in one line

### DIFF
--- a/packages/@coorpacademy-components/src/template/app-player/popin-correction/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-correction/style.css
@@ -136,6 +136,7 @@
   composes: text;
   margin-right: 5px;
   min-width: 120px;
+  flex-shrink: 0;
 }
 
 .answer {


### PR DESCRIPTION
[ticket](https://trello.com/c/zgSOOry7/27-modifier-la-taille-de-laffichage-du-texte-la-bonne-r%C3%A9ponse-dans-les-popin-fr) 
**avant résolution ("La bonne réponse" ne prend pas une seule ligne):**
<img width="733" alt="image" src="https://user-images.githubusercontent.com/111736786/205655775-5ffe3693-bf15-45c4-a27d-481daa1e5cbe.png">
**après résolution ("La bonne réponse" prend une seule ligne):**
<img width="733" alt="image" src="https://user-images.githubusercontent.com/111736786/205656302-304e859c-5f2d-4462-ab3b-3a4834a35323.png">

**solution** : en applicant flex-shrink à 0 à notre element "La bonne réponse", ce dernier ne sera pas rétréci et reprendra la largeur du contenu. Je trouve que cette solution est meilleur (plus propre) que changer la taille du texte  