### PR TITLE
[RGAA] refacto <div> element to <ul> in Stars box in template activity

### DIFF
--- a/packages/@coorpacademy-components/src/template/activity/stars-summary.css
+++ b/packages/@coorpacademy-components/src/template/activity/stars-summary.css
@@ -21,6 +21,8 @@
     display: flex;
     flex-direction: row;
     overflow: hidden;
+    margin: auto;
+    padding-left: 0;
 }
 
 .myStars {

--- a/packages/@coorpacademy-components/src/template/activity/stars-summary.js
+++ b/packages/@coorpacademy-components/src/template/activity/stars-summary.js
@@ -14,9 +14,9 @@ const EngineTab = ({engine, engineIndex, firstItem}) => {
   const {type} = engine;
   const state = engineIndex < firstItem ? 'hidden' : 'active';
   return (
-    <div className={style[state]} key={type} data-name={`${type}_total_${state}`}>
+    <li className={style[state]} key={type} data-name={`${type}_total_${state}`}>
       <EngineStars {...engine} className={engineIndex < firstItem ? style.hidden : style.active} />
-    </div>
+    </li>
   );
 };
 EngineTab.propTypes = {
@@ -118,9 +118,9 @@ class StarsSummary extends React.Component {
     return (
       <div data-name="myStars" className={style.myStars}>
         <div data-name="myStars-wrapper" className={style.myStarsWrapper}>
-          <div className={style.allStars} data-name="engineList">
+          <ul className={style.allStars} data-name="engineList">
             <EngineTabs engines={engines} firstItem={firstItem} />
-          </div>
+          </ul>
           <div
             className={style.footerSummaryStars}
             style={{


### PR DESCRIPTION
Final part of this trello card : [Dans chaque page web, le contenu proposé est-il consultable quelle que soit l’orientation de l’écran (portait ou paysage) (hors cas particuliers) ?](https://trello.com/c/Dm9dlTHe/14-dans-chaque-page-web-le-contenu-propos%C3%A9-est-il-consultable-quelle-que-soit-lorientation-de-l%C3%A9cran-portait-ou-paysage-hors-cas-pa)

**Detailed purpose of the PR**
Change the div element to ul to match [this RGAA rule](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#9) about list in template activity.

**Result and observation**
### Mobile version
![Capture d’écran 2022-12-28 à 15 26 00](https://user-images.githubusercontent.com/113359769/209826807-a87828a1-d797-47ad-8951-e04b034e61ab.png)


### Web version
![Capture d’écran 2022-12-28 à 15 24 36](https://user-images.githubusercontent.com/113359769/209826730-39a7e387-760a-49ca-8934-a4d54a1d6ef4.png)


**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
