### PR TITLE
[RGAA]  add active page aria label

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -89,6 +89,7 @@ class MoocHeader extends React.Component {
     }),
     'settings-aria-label': PropTypes.string,
     'close-settings-aria-label': PropTypes.string,
+    'active-page-alt': PropTypes.string,
     settings: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string,
@@ -239,7 +240,8 @@ class MoocHeader extends React.Component {
       search,
       'search-reset-aria-label': searchResetAriaLabel,
       'settings-aria-label': settingsAriaLabel,
-      'close-settings-aria-label': closeSettingsAriaLabel
+      'close-settings-aria-label': closeSettingsAriaLabel,
+      'active-page-alt': activePageAlt
     } = this.props;
     const {isFocus, isSettingsOpen, isMenuOpen} = this.state;
     const {translate, skin} = this.context;
@@ -271,6 +273,7 @@ class MoocHeader extends React.Component {
           : null;
 
         const {'page-count-aria-label': pageCountAriaLabel} = item;
+        const itemLabel = item.selected ? `${item.title}. ${activePageAlt}` : item.title;
         const pageBadge =
           item.counter > 0 ? (
             <Link
@@ -294,7 +297,7 @@ class MoocHeader extends React.Component {
             skinHover
             onClick={this.handleLinkClick}
             target={item.target || null}
-            aria-label={item.title}
+            aria-label={itemLabel}
             style={{
               ...activeColor
             }}
@@ -317,9 +320,8 @@ class MoocHeader extends React.Component {
               color: primaryColor
             }
           : null;
-
+        const itemLabel = item.selected ? `${item.title}. ${activePageAlt}` : item.title;
         const {name: itemName = index} = item;
-
         return (
           <Link
             href={item.href}
@@ -327,7 +329,7 @@ class MoocHeader extends React.Component {
             className={style.option}
             data-name={`item-more-${itemName}`}
             target={item.target || null}
-            aria-label={item.title}
+            aria-label={itemLabel}
             onClick={this.handleLinkClick}
             skinHover
             style={{

--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -89,7 +89,7 @@ class MoocHeader extends React.Component {
     }),
     'settings-aria-label': PropTypes.string,
     'close-settings-aria-label': PropTypes.string,
-    'active-page-alt': PropTypes.string,
+    'active-page-aria-label': PropTypes.string,
     settings: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string,
@@ -241,7 +241,7 @@ class MoocHeader extends React.Component {
       'search-reset-aria-label': searchResetAriaLabel,
       'settings-aria-label': settingsAriaLabel,
       'close-settings-aria-label': closeSettingsAriaLabel,
-      'active-page-alt': activePageAlt
+      'active-page-aria-label': activePageAriaLabel
     } = this.props;
     const {isFocus, isSettingsOpen, isMenuOpen} = this.state;
     const {translate, skin} = this.context;
@@ -273,7 +273,7 @@ class MoocHeader extends React.Component {
           : null;
 
         const {'page-count-aria-label': pageCountAriaLabel} = item;
-        const itemLabel = item.selected ? `${item.title}. ${activePageAlt}` : item.title;
+        const itemLabel = item.selected ? `${item.title}. ${activePageAriaLabel}` : item.title;
         const pageBadge =
           item.counter > 0 ? (
             <Link
@@ -320,7 +320,7 @@ class MoocHeader extends React.Component {
               color: primaryColor
             }
           : null;
-        const itemLabel = item.selected ? `${item.title}. ${activePageAlt}` : item.title;
+        const itemLabel = item.selected ? `${item.title}. ${activePageAriaLabel}` : item.title;
         const {name: itemName = index} = item;
         return (
           <Link

--- a/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
@@ -108,6 +108,7 @@ export default {
     ],
     'settings-aria-label': 'account settings',
     'close-settings-aria-label': 'close account settings',
+    'active-page-alt': 'Active page',
     settings: [
       {
         title: 'Language',

--- a/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
@@ -108,7 +108,7 @@ export default {
     ],
     'settings-aria-label': 'account settings',
     'close-settings-aria-label': 'close account settings',
-    'active-page-alt': 'Active page',
+    'active-page-aria-label': 'Active page',
     settings: [
       {
         title: 'Language',


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->
ajouter une alternative textuelle pour indiquer la page active dans le menu du header
<img width="417" alt="Capture d’écran 2022-12-23 à 11 56 21" src="https://user-images.githubusercontent.com/119853351/209324823-97fa0eb9-5c05-42ee-8be1-e707cb2d1420.png">

