### PR TITLE
[RGAA]add alt to profile picture

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -62,6 +62,7 @@ class MoocHeader extends React.Component {
     user: PropTypes.shape({
       picture: PropTypes.string,
       'picture-aria-label': PropTypes.string,
+      profileAvatarAlt: PropTypes.string,
       href: PropTypes.string,
       notifications: PropTypes.shape({
         href: PropTypes.string,
@@ -448,7 +449,7 @@ class MoocHeader extends React.Component {
                 onClick={this.handleLinkClick}
                 aria-label={user['picture-aria-label']}
               >
-                <Picture src={user.picture} alt={user['picture-aria-label']} />
+                <Picture src={user.picture} alt={user.profileAvatarAlt} />
               </Link>
             </div>
           </div>

--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -448,7 +448,7 @@ class MoocHeader extends React.Component {
                 onClick={this.handleLinkClick}
                 aria-label={user['picture-aria-label']}
               >
-                <Picture src={user.picture} />
+                <Picture src={user.picture} alt={user['picture-aria-label']} />
               </Link>
             </div>
           </div>

--- a/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/logged-with-battle-notifications.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/logged-with-battle-notifications.js
@@ -27,7 +27,8 @@ export default {
     onResetSearch: () => console.log('onResetSearch'),
     user: {
       picture: 'https://image.freepik.com/free-icon/male-user-shadow_318-34042.jpg',
-      'picture-aria-label': 'Your picture',
+      'picture-aria-label': 'My account',
+      profileAvatarAlt: 'Your profile picture',
       notifications: {
         href: '#notifications',
         value: 5,


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
 - https://trello.com/c/RPPNQo3P/84-header-alternative-textuelle-pour-les-svg-porteuses-dinformations-stars-badge-ranking
-->

**Detailed purpose of the PR**
ajouter alternative textuelle pour la photo de profil 
<!--What existing problem does the PR solve?/
What is the current behavior? -->
<img width="268" alt="Capture d’écran 2022-12-21 à 15 14 07" src="https://user-images.githubusercontent.com/119853351/208926441-4b9a9c01-6cf2-4737-93d6-3e5662c58290.png">

