### PR TITLE
[RGAA] Player: Alternative textuelle pour les <img> porteuses d'informations

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/discipline-partners/index.js
+++ b/packages/@coorpacademy-components/src/molecule/discipline-partners/index.js
@@ -112,7 +112,8 @@ DisciplinePartners.propTypes = {
       href: PropTypes.string,
       logo: PropTypes.shape({
         src: PropTypes.string,
-        href: PropTypes.string
+        href: PropTypes.string,
+        alt: PropTypes.string
       }),
       socialLinks: PropTypes.arrayOf(PropTypes.shape(SocialLink.propTypes))
     })

--- a/packages/@coorpacademy-components/src/molecule/discipline-partners/index.js
+++ b/packages/@coorpacademy-components/src/molecule/discipline-partners/index.js
@@ -67,7 +67,7 @@ const DisciplinePartners = (props, context) => {
 
     const logoView = authorLogo ? (
       <div className={style.logoContainer}>
-        <Picture className={style.logo} src={authorLogo.src} />
+        <Picture className={style.logo} src={authorLogo.src} alt={authorLogo.alt} />
         <div className={style.arrowWrapper}>
           <ArrowDown className={style.arrow} height={14} whidth={14} />
         </div>

--- a/packages/@coorpacademy-components/src/molecule/discipline-partners/test/fixtures/more-info.js
+++ b/packages/@coorpacademy-components/src/molecule/discipline-partners/test/fixtures/more-info.js
@@ -7,7 +7,8 @@ export default {
         more: 'Author Details',
         logo: {
           src: 'https://static-staging.coorpacademy.com/upload/up/partners/1472198693277logo_elephant.png',
-          href: 'http://google.fr'
+          href: 'http://google.fr',
+          alt: "ELEPHANT's author logo"
         },
         socialLinks: [
           {
@@ -26,7 +27,8 @@ export default {
         more: 'Author Details',
         logo: {
           src: 'https://static-staging.coorpacademy.com/upload/up/partners/1472198693277logo_elephant.png',
-          href: 'http://www.nextstage.com/'
+          href: 'http://www.nextstage.com/',
+          alt: "NEXSTAGE's author logo"
         },
         socialLinks: [
           {


### PR DESCRIPTION
[ticket](https://trello.com/c/usYECP18/78-player-alternative-textuelle-pour-les-img-porteuses-dinformations)
fait dans cette PR :
-alternative textuelle pour le logo de l'auteur de la discipline (player)
