### PR TITLE
[RGAA]  Footer & MonCompte : Alternative textuelle pour les <img> porteuses d'informations

### DIFF
--- a/packages/@coorpacademy-components/src/organism/get-the-app/index.js
+++ b/packages/@coorpacademy-components/src/organism/get-the-app/index.js
@@ -115,7 +115,9 @@ StoresLinks.propTypes = {
   onAppStoreButtonClick: PropTypes.func,
   appStoreButtonImageUrl: PropTypes.string,
   playStoreButtonImageUrl: PropTypes.string,
-  onPlayStoreButtonClick: PropTypes.func
+  onPlayStoreButtonClick: PropTypes.func,
+  'android-alt': PropTypes.string,
+  'ios-alt': PropTypes.string
 };
 
 const Divider = ({word}) => (
@@ -148,7 +150,9 @@ const GetTheApp = (props, context) => {
     submitValue,
     preMessage,
     linkMessage,
-    endMessage
+    endMessage,
+    'android-alt': androidAlt,
+    'ios-alt': iosAlt
   } = props;
   const {skin} = context;
   const primaryColor = get('common.primary', skin);
@@ -164,6 +168,8 @@ const GetTheApp = (props, context) => {
           appStoreButtonImageUrl={appStoreButtonImageUrl}
           playStoreButtonImageUrl={playStoreButtonImageUrl}
           onPlayStoreButtonClick={onPlayStoreButtonClick}
+          android-alt={androidAlt}
+          ios-alt={iosAlt}
         />
       </div>
       <div className={style.secondStepWrapper}>

--- a/packages/@coorpacademy-components/src/organism/get-the-app/index.js
+++ b/packages/@coorpacademy-components/src/organism/get-the-app/index.js
@@ -34,11 +34,12 @@ const QrCodeImage = ({
   qrCodeImageUrl,
   preMessage,
   linkMessage,
-  endMessage
+  endMessage,
+  qrCodeImageAlt
 }) => {
   return (
     <div className={style.qrcodeWrapper}>
-      <img src={qrCodeImageUrl} />
+      <Picture src={qrCodeImageUrl} alt={qrCodeImageAlt} />
       {showMobileAppAccess ? (
         <div className={style.qrcodeOverlay}>
           <div className={style.qrcodeModal}>
@@ -58,7 +59,8 @@ QrCodeImage.propTypes = {
   qrCodeImageUrl: PropTypes.string,
   preMessage: PropTypes.string,
   linkMessage: PropTypes.string,
-  endMessage: PropTypes.string
+  endMessage: PropTypes.string,
+  qrCodeImageAlt: PropTypes.string
 };
 
 const MagicLink = ({disabled, submitValue, magicLinkUrl, color}) => {
@@ -152,7 +154,8 @@ const GetTheApp = (props, context) => {
     linkMessage,
     endMessage,
     'android-alt': androidAlt,
-    'ios-alt': iosAlt
+    'ios-alt': iosAlt,
+    qrCodeImageAlt
   } = props;
   const {skin} = context;
   const primaryColor = get('common.primary', skin);
@@ -183,6 +186,7 @@ const GetTheApp = (props, context) => {
               preMessage={preMessage}
               linkMessage={linkMessage}
               endMessage={endMessage}
+              qrCodeImageAlt={qrCodeImageAlt}
             />
           </div>
           <Divider word={diviserWord} />

--- a/packages/@coorpacademy-components/src/organism/get-the-app/index.js
+++ b/packages/@coorpacademy-components/src/organism/get-the-app/index.js
@@ -6,6 +6,7 @@ import {
 } from '@coorpacademy/nova-icons';
 import {get} from 'lodash/fp';
 import Button from '../../atom/button';
+import Picture from '../../atom/picture';
 import style from './style.css';
 
 const Header = ({step, header, subHeader}) => (
@@ -90,11 +91,23 @@ const StoresLinks = ({
   onAppStoreButtonClick,
   appStoreButtonImageUrl,
   playStoreButtonImageUrl,
-  onPlayStoreButtonClick
+  onPlayStoreButtonClick,
+  'android-alt': androidAlt,
+  'ios-alt': iosAlt
 }) => (
   <div className={style.storeLinksContainer}>
-    <img className={style.img} src={appStoreButtonImageUrl} onClick={onAppStoreButtonClick} />
-    <img className={style.img} src={playStoreButtonImageUrl} onClick={onPlayStoreButtonClick} />
+    <Picture
+      className={style.img}
+      src={appStoreButtonImageUrl}
+      onClick={onAppStoreButtonClick}
+      alt={iosAlt}
+    />
+    <Picture
+      className={style.img}
+      src={playStoreButtonImageUrl}
+      onClick={onPlayStoreButtonClick}
+      alt={androidAlt}
+    />
   </div>
 );
 

--- a/packages/@coorpacademy-components/src/organism/get-the-app/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/get-the-app/test/fixtures/default.js
@@ -32,6 +32,8 @@ export default {
     preMessage:
       "Cette fonctionnalité n'est pas encore activée sur votre plateform. Si vous souhaitez l'activer, contactez votre resposable RH ou",
     linkMessage: 'cliquez ici',
-    endMessage: 'et nous passerons le message'
+    endMessage: 'et nous passerons le message',
+    'android-alt': 'Link to the Coorpacademy android app',
+    'ios-alt': 'Link to the Coorpacademy ios app'
   }
 };

--- a/packages/@coorpacademy-components/src/organism/get-the-app/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/get-the-app/test/fixtures/default.js
@@ -34,6 +34,7 @@ export default {
     linkMessage: 'cliquez ici',
     endMessage: 'et nous passerons le message',
     'android-alt': 'Link to the Coorpacademy android app',
-    'ios-alt': 'Link to the Coorpacademy ios app'
+    'ios-alt': 'Link to the Coorpacademy ios app',
+    qrCodeImageAlt: 'QR code to be scanned for app connection'
   }
 };

--- a/packages/@coorpacademy-components/src/organism/mooc-footer/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-footer/index.js
@@ -7,6 +7,7 @@ import {
 } from '@coorpacademy/nova-icons';
 import Link from '../../atom/link';
 import SocialLink from '../../atom/social-link';
+import Picture from '../../atom/picture';
 import style from './style.css';
 
 const socialLinksTypes = ['facebook', 'twitter', 'linkedin', 'youtube', 'instagram'];
@@ -20,13 +21,13 @@ const StoresLinks = ({
   'ios-alt': iosAlt
 }) => (
   <div className={style.storeLinksContainer}>
-    <img
+    <Picture
       className={style.imgApple}
       src={appStoreButtonImageUrl}
       onClick={onAppStoreButtonClick}
       alt={iosAlt}
     />
-    <img
+    <Picture
       className={style.img}
       src={playStoreButtonImageUrl}
       onClick={onPlayStoreButtonClick}


### PR DESCRIPTION
[ticket](https://trello.com/c/35W9NgA8/71-mon-compte-alternative-textuelle-pour-les-img-porteuses-dinformations)
choses faites dans cette PR : 

- monCompte : alternatives textuelles pour les images (android & ios & qrCode) 
- Footer:  remplacement de img par le composant Picture + remplacement de l'image download ios : 

avant : 
![image](https://user-images.githubusercontent.com/111736786/207390886-458f5298-facf-4ebe-83ea-7d527e0546d2.png)
après : 
![image](https://user-images.githubusercontent.com/111736786/207391031-42df1e20-22ad-41ec-b936-8864676f5493.png)
