### PR TITLE
[RGAA][Quick Fix] : web style regression- template activity

### DIFF
--- a/packages/@coorpacademy-components/src/template/activity/stars-summary.css
+++ b/packages/@coorpacademy-components/src/template/activity/stars-summary.css
@@ -21,7 +21,6 @@
     display: flex;
     flex-direction: row;
     overflow: hidden;
-    margin-left: -40px;
 }
 
 .myStars {

--- a/packages/@coorpacademy-components/src/template/activity/stars-summary.js
+++ b/packages/@coorpacademy-components/src/template/activity/stars-summary.js
@@ -14,9 +14,9 @@ const EngineTab = ({engine, engineIndex, firstItem}) => {
   const {type} = engine;
   const state = engineIndex < firstItem ? 'hidden' : 'active';
   return (
-    <li className={style[state]} key={type} data-name={`${type}_total_${state}`}>
+    <div className={style[state]} key={type} data-name={`${type}_total_${state}`}>
       <EngineStars {...engine} className={engineIndex < firstItem ? style.hidden : style.active} />
-    </li>
+    </div>
   );
 };
 EngineTab.propTypes = {
@@ -118,9 +118,9 @@ class StarsSummary extends React.Component {
     return (
       <div data-name="myStars" className={style.myStars}>
         <div data-name="myStars-wrapper" className={style.myStarsWrapper}>
-          <ul className={style.allStars} data-name="engineList">
+          <div className={style.allStars} data-name="engineList">
             <EngineTabs engines={engines} firstItem={firstItem} />
-          </ul>
+          </div>
           <div
             className={style.footerSummaryStars}
             style={{


### PR DESCRIPTION
Trello card : 

**Detailed purpose of the PR**
Issue : stars block in web mode regression.

![Capture d’écran 2022-12-28 à 11 31 59](https://user-images.githubusercontent.com/113359769/209798630-13bbc152-ba7d-4984-816d-a4babf7f436f.png)

**Result and observation**
Div element replaced by ul in the previous PR broke some features:
![Capture d’écran 2022-12-28 à 11 35 53](https://user-images.githubusercontent.com/113359769/209799207-f487ec02-b202-474a-95d4-c3390eaa6935.png)


**TO DO**
- Quick fix by removing ul and replace by div
- Create another PR to re-replace the ul by div according to this RGAA rule : [9. Structuration de l’information](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#9)
**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
