### PR TITLE
[RGAA]  add aria label to dashboard button

### DIFF
--- a/packages/@coorpacademy-components/src/atom/button/index.js
+++ b/packages/@coorpacademy-components/src/atom/button/index.js
@@ -9,6 +9,7 @@ const ButtonContent = props => {
   const {
     color,
     submitValue,
+    submitAriaLabel,
     disabled,
     download,
     href,
@@ -35,6 +36,7 @@ const ButtonContent = props => {
           onClick={anchorOnClick}
           target={target}
           className={anchorClassName}
+          aria-label={submitAriaLabel}
           style={style}
         >
           {submitValue || children || 'submit'}
@@ -76,6 +78,7 @@ const ButtonContent = props => {
 ButtonContent.propTypes = {
   color: ColorPropType,
   submitValue: PropTypes.string,
+  submitAriaLabel: PropTypes.string,
   disabled: PropTypes.bool,
   href: PropTypes.string,
   download: PropTypes.bool,

--- a/packages/@coorpacademy-components/src/atom/button/index.js
+++ b/packages/@coorpacademy-components/src/atom/button/index.js
@@ -9,7 +9,7 @@ const ButtonContent = props => {
   const {
     color,
     submitValue,
-    submitAriaLabel,
+    'aria-label': submitAriaLabel,
     disabled,
     download,
     href,
@@ -78,7 +78,7 @@ const ButtonContent = props => {
 ButtonContent.propTypes = {
   color: ColorPropType,
   submitValue: PropTypes.string,
-  submitAriaLabel: PropTypes.string,
+  'aria-label': PropTypes.string,
   disabled: PropTypes.bool,
   href: PropTypes.string,
   download: PropTypes.bool,

--- a/packages/@coorpacademy-components/src/atom/cta/index.js
+++ b/packages/@coorpacademy-components/src/atom/cta/index.js
@@ -11,6 +11,7 @@ import style from './style.css';
 class CTA extends React.Component {
   static propTypes = {
     submitValue: Link.propTypes.children,
+    submitAriaLabel: Link.propTypes.children,
     href: Link.propTypes.href,
     onClick: Link.propTypes.onClick,
     target: Link.propTypes.target,
@@ -96,6 +97,7 @@ class CTA extends React.Component {
   render() {
     const {
       submitValue = 'submit',
+      submitAriaLabel,
       name: ctaName,
       href,
       target,
@@ -117,6 +119,7 @@ class CTA extends React.Component {
         onClick={disabled ? noop : onClick}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
+        aria-label={submitAriaLabel}
         target={target}
         className={classnames(
           style.button,

--- a/packages/@coorpacademy-components/src/atom/cta/index.js
+++ b/packages/@coorpacademy-components/src/atom/cta/index.js
@@ -11,7 +11,7 @@ import style from './style.css';
 class CTA extends React.Component {
   static propTypes = {
     submitValue: Link.propTypes.children,
-    submitAriaLabel: Link.propTypes.children,
+    'aria-label': PropTypes.string,
     href: Link.propTypes.href,
     onClick: Link.propTypes.onClick,
     target: Link.propTypes.target,
@@ -97,7 +97,7 @@ class CTA extends React.Component {
   render() {
     const {
       submitValue = 'submit',
-      submitAriaLabel,
+      'aria-label': submitAriaLabel,
       name: ctaName,
       href,
       target,

--- a/packages/@coorpacademy-components/src/molecule/card-content/test/fixtures/arabic-hero.js
+++ b/packages/@coorpacademy-components/src/molecule/card-content/test/fixtures/arabic-hero.js
@@ -6,6 +6,7 @@ export default {
     author: 'Coorpcademy',
     title: '<p align="right"> وضع الناء كانت تصاميم مطبوعه</p>',
     submitValue: 'Continue',
+    ariaLabel: 'Continue. Continue course',
     progress: 0.67,
     onClick: () => console.log('card-content.hero.onclick')
   }

--- a/packages/@coorpacademy-components/src/molecule/card-content/test/fixtures/hero.js
+++ b/packages/@coorpacademy-components/src/molecule/card-content/test/fixtures/hero.js
@@ -6,7 +6,7 @@ export default {
     author: 'Coorpcademy',
     title: 'From Mass Market to One to One targeting',
     submitValue: 'Continue',
-    submitAriaLabel: 'Continue. Continue course',
+    'aria-label': 'Continue. Continue course',
     progress: 0.67,
     onClick: () => console.log('card-content.hero.onclick')
   }

--- a/packages/@coorpacademy-components/src/molecule/card-content/test/fixtures/hero.js
+++ b/packages/@coorpacademy-components/src/molecule/card-content/test/fixtures/hero.js
@@ -6,6 +6,7 @@ export default {
     author: 'Coorpcademy',
     title: 'From Mass Market to One to One targeting',
     submitValue: 'Continue',
+    submitAriaLabel: 'Continue. Continue course',
     progress: 0.67,
     onClick: () => console.log('card-content.hero.onclick')
   }

--- a/packages/@coorpacademy-components/src/molecule/card-content/test/fixtures/hero.js
+++ b/packages/@coorpacademy-components/src/molecule/card-content/test/fixtures/hero.js
@@ -6,7 +6,7 @@ export default {
     author: 'Coorpcademy',
     title: 'From Mass Market to One to One targeting',
     submitValue: 'Continue',
-    'aria-label': 'Continue. Continue course',
+    ariaLabel: 'Continue. Continue course',
     progress: 0.67,
     onClick: () => console.log('card-content.hero.onclick')
   }

--- a/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/index.js
@@ -9,8 +9,14 @@ import Link from '../../../atom/link';
 import style from './style.css';
 
 const StartBattle = React.memo(function StartBattle(props) {
-  const {startBattleText, becomeAChampionText, challengeText, onClick, href, startBattleAriaLabel} =
-    props;
+  const {
+    startBattleText,
+    becomeAChampionText,
+    challengeText,
+    onClick,
+    href,
+    'aria-label': startBattleAriaLabel
+  } = props;
 
   return (
     <div className={style.root} data-name="start-battle">
@@ -58,7 +64,7 @@ StartBattle.propTypes = {
   challengeText: PropTypes.string,
   onClick: PropTypes.func,
   href: PropTypes.string,
-  startBattleAriaLabel: PropTypes.string
+  'aria-label': PropTypes.string
 };
 
 export default StartBattle;

--- a/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/index.js
@@ -9,7 +9,8 @@ import Link from '../../../atom/link';
 import style from './style.css';
 
 const StartBattle = React.memo(function StartBattle(props) {
-  const {startBattleText, becomeAChampionText, challengeText, onClick, href} = props;
+  const {startBattleText, becomeAChampionText, challengeText, onClick, href, startBattleAriaLabel} =
+    props;
 
   return (
     <div className={style.root} data-name="start-battle">
@@ -27,7 +28,12 @@ const StartBattle = React.memo(function StartBattle(props) {
                 <FlashRight className={style.smallFlashRightMobile} />
               </div>
               <div className={style.challengeText}>{challengeText}</div>
-              <Link className={style.button} onClick={onClick} href={href}>
+              <Link
+                className={style.button}
+                onClick={onClick}
+                href={href}
+                aria-label={startBattleAriaLabel}
+              >
                 {startBattleText}
               </Link>
             </div>
@@ -51,7 +57,8 @@ StartBattle.propTypes = {
   becomeAChampionText: PropTypes.string,
   challengeText: PropTypes.string,
   onClick: PropTypes.func,
-  href: PropTypes.string
+  href: PropTypes.string,
+  startBattleAriaLabel: PropTypes.string
 };
 
 export default StartBattle;

--- a/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/test/fixtures/default.js
@@ -1,7 +1,7 @@
 export default {
   props: {
     startBattleText: 'Create a battle',
-    startBattleAriaLabel: 'Create a battle. Go to the battles page',
+    'aria-label': 'Create a battle. Go to the battles page',
     becomeAChampionText: 'Become A Champion',
     challengeText: 'Challenge your colleagues',
     onClick: () => {}

--- a/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/test/fixtures/default.js
@@ -1,6 +1,7 @@
 export default {
   props: {
     startBattleText: 'Create a battle',
+    startBattleAriaLabel: 'Create a battle. Go to the battles page',
     becomeAChampionText: 'Become A Champion',
     challengeText: 'Challenge your colleagues',
     onClick: () => {}

--- a/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/test/fixtures/href.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/test/fixtures/href.js
@@ -1,7 +1,7 @@
 export default {
   props: {
     startBattleText: 'Create a battle',
-    startBattleAriaLabel: 'Create a battle. Go to the battles page',
+    'aria-label': 'Create a battle. Go to the battles page',
     becomeAChampionText: 'become A Champion',
     challengeText: 'Challenge your colleagues',
     href: '#'

--- a/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/test/fixtures/href.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/start-battle/test/fixtures/href.js
@@ -1,6 +1,7 @@
 export default {
   props: {
     startBattleText: 'Create a battle',
+    startBattleAriaLabel: 'Create a battle. Go to the battles page',
     becomeAChampionText: 'become A Champion',
     challengeText: 'Challenge your colleagues',
     href: '#'

--- a/packages/@coorpacademy-components/src/molecule/hero/index.js
+++ b/packages/@coorpacademy-components/src/molecule/hero/index.js
@@ -33,7 +33,7 @@ const Hero = (props, context) => {
           data-name="hero-button"
           onClick={onClick}
           submitValue={submitValue}
-          submitAriaLabel={submitAriaLabel}
+          aria-label={submitAriaLabel}
           className={style.heroButton}
           style={{backgroundColor: primaryColor}}
         />
@@ -53,7 +53,7 @@ Hero.propTypes = {
   progress: CardContentInfo.propTypes.progress,
   onClick: Button.propTypes.onClick,
   submitValue: Button.propTypes.submitValue,
-  submitAriaLabel: Button.propTypes.submitAriaLabel
+  submitAriaLabel: PropTypes.string
 };
 
 export default Hero;

--- a/packages/@coorpacademy-components/src/molecule/hero/index.js
+++ b/packages/@coorpacademy-components/src/molecule/hero/index.js
@@ -9,7 +9,15 @@ import style from './style.css';
 
 const Hero = (props, context) => {
   const {skin} = context;
-  const {image, title, author, progress, onClick, submitValue, submitAriaLabel} = props;
+  const {
+    image,
+    title,
+    author,
+    progress,
+    onClick,
+    submitValue,
+    'aria-label': submitAriaLabel
+  } = props;
 
   const primaryColor = get('common.primary', skin);
   const cardStyle = classnames(style.hero, title ? null : style.lazy);
@@ -53,7 +61,7 @@ Hero.propTypes = {
   progress: CardContentInfo.propTypes.progress,
   onClick: Button.propTypes.onClick,
   submitValue: Button.propTypes.submitValue,
-  submitAriaLabel: PropTypes.string
+  'aria-label': PropTypes.string
 };
 
 export default Hero;

--- a/packages/@coorpacademy-components/src/molecule/hero/index.js
+++ b/packages/@coorpacademy-components/src/molecule/hero/index.js
@@ -9,15 +9,7 @@ import style from './style.css';
 
 const Hero = (props, context) => {
   const {skin} = context;
-  const {
-    image,
-    title,
-    author,
-    progress,
-    onClick,
-    submitValue,
-    'aria-label': submitAriaLabel
-  } = props;
+  const {image, title, author, progress, onClick, submitValue, ariaLabel} = props;
 
   const primaryColor = get('common.primary', skin);
   const cardStyle = classnames(style.hero, title ? null : style.lazy);
@@ -41,7 +33,7 @@ const Hero = (props, context) => {
           data-name="hero-button"
           onClick={onClick}
           submitValue={submitValue}
-          aria-label={submitAriaLabel}
+          aria-label={ariaLabel}
           className={style.heroButton}
           style={{backgroundColor: primaryColor}}
         />
@@ -61,7 +53,7 @@ Hero.propTypes = {
   progress: CardContentInfo.propTypes.progress,
   onClick: Button.propTypes.onClick,
   submitValue: Button.propTypes.submitValue,
-  'aria-label': PropTypes.string
+  ariaLabel: PropTypes.string
 };
 
 export default Hero;

--- a/packages/@coorpacademy-components/src/molecule/hero/index.js
+++ b/packages/@coorpacademy-components/src/molecule/hero/index.js
@@ -9,7 +9,7 @@ import style from './style.css';
 
 const Hero = (props, context) => {
   const {skin} = context;
-  const {image, title, author, progress, onClick, submitValue} = props;
+  const {image, title, author, progress, onClick, submitValue, submitAriaLabel} = props;
 
   const primaryColor = get('common.primary', skin);
   const cardStyle = classnames(style.hero, title ? null : style.lazy);
@@ -33,6 +33,7 @@ const Hero = (props, context) => {
           data-name="hero-button"
           onClick={onClick}
           submitValue={submitValue}
+          submitAriaLabel={submitAriaLabel}
           className={style.heroButton}
           style={{backgroundColor: primaryColor}}
         />
@@ -51,7 +52,8 @@ Hero.propTypes = {
   author: CardContentInfo.propTypes.author,
   progress: CardContentInfo.propTypes.progress,
   onClick: Button.propTypes.onClick,
-  submitValue: Button.propTypes.submitValue
+  submitValue: Button.propTypes.submitValue,
+  submitAriaLabel: Button.propTypes.submitAriaLabel
 };
 
 export default Hero;

--- a/packages/@coorpacademy-components/src/molecule/news/test/fixtures/arabic.js
+++ b/packages/@coorpacademy-components/src/molecule/news/test/fixtures/arabic.js
@@ -8,7 +8,8 @@ export default {
     authorLogo:
       'https://static.coorpacademy.com/content/digital/raw/logo_coorpacademy-1487689750995.svg',
     cta: {
-      submitValue: 'Read more',
+      submitValue: 'More',
+      submitAriaLabel: 'More. see more news',
       href: '#',
       small: true,
       target: '_blank'

--- a/packages/@coorpacademy-components/src/molecule/news/test/fixtures/arabic.js
+++ b/packages/@coorpacademy-components/src/molecule/news/test/fixtures/arabic.js
@@ -9,7 +9,7 @@ export default {
       'https://static.coorpacademy.com/content/digital/raw/logo_coorpacademy-1487689750995.svg',
     cta: {
       submitValue: 'More',
-      submitAriaLabel: 'More. see more news',
+      'aria-label': 'More. see more news',
       href: '#',
       small: true,
       target: '_blank'

--- a/packages/@coorpacademy-components/src/molecule/news/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/news/test/fixtures/default.js
@@ -7,7 +7,8 @@ export default {
     authorLogo:
       'https://static.coorpacademy.com/content/digital/raw/logo_coorpacademy-1487689750995.svg',
     cta: {
-      submitValue: 'Read more',
+      submitValue: 'More',
+      submitAriaLabel: 'More. see more news',
       href: '#',
       small: true,
       target: '_blank'

--- a/packages/@coorpacademy-components/src/molecule/news/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/news/test/fixtures/default.js
@@ -8,7 +8,7 @@ export default {
       'https://static.coorpacademy.com/content/digital/raw/logo_coorpacademy-1487689750995.svg',
     cta: {
       submitValue: 'More',
-      submitAriaLabel: 'More. see more news',
+      'aria-label': 'More. see more news',
       href: '#',
       small: true,
       target: '_blank'


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
Ajouter des aria labels pour les boutons de dashboard
<img width="340" alt="Capture d’écran 2023-01-03 à 16 45 53" src="https://user-images.githubusercontent.com/119853351/210394091-50082bd4-911c-4518-96a2-d2cf17f397ea.png">
<img width="579" alt="Capture d’écran 2023-01-03 à 16 46 09" src="https://user-images.githubusercontent.com/119853351/210394254-cf0aee4d-c37a-4746-8efd-7ce7e82d2c9d.png">
<img width="515" alt="Capture d’écran 2023-01-03 à 16 46 23" src="https://user-images.githubusercontent.com/119853351/210394305-179af988-2800-4aa4-bb58-c09cbd4154b3.png">
<img width="577" alt="Capture d’écran 2023-01-03 à 16 46 50" src="https://user-images.githubusercontent.com/119853351/210394363-cb035fc1-56c5-4d2a-9f0a-13cb011a7d03.png">
<img width="848" alt="Capture d’écran 2023-01-03 à 16 47 05" src="https://user-images.githubusercontent.com/119853351/210394416-ffa13cf6-e045-4258-b715-8cea204490d6.png">
<img width="608" alt="Capture d’écran 2023-01-03 à 16 47 34" src="https://user-images.githubusercontent.com/119853351/210394460-985322bf-612d-4c5a-a5ed-b56d34a67841.png">



