### PR TITLE
[R&D] Remove Lottie ie11 backup

### DIFF
--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -68,8 +68,7 @@ const buildConfettiAnimation = (translate: Translate): LottieAnimationProps => (
   autoplay: true,
   rendererSettings: {
     hideOnTransparent: false
-  },
-  ie11ImageBackup: 'https://static-staging.coorpacademy.com/animations/review/conffeti_congrats.svg'
+  }
 });
 
 export const initialState: SlidesStack = {
@@ -325,9 +324,7 @@ const buildRankCard = (rank: number, translate: Translate): CongratsCardProps =>
       'data-name': 'default-lottie',
       animationSrc: 'https://static-staging.coorpacademy.com/animations/review/rank.json',
       loop: true,
-      autoplay: true,
-      ie11ImageBackup:
-        'https://static-staging.coorpacademy.com/animations/review/rank_icon_congrats.svg'
+      autoplay: true
     },
     cardType: 'card-rank',
     iconAriaLabel: 'Image without information',
@@ -361,9 +358,7 @@ const buildCongratsProps = (
       autoplay: undefined,
       rendererSettings: {
         hideOnTransparent: false
-      },
-      ie11ImageBackup:
-        'https://static-staging.coorpacademy.com/animations/review/stars_icon_congrats.svg'
+      }
     },
     iconAriaLabel: 'Image without information',
     className: undefined,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -1168,8 +1168,6 @@ test('should verify props showing congrats', t => {
         'aria-label': '__New rank animation',
         autoplay: true,
         'data-name': 'default-lottie',
-        ie11ImageBackup:
-          'https://static-staging.coorpacademy.com/animations/review/rank_icon_congrats.svg',
         loop: true
       },
       rankSuffix: 'th',
@@ -1191,8 +1189,6 @@ test('should verify props showing congrats', t => {
         autoplay: undefined,
         className: undefined,
         'data-name': 'default-lottie',
-        ie11ImageBackup:
-          'https://static-staging.coorpacademy.com/animations/review/stars_icon_congrats.svg',
         loop: false,
         rendererSettings: {
           hideOnTransparent: false
@@ -1314,8 +1310,6 @@ test('should verify props showing congrats, with only stars card, if user has no
         autoplay: undefined,
         className: undefined,
         'data-name': 'default-lottie',
-        ie11ImageBackup:
-          'https://static-staging.coorpacademy.com/animations/review/stars_icon_congrats.svg',
         loop: false,
         rendererSettings: {
           hideOnTransparent: false

--- a/packages/@coorpacademy-components/package.json
+++ b/packages/@coorpacademy-components/package.json
@@ -131,6 +131,7 @@
     "color": "^4.2.3",
     "concurrently": "^7.4.0",
     "cross-env": "^7.0.3",
+    "delay": "5.0.0",
     "enzyme": "^3.11.0",
     "eslint": "^7.3.1",
     "eventsource-polyfill": "^0.9.6",

--- a/packages/@coorpacademy-components/src/atom/lottie-wrapper/index.js
+++ b/packages/@coorpacademy-components/src/atom/lottie-wrapper/index.js
@@ -1,24 +1,12 @@
 import React, {useMemo, useRef, useEffect, useState} from 'react';
 import classnames from 'classnames';
 import lottie from 'lottie-web';
-import get from 'lodash/fp/get';
-import has from 'lodash/fp/has';
 import includes from 'lodash/fp/includes';
 import keys from 'lodash/fp/keys';
 import omit from 'lodash/fp/omit';
 import unfetch from 'isomorphic-unfetch';
 import style from './style.css';
 import propTypes, {ANIMATION_CONTROL} from './prop-types';
-
-const isIE11 = () => {
-  if (typeof window === 'undefined') return;
-  const userAgent = get('navigator.userAgent', window);
-  const hasMsCrypto = has('msCrypto', window);
-  const hasRevision = includes('rv:', userAgent);
-  const hasTrident = includes('Trident/', userAgent);
-
-  return hasMsCrypto || (hasRevision && hasTrident);
-};
 
 export const fetchAndLoadAnimation = async (
   _lottie,
@@ -67,8 +55,6 @@ const LottieWrapper = props => {
     rendererSettings = {},
     width,
     height,
-    ie11ImageBackup,
-    backupImageClassName,
     autoplay = true,
     animationControl
   } = props;
@@ -82,18 +68,11 @@ const LottieWrapper = props => {
 
   const [isAnimationVisible, setIsAnimationVisible] = useState(autoplay);
 
-  const _isIE11 = useMemo(() => isIE11(), []);
-
   const wrapperClassName = useMemo(() => classnames(className, style.lottieContainer), [className]);
 
   const lottieAnimationClassName = useMemo(
     () => classnames(animationClassName, style.animation),
     [animationClassName]
-  );
-
-  const ie11BackupImageClassName = useMemo(
-    () => classnames(backupImageClassName, style.backupImage),
-    [backupImageClassName]
   );
 
   useEffect(() => {
@@ -109,7 +88,8 @@ const LottieWrapper = props => {
 
   useEffect(() => {
     const loadAnimation = async () => {
-      if (!_isIE11 && !animationItem) {
+      /* istanbul ignore else */
+      if (!animationItem) {
         /* istanbul ignore else */
         if (typeof window !== 'undefined') {
           window.lottie = lottie;
@@ -138,7 +118,6 @@ const LottieWrapper = props => {
     hideOnTransparent,
     loop,
     animationSrc,
-    _isIE11,
     animationItem,
     autoplay
   ]);
@@ -171,15 +150,7 @@ const LottieWrapper = props => {
         opacity: isAnimationVisible ? 1 : 0,
         transition: 'opacity 0.25s ease-in'
       }}
-    >
-      {_isIE11 ? (
-        <img
-          src={ie11ImageBackup}
-          className={ie11BackupImageClassName}
-          data-name="ie11-backup-image"
-        />
-      ) : null}
-    </div>
+    />
   );
 };
 

--- a/packages/@coorpacademy-components/src/atom/lottie-wrapper/index.js
+++ b/packages/@coorpacademy-components/src/atom/lottie-wrapper/index.js
@@ -79,7 +79,11 @@ const LottieWrapper = props => {
     // enzyme does not handle well the state update after an async useEffect in tests
     // to remove when the migration towards @testing-library/react is done
     /* istanbul ignore next */
-    if (includes(animationControl, keys(omit('loading', ANIMATION_CONTROL))) && !autoplay) {
+    if (
+      containerRef.current &&
+      includes(animationControl, keys(omit('loading', ANIMATION_CONTROL))) &&
+      !autoplay
+    ) {
       setIsAnimationVisible(true);
       if (animationItem) animationItem[animationControl]();
       if (animationControl === ANIMATION_CONTROL.stop) setIsAnimationVisible(false);
@@ -105,13 +109,15 @@ const LottieWrapper = props => {
           autoplay
         );
 
-        /* istanbul ignore next */
-        setAnimationItem(animation);
+        containerRef.current && setAnimationItem(animation);
       }
     };
 
     loadAnimation();
-    return () => animationItem && /* istanbul ignore next */ lottie.destroy(animationItem.name);
+    return () => {
+      containerRef.current = false;
+      return animationItem && /* istanbul ignore next */ lottie.destroy(animationItem.name);
+    };
   }, [
     lottieAnimationClassName,
     containerRef,

--- a/packages/@coorpacademy-components/src/atom/lottie-wrapper/prop-types.ts
+++ b/packages/@coorpacademy-components/src/atom/lottie-wrapper/prop-types.ts
@@ -13,8 +13,6 @@ export type LottieAnimationProps = {
   height?: number;
   width?: number;
   className?: string;
-  ie11ImageBackup: string;
-  backupImageClassName?: string;
   autoplay?: boolean;
   animationControl?: 'play' | 'pause' | 'stop' | 'loading';
 };
@@ -38,8 +36,6 @@ const propTypes = {
   height: PropTypes.number,
   width: PropTypes.number,
   className: PropTypes.string,
-  ie11ImageBackup: PropTypes.string.isRequired,
-  backupImageClassName: PropTypes.string,
   autoplay: PropTypes.bool,
   animationControl: PropTypes.oneOf(keys(ANIMATION_CONTROL))
 };

--- a/packages/@coorpacademy-components/src/atom/lottie-wrapper/style.css
+++ b/packages/@coorpacademy-components/src/atom/lottie-wrapper/style.css
@@ -8,8 +8,3 @@
   height: 100%;
   width: 100%;
 }
-
-.backupImage {
-  height: 100%;
-  width: 100%;
-}

--- a/packages/@coorpacademy-components/src/atom/lottie-wrapper/test/fixtures/confetti.js
+++ b/packages/@coorpacademy-components/src/atom/lottie-wrapper/test/fixtures/confetti.js
@@ -12,8 +12,6 @@ export default {
     },
     height: 600,
     width: 1000,
-    ie11ImageBackup:
-      'https://static-staging.coorpacademy.com/animations/review/conffeti_congrats.svg',
     animationControl: undefined
   }
 };

--- a/packages/@coorpacademy-components/src/atom/lottie-wrapper/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/atom/lottie-wrapper/test/fixtures/default.js
@@ -12,8 +12,6 @@ export default {
     },
     height: 200,
     width: 200,
-    ie11ImageBackup:
-      'https://static-staging.coorpacademy.com/animations/review/stars_icon_congrats.svg',
     animationControl: undefined
   }
 };

--- a/packages/@coorpacademy-components/src/atom/lottie-wrapper/test/fixtures/rank.js
+++ b/packages/@coorpacademy-components/src/atom/lottie-wrapper/test/fixtures/rank.js
@@ -7,8 +7,6 @@ export default {
     autoplay: true,
     height: 200,
     width: 200,
-    ie11ImageBackup:
-      'https://static-staging.coorpacademy.com/animations/review/rank_icon_congrats.svg',
     animationControl: undefined
   }
 };

--- a/packages/@coorpacademy-components/src/atom/lottie-wrapper/test/lottie.js
+++ b/packages/@coorpacademy-components/src/atom/lottie-wrapper/test/lottie.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import browserEnv from 'browser-env';
 import React from 'react';
+import delay from 'delay';
 import {render, cleanup} from '@testing-library/react';
 import LottieWrapper, {fetchAndLoadAnimation} from '..';
 import starFixture from './fixtures/default';
@@ -10,16 +11,17 @@ browserEnv();
 
 test.afterEach(cleanup);
 
-test('should update && load the animation, should clean up after unmount', t => {
+test('should update && load the animation, should clean up after unmount', async t => {
   const {container, rerender, unmount} = render(<LottieWrapper {...starFixture.props} />);
+
+  await delay(500);
 
   rerender(<LottieWrapper {...starFixture.props} />);
 
+  await delay(500);
+
   const wrapper = container.querySelectorAll('[data-name="default-lottie"]');
   t.truthy(wrapper);
-
-  const backupImage = wrapper[0].querySelector('[data-name="ie11-backup-image"]');
-  t.falsy(backupImage);
 
   unmount();
 
@@ -38,58 +40,6 @@ test('lottie controls: should update && load the animation, should clean up afte
   const wrapper = container.querySelectorAll('[data-name="default-lottie"]');
   t.truthy(wrapper);
 
-  const backupImage = wrapper[0].querySelector('[data-name="ie11-backup-image"]');
-  t.falsy(backupImage);
-  unmount();
-
-  t.pass();
-});
-
-test('ie11: should load an image in place of the animation', t => {
-  window.msCrypto = () => {};
-  // eslint-disable-next-line lodash-fp/prefer-constant
-  window.navigator.__defineGetter__('userAgent', function () {
-    return 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
-  });
-
-  const {container, rerender, unmount} = render(<LottieWrapper {...starFixture.props} />);
-
-  rerender(<LottieWrapper {...starFixture.props} />);
-  const wrapper = container.querySelectorAll('[data-name="default-lottie"]');
-  t.truthy(wrapper);
-
-  const backupImage = wrapper[0].querySelector('[data-name="ie11-backup-image"]');
-  t.truthy(backupImage);
-
-  delete window.msCrypto;
-  // eslint-disable-next-line lodash-fp/prefer-constant
-  window.navigator.__defineGetter__('userAgent', function () {
-    return 'Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/13.2.0';
-  });
-  unmount();
-
-  t.pass();
-});
-
-test('other browser: should not load an image in place of the animation', t => {
-  // eslint-disable-next-line lodash-fp/prefer-constant
-  window.navigator.__defineGetter__('userAgent', function () {
-    return 'Mozilla/5.0 (other stuff; rv:77.0) like Gecko';
-  });
-
-  const {container, rerender, unmount} = render(<LottieWrapper {...starFixture.props} />);
-
-  rerender(<LottieWrapper {...starFixture.props} />);
-  const wrapper = container.querySelectorAll('[data-name="default-lottie"]');
-  t.truthy(wrapper);
-
-  const backupImage = wrapper[0].querySelector('[data-name="ie11-backup-image"]');
-  t.falsy(backupImage);
-
-  // eslint-disable-next-line lodash-fp/prefer-constant
-  window.navigator.__defineGetter__('userAgent', function () {
-    return 'Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/13.2.0';
-  });
   unmount();
 
   t.pass();

--- a/packages/@coorpacademy-components/src/atom/lottie-wrapper/test/lottie.js
+++ b/packages/@coorpacademy-components/src/atom/lottie-wrapper/test/lottie.js
@@ -12,7 +12,7 @@ browserEnv();
 test.afterEach(cleanup);
 
 test('should update && load the animation, should clean up after unmount', async t => {
-  const {container, rerender, unmount} = render(<LottieWrapper {...starFixture.props} />);
+  const {container, rerender} = render(<LottieWrapper {...starFixture.props} />);
 
   await delay(500);
 
@@ -22,8 +22,6 @@ test('should update && load the animation, should clean up after unmount', async
 
   const wrapper = container.querySelectorAll('[data-name="default-lottie"]');
   t.truthy(wrapper);
-
-  unmount();
 
   t.pass();
 });

--- a/packages/@coorpacademy-components/src/template/app-player/popin-end/summary.js
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-end/summary.js
@@ -264,8 +264,6 @@ const BackgroundScorm = props => {
                   hideOnTransparent: false,
                   animationClassName: ''
                 },
-                ie11ImageBackup:
-                  'https://static-staging.coorpacademy.com/animations/review/conffeti_congrats.svg',
                 animationControl: undefined
               }}
               loop={false}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8114,6 +8114,11 @@ del@^6.1.1:
     rimraf "^3.0.2"
     slash "^3.0.0"
 
+delay@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
+  integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"


### PR DESCRIPTION
**Detailed purpose of the PR**

- Removes Lottie ie11 backup (no more backup image), this makes Lottie component lighter.

- [x] Already covered by tests
