### PR TITLE
[RGAA]Catalog, bibliothèque, classement, settings : Alternative textuelle pour les <svg> porteuses d'informations #17058

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/filters/index.js
+++ b/packages/@coorpacademy-components/src/molecule/filters/index.js
@@ -19,7 +19,9 @@ class Filters extends React.Component {
     sorting: PropTypes.shape(Select.propTypes),
     onSearch: PropTypes.func,
     onToggleFilters: PropTypes.func,
-    onToggleSorts: PropTypes.func
+    onToggleSorts: PropTypes.func,
+    moreSortAriaLabel: PropTypes.string,
+    moreFilterAriaLabel: PropTypes.string
   };
 
   static contextTypes = {
@@ -77,8 +79,16 @@ class Filters extends React.Component {
   }
 
   render() {
-    const {sorting, filterCTALabel, filterTabLabel, sortCTALabel, sortTabLabel, filters} =
-      this.props;
+    const {
+      sorting,
+      filterCTALabel,
+      filterTabLabel,
+      sortCTALabel,
+      sortTabLabel,
+      filters,
+      moreFilterAriaLabel,
+      moreSortAriaLabel
+    } = this.props;
     const {filter, sorted} = this.state;
     const {skin} = this.context;
 
@@ -104,7 +114,7 @@ class Filters extends React.Component {
           <div className={style.title} data-name="filterButton" onClick={this.handleOpenFilter}>
             {filterTabLabel}
             <div className={style.arrow}>
-              <ArrowDown color={darkColor} height={14} />
+              <ArrowDown color={darkColor} height={14} aria-label={moreFilterAriaLabel} />
             </div>
           </div>
         </div>
@@ -116,7 +126,7 @@ class Filters extends React.Component {
           <div className={style.title} data-name="sortButton" onClick={this.handleOpenSort}>
             {sortTabLabel}
             <div className={style.arrow}>
-              <ArrowDown color={darkColor} height={14} />
+              <ArrowDown color={darkColor} height={14} aria-label={moreSortAriaLabel} />
             </div>
           </div>
         </div>

--- a/packages/@coorpacademy-components/src/molecule/filters/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/filters/test/fixtures/default.js
@@ -12,6 +12,8 @@ export default {
     filterCTALabel: 'Filter',
     sortTabLabel: 'Sort by',
     sortCTALabel: 'Sort',
+    moreSortAriaLabel: 'show or hide sortBy options',
+    moreFilterAriaLabel: 'show or hide sortBy options',
     filters: [
       {
         ...selectFilter,

--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -497,14 +497,9 @@ class MoocHeader extends React.Component {
             selectProps.onChange = options.onChange;
 
             settingView = (
-              <div
-                data-name={`setting-${settingName}`}
-                className={style.setting}
-                key={settingName}
-                aria-label={ariaLabel || title}
-              >
+              <div data-name={`setting-${settingName}`} className={style.setting} key={settingName}>
                 <span className={style.label}>{title}</span>
-                <Select {...selectProps} />
+                <Select {...selectProps} moreAriaLabel={ariaLabel || title} />
               </div>
             );
             break;

--- a/packages/@coorpacademy-components/src/template/common/search-page/index.js
+++ b/packages/@coorpacademy-components/src/template/common/search-page/index.js
@@ -9,7 +9,16 @@ import CardsList from '../../../molecule/dashboard/cards-list';
 import style from './style.css';
 
 const SearchPage = (props, context) => {
-  const {title, searchFilters, cards, noresultsfound, clearFilters, recommendations} = props;
+  const {
+    title,
+    searchFilters,
+    cards,
+    noresultsfound,
+    clearFilters,
+    recommendations,
+    moreSortAriaLabel,
+    moreFilterAriaLabel
+  } = props;
 
   const {skin} = context;
   const defaultColor = getOr('#00B0FF', 'common.primary', skin);
@@ -36,7 +45,11 @@ const SearchPage = (props, context) => {
 
   return (
     <div>
-      <Filters {...searchFilters} />
+      <Filters
+        {...searchFilters}
+        moreSortAriaLabel={moreSortAriaLabel}
+        moreFilterAriaLabel={moreFilterAriaLabel}
+      />
       <div data-name="searchResult" className={style.cardsWrapper}>
         <div className={style.title}>{title}</div>
         {cardsView}
@@ -55,7 +68,9 @@ SearchPage.propTypes = {
   searchFilters: PropTypes.shape(Filters.propTypes),
   cards: PropTypes.shape(CardsGrid.propTypes),
   clearFilters: PropTypes.shape(Button.propTypes),
-  recommendations: PropTypes.shape(CardsList.propTypes)
+  recommendations: PropTypes.shape(CardsList.propTypes),
+  moreSortAriaLabel: PropTypes.string,
+  moreFilterAriaLabel: PropTypes.string
 };
 
 export default SearchPage;

--- a/packages/@coorpacademy-components/src/template/common/search-page/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/template/common/search-page/test/fixtures/default.js
@@ -11,6 +11,8 @@ export default {
     searchFilters: defaultsDeep(searchFilters, {
       openFilters: true
     }),
-    cards
+    cards,
+    moreSortAriaLabel: 'show or hide sortBy options',
+    moreFilterAriaLabel: 'show or hide sortBy options'
   }
 };


### PR DESCRIPTION
[ticket](https://trello.com/c/Zxs5cTAh/112-catalog-alternative-textuelle-pour-les-svg-porteuses-dinformations)
add moreSortAriaLabel and moreFilterAriaLabel