### PR TITLE
[RGAA]  add aria label to faq link

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-footer/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-footer/index.js
@@ -103,6 +103,7 @@ function MoocFooter(props) {
                 data-text={page.title}
                 className={style.pageLink}
                 target={page.target}
+                aria-label={page.ariaLabel ? page.ariaLabel : page.title}
                 data-name={page.title}
               >
                 {page.title}

--- a/packages/@coorpacademy-components/src/organism/mooc-footer/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-footer/index.js
@@ -190,7 +190,12 @@ MoocFooter.propTypes = {
     PropTypes.shape({
       title: PropTypes.string,
       pages: PropTypes.arrayOf(
-        PropTypes.shape({title: PropTypes.string, link: PropTypes.string, target: PropTypes.string})
+        PropTypes.shape({
+          title: PropTypes.string,
+          link: PropTypes.string,
+          target: PropTypes.string,
+          ariaLabel: PropTypes.string
+        })
       )
     })
   ),

--- a/packages/@coorpacademy-components/src/organism/mooc-footer/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-footer/test/fixtures/default.js
@@ -45,7 +45,8 @@ export default {
           {
             title: 'FAQ',
             link: 'https://www.support.coorpacademy.com/faq-users-fr',
-            target: '_self'
+            target: '_self',
+            ariaLabel: 'Access to the support page'
           },
           {
             title: 'Data privacy policy',


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
ajouter aria label pour le lien faq dans le footer de mooc

**Result and observation**
<img width="439" alt="Capture d’écran 2022-12-27 à 17 51 50" src="https://user-images.githubusercontent.com/119853351/209697618-f08d77fc-7864-4750-86e5-7088e1c45514.png">

<img width="439" alt="Capture d’écran 2022-12-27 à 17 51 13" src="https://user-images.githubusercontent.com/119853351/209697407-cbcdb941-24a1-4a31-bd96-66ea182ecec1.png">


