### PR TITLE
[RGAA] Information icon reviewable skill keyboard events

### DIFF
--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -50,7 +50,8 @@ const ToolTip = ({tooltipText, 'aria-label': moreDetailsAriaLabel, 'data-testid'
   };
   return (
     <div className={style.tooltipContainer}>
-      <div
+      <button
+        type="button"
         className={style.tooltipIconContainer}
         data-testid={dataTestId}
         onMouseOver={handleMouseOver}
@@ -64,7 +65,7 @@ const ToolTip = ({tooltipText, 'aria-label': moreDetailsAriaLabel, 'data-testid'
           height={12}
           aria-label={moreDetailsAriaLabel}
         />
-      </div>
+      </button>
       {toolTipIsVisible ? (
         <div
           className={style.toolTip}

--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -46,21 +46,29 @@ const ToolTip = ({
     },
     [setToolTipIsVisible, toolTipIsVisible]
   );
-  const handleMouseOver = useCallback(() => setToolTipIsVisible(true), [setToolTipIsVisible]);
+  const handleMouseOver = useCallback(() => {
+    setToolTipIsVisible(true);
+  }, [setToolTipIsVisible]);
 
-  const handleMouseLeave = useCallback(() => setToolTipIsVisible(false), [setToolTipIsVisible]);
+  const handleMouseLeave = useCallback(() => {
+    setToolTipIsVisible(false);
+  }, [setToolTipIsVisible]);
+
   const customStyle = {
     visibility: toolTipIsVisible ? 'visible' : 'hidden',
     opacity: toolTipIsVisible ? 1 : 0
   };
+
   return (
-    <div className={style.tooltipContainer}>
+    <div
+      className={style.tooltipContainer}
+      onMouseLeave={handleMouseLeave}
+      onMouseOver={handleMouseOver}
+    >
       <button
         type="button"
         className={style.tooltipIconContainer}
         data-testid={dataTestId}
-        onMouseOver={handleMouseOver}
-        onMouseLeave={handleMouseLeave}
         onKeyDown={handleKeyPress}
         tabIndex={0}
       >

--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -29,7 +29,12 @@ const ReviewIcon = ({icon}) => {
   return <Icon className={style.labelIcon} />;
 };
 
-const ToolTip = ({tooltipText, 'aria-label': moreDetailsAriaLabel, 'data-testid': dataTestId}) => {
+const ToolTip = ({
+  tooltipText,
+  'aria-label': moreDetailsAriaLabel,
+  'data-testid': dataTestId,
+  closeToolTipInformationTextAriaLabel
+}) => {
   const [toolTipIsVisible, setToolTipIsVisible] = useState(false);
   const handleKeyPress = useCallback(
     event => {
@@ -71,7 +76,7 @@ const ToolTip = ({tooltipText, 'aria-label': moreDetailsAriaLabel, 'data-testid'
           className={style.toolTip}
           style={customStyle}
           data-testid="review-presentation-tooltip"
-          // aria-label to close the information icon with Echap or Enter
+          aria-label={closeToolTipInformationTextAriaLabel}
         >
           <p className={style.tooltipText}>{tooltipText}</p>
         </div>
@@ -81,7 +86,6 @@ const ToolTip = ({tooltipText, 'aria-label': moreDetailsAriaLabel, 'data-testid'
 };
 
 const ReviewListItemWrapper = ({iconKey, label}) => {
-  // déplacer dans ToolTip
   return (
     <div className={style.reviewListItemWrapper} data-tip data-for="reviewListItem" tabIndex={0}>
       <div className={style.reviewListText}>
@@ -90,6 +94,7 @@ const ReviewListItemWrapper = ({iconKey, label}) => {
       <ToolTip
         tooltipText={label.tooltipText}
         aria-label={label.moreDetailsAriaLabel}
+        closeToolTipInformationTextAriaLabel={label.closeToolTipInformationTextAriaLabel}
         data-testid={`review-list-item-tooltip-button-${iconKey}`}
       />
     </div>
@@ -132,7 +137,8 @@ const ReviewPresentation = props => {
 ToolTip.propTypes = {
   tooltipText: PropTypes.string,
   'aria-label': PropTypes.string,
-  'data-testid': PropTypes.string
+  'data-testid': PropTypes.string,
+  closeToolTipInformationTextAriaLabel: PropTypes.string
 };
 
 ReviewIcon.propTypes = {

--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -54,11 +54,6 @@ const ToolTip = ({
     setToolTipIsVisible(false);
   }, [setToolTipIsVisible]);
 
-  const customStyle = {
-    visibility: toolTipIsVisible ? 'visible' : 'hidden',
-    opacity: toolTipIsVisible ? 1 : 0
-  };
-
   return (
     <div
       className={style.tooltipContainer}
@@ -82,7 +77,6 @@ const ToolTip = ({
       {toolTipIsVisible ? (
         <div
           className={style.toolTip}
-          style={customStyle}
           data-testid="review-presentation-tooltip"
           aria-label={closeToolTipInformationTextAriaLabel}
         >

--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -45,7 +45,11 @@ const ToolTip = ({tooltipText, 'aria-label': moreDetailsAriaLabel, isVisible}) =
         />
       </div>
       {isVisible ? (
-        <div className={style.toolTip} style={customStyle}>
+        <div
+          className={style.toolTip}
+          style={customStyle}
+          data-testid="review-presentation-tooltip"
+        >
           <p className={style.tooltipText}>{tooltipText}</p>
         </div>
       ) : null}
@@ -53,7 +57,7 @@ const ToolTip = ({tooltipText, 'aria-label': moreDetailsAriaLabel, isVisible}) =
   );
 };
 
-const ReviewListItemWrapper = ({iconKey, label}) => {
+const ReviewListItemWrapper = ({iconKey, label, 'data-testid': dataTestId}) => {
   const [toolTipIsVisible, setToolTipIsVisible] = useState(false);
   const handleKeyPress = useCallback(
     event => {
@@ -77,6 +81,7 @@ const ReviewListItemWrapper = ({iconKey, label}) => {
       onMouseLeave={handleMouseLeave}
       onKeyDown={handleKeyPress}
       tabIndex={0}
+      data-testid={dataTestId}
     >
       <div className={style.reviewListText}>
         <ReviewIcon icon={iconKey} /> {label.text}
@@ -114,6 +119,7 @@ const ReviewPresentation = props => {
                 label={label}
                 tooltipText={label.tooltipText}
                 aria-label={label.moreDetailsAriaLabel}
+                data-testid={`review-list-item-wrapper-${key}`}
               />
             </li>
           );
@@ -139,7 +145,8 @@ ReviewListItemWrapper.propTypes = {
   label: PropTypes.shape({
     tooltipText: PropTypes.string,
     moreDetailsAriaLabel: PropTypes.string
-  })
+  }),
+  'data-testid': PropTypes.string
 };
 
 ReviewPresentation.propTypes = propTypes;

--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -44,24 +44,26 @@ const ToolTip = ({tooltipText, 'aria-label': moreDetailsAriaLabel, isVisible}) =
           aria-label={moreDetailsAriaLabel}
         />
       </div>
-      <div className={style.toolTip} style={customStyle}>
-        <p className={style.tooltipText}>{tooltipText}</p>
-      </div>
+      {isVisible ? (
+        <div className={style.toolTip} style={customStyle}>
+          <p className={style.tooltipText}>{tooltipText}</p>
+        </div>
+      ) : null}
     </div>
   );
 };
 
-const ReviewListItemWrapper = ({key, label}) => {
+const ReviewListItemWrapper = ({iconKey, label}) => {
   const [toolTipIsVisible, setToolTipIsVisible] = useState(false);
   const handleKeyPress = useCallback(
     event => {
-      // eslint-disable-next-line no-console
-      console.log('event key', event.key);
-      if (event.key === 'Esc') {
+      if (event.key === 'Enter') {
+        setToolTipIsVisible(!toolTipIsVisible);
+      } else if (event.key === 'Tab' || event.key === 'Escape') {
         setToolTipIsVisible(false);
       }
     },
-    [setToolTipIsVisible]
+    [setToolTipIsVisible, toolTipIsVisible]
   );
   const handleMouseOver = useCallback(() => setToolTipIsVisible(true), [setToolTipIsVisible]);
 
@@ -73,11 +75,11 @@ const ReviewListItemWrapper = ({key, label}) => {
       data-for="reviewListItem"
       onMouseOver={handleMouseOver}
       onMouseLeave={handleMouseLeave}
-      onKeyPress={handleKeyPress}
+      onKeyDown={handleKeyPress}
       tabIndex={0}
     >
       <div className={style.reviewListText}>
-        <ReviewIcon icon={key} /> {label.text}
+        <ReviewIcon icon={iconKey} /> {label.text}
       </div>
       <ToolTip
         tooltipText={label.tooltipText}
@@ -105,10 +107,12 @@ const ReviewPresentation = props => {
       />
       <ul className={style.reviewListWrapper}>
         {map.convert({cap: false})((label, key) => {
+          // eslint-disable-next-line no-console
+          console.log(key);
           return (
             <li key={`step-${key}`} className={style.reviewList}>
               <ReviewListItemWrapper
-                key={key}
+                iconKey={key}
                 label={label}
                 tooltipText={label.tooltipText}
                 aria-label={label.moreDetailsAriaLabel}
@@ -133,7 +137,7 @@ ReviewIcon.propTypes = {
 
 ReviewListItemWrapper.propTypes = {
   ...ToolTip.propTypes,
-  key: PropTypes.string,
+  iconKey: PropTypes.string,
   label: PropTypes.string
 };
 

--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -29,35 +29,7 @@ const ReviewIcon = ({icon}) => {
   return <Icon className={style.labelIcon} />;
 };
 
-const ToolTip = ({tooltipText, 'aria-label': moreDetailsAriaLabel, isVisible}) => {
-  const customStyle = {
-    visibility: isVisible ? 'visible' : 'hidden',
-    opacity: isVisible ? 1 : 0
-  };
-  return (
-    <div className={style.tooltipContainer}>
-      <div className={style.tooltipIconContainer}>
-        <InformationIcon
-          className={style.informationIcon}
-          width={12}
-          height={12}
-          aria-label={moreDetailsAriaLabel}
-        />
-      </div>
-      {isVisible ? (
-        <div
-          className={style.toolTip}
-          style={customStyle}
-          data-testid="review-presentation-tooltip"
-        >
-          <p className={style.tooltipText}>{tooltipText}</p>
-        </div>
-      ) : null}
-    </div>
-  );
-};
-
-const ReviewListItemWrapper = ({iconKey, label, 'data-testid': dataTestId}) => {
+const ToolTip = ({tooltipText, 'aria-label': moreDetailsAriaLabel, 'data-testid': dataTestId}) => {
   const [toolTipIsVisible, setToolTipIsVisible] = useState(false);
   const handleKeyPress = useCallback(
     event => {
@@ -72,24 +44,52 @@ const ReviewListItemWrapper = ({iconKey, label, 'data-testid': dataTestId}) => {
   const handleMouseOver = useCallback(() => setToolTipIsVisible(true), [setToolTipIsVisible]);
 
   const handleMouseLeave = useCallback(() => setToolTipIsVisible(false), [setToolTipIsVisible]);
+  const customStyle = {
+    visibility: toolTipIsVisible ? 'visible' : 'hidden',
+    opacity: toolTipIsVisible ? 1 : 0
+  };
   return (
-    <div
-      className={style.reviewListItemWrapper}
-      data-tip
-      data-for="reviewListItem"
-      onMouseOver={handleMouseOver}
-      onMouseLeave={handleMouseLeave}
-      onKeyDown={handleKeyPress}
-      tabIndex={0}
-      data-testid={dataTestId}
-    >
+    <div className={style.tooltipContainer}>
+      <div
+        className={style.tooltipIconContainer}
+        data-testid={dataTestId}
+        onMouseOver={handleMouseOver}
+        onMouseLeave={handleMouseLeave}
+        onKeyDown={handleKeyPress}
+        tabIndex={0}
+      >
+        <InformationIcon
+          className={style.informationIcon}
+          width={12}
+          height={12}
+          aria-label={moreDetailsAriaLabel}
+        />
+      </div>
+      {toolTipIsVisible ? (
+        <div
+          className={style.toolTip}
+          style={customStyle}
+          data-testid="review-presentation-tooltip"
+          // aria-label to close the information icon with Echap or Enter
+        >
+          <p className={style.tooltipText}>{tooltipText}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const ReviewListItemWrapper = ({iconKey, label}) => {
+  // déplacer dans ToolTip
+  return (
+    <div className={style.reviewListItemWrapper} data-tip data-for="reviewListItem" tabIndex={0}>
       <div className={style.reviewListText}>
         <ReviewIcon icon={iconKey} /> {label.text}
       </div>
       <ToolTip
         tooltipText={label.tooltipText}
         aria-label={label.moreDetailsAriaLabel}
-        isVisible={toolTipIsVisible}
+        data-testid={`review-list-item-tooltip-button-${iconKey}`}
       />
     </div>
   );
@@ -119,7 +119,6 @@ const ReviewPresentation = props => {
                 label={label}
                 tooltipText={label.tooltipText}
                 aria-label={label.moreDetailsAriaLabel}
-                data-testid={`review-list-item-wrapper-${key}`}
               />
             </li>
           );
@@ -132,7 +131,7 @@ const ReviewPresentation = props => {
 ToolTip.propTypes = {
   tooltipText: PropTypes.string,
   'aria-label': PropTypes.string,
-  isVisible: PropTypes.bool
+  'data-testid': PropTypes.string
 };
 
 ReviewIcon.propTypes = {
@@ -145,8 +144,7 @@ ReviewListItemWrapper.propTypes = {
   label: PropTypes.shape({
     tooltipText: PropTypes.string,
     moreDetailsAriaLabel: PropTypes.string
-  }),
-  'data-testid': PropTypes.string
+  })
 };
 
 ReviewPresentation.propTypes = propTypes;

--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -107,8 +107,6 @@ const ReviewPresentation = props => {
       />
       <ul className={style.reviewListWrapper}>
         {map.convert({cap: false})((label, key) => {
-          // eslint-disable-next-line no-console
-          console.log(key);
           return (
             <li key={`step-${key}`} className={style.reviewList}>
               <ReviewListItemWrapper
@@ -138,7 +136,10 @@ ReviewIcon.propTypes = {
 ReviewListItemWrapper.propTypes = {
   ...ToolTip.propTypes,
   iconKey: PropTypes.string,
-  label: PropTypes.string
+  label: PropTypes.shape({
+    tooltipText: PropTypes.string,
+    moreDetailsAriaLabel: PropTypes.string
+  })
 };
 
 ReviewPresentation.propTypes = propTypes;

--- a/packages/@coorpacademy-components/src/atom/review-presentation/prop-types.ts
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/prop-types.ts
@@ -4,7 +4,8 @@ import {ColorValue, GestureResponderEvent, ViewStyle} from 'react-native';
 const levelItem = PropTypes.shape({
   text: PropTypes.string,
   tooltipText: PropTypes.string,
-  moreDetailsAreaLabel: PropTypes.string
+  moreDetailsAreaLabel: PropTypes.string,
+  closeToolTipInformationTextAriaLabel: PropTypes.string
 });
 
 const propTypes = {

--- a/packages/@coorpacademy-components/src/atom/review-presentation/style.css
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/style.css
@@ -128,6 +128,8 @@
   display: flex;
   justify-content: flex-end;
   border: none;
+  background: cm_grey_75;
+  height: 25px;
 }
 
 @media tablet {

--- a/packages/@coorpacademy-components/src/atom/review-presentation/style.css
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/style.css
@@ -82,8 +82,8 @@
 }
 
 .toolTip {
-  visibility: hidden;
-  opacity: 0;
+  /* visibility: hidden;
+  opacity: 0; */
   transition: opacity 0.8s;
   position: absolute;
   height: auto;
@@ -97,8 +97,10 @@
 .toolTip::before {
   content: '';
   display: inline-block;
-  visibility: hidden;
-  opacity: 0;
+  /* visibility: hidden; */
+  visibility: inherit;
+  /* opacity: 0; */
+  opacity: inherit;
   width: 15px;
   height: 15px;
   transform: rotate(-45deg);
@@ -126,7 +128,7 @@
   position: relative;
 }
 
-.reviewListItemWrapper:hover .tooltipContainer .toolTip {
+/* .reviewListItemWrapper:hover .tooltipContainer .toolTip {
   visibility: visible;
   opacity: 1;
 }
@@ -134,7 +136,7 @@
 .reviewListItemWrapper:hover .tooltipContainer .toolTip::before {
   visibility: visible;
   opacity: 1;
-}
+} */
 
 .tooltipIconContainer {
   display: flex;

--- a/packages/@coorpacademy-components/src/atom/review-presentation/style.css
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/style.css
@@ -127,6 +127,7 @@
 .tooltipIconContainer {
   display: flex;
   justify-content: flex-end;
+  border: none;
 }
 
 @media tablet {

--- a/packages/@coorpacademy-components/src/atom/review-presentation/style.css
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/style.css
@@ -82,8 +82,6 @@
 }
 
 .toolTip {
-  /* visibility: hidden;
-  opacity: 0; */
   transition: opacity 0.8s;
   position: absolute;
   height: auto;
@@ -97,9 +95,7 @@
 .toolTip::before {
   content: '';
   display: inline-block;
-  /* visibility: hidden; */
   visibility: inherit;
-  /* opacity: 0; */
   opacity: inherit;
   width: 15px;
   height: 15px;
@@ -127,16 +123,6 @@
   overflow: visible;
   position: relative;
 }
-
-/* .reviewListItemWrapper:hover .tooltipContainer .toolTip {
-  visibility: visible;
-  opacity: 1;
-}
-
-.reviewListItemWrapper:hover .tooltipContainer .toolTip::before {
-  visibility: visible;
-  opacity: 1;
-} */
 
 .tooltipIconContainer {
   display: flex;

--- a/packages/@coorpacademy-components/src/atom/review-presentation/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/test/fixtures/default.ts
@@ -7,22 +7,26 @@ export const defaultProps = {
     skills: {
       text: 'Choose 1 Skill',
       tooltipText: 'This is the tooltip text',
-      moreDetailsAriaLabel: 'More details'
+      moreDetailsAriaLabel: 'More details',
+      closeToolTipInformationTextAriaLabel: 'Click on Escape to close the information text'
     },
     questions: {
       text: 'Answer 5 Questions',
       tooltipText: 'This is the tooltip text',
-      moreDetailsAriaLabel: 'More details'
+      moreDetailsAriaLabel: 'More details',
+      closeToolTipInformationTextAriaLabel: 'Click on Escape to close the information text'
     },
     lifes: {
       text: 'You have Infinite Lifes',
       tooltipText: 'This is the tooltip text, a tooltip text',
-      moreDetailsAriaLabel: 'More details'
+      moreDetailsAriaLabel: 'More details',
+      closeToolTipInformationTextAriaLabel: 'Click on Escape to close the information text'
     },
     allright: {
       text: 'Get it all right',
       tooltipText: 'Egestas elementum duis bibendum',
-      moreDetailsAriaLabel: 'More details'
+      moreDetailsAriaLabel: 'More details',
+      closeToolTipInformationTextAriaLabel: 'Click on Escape to close the information text'
     }
   }
 };

--- a/packages/@coorpacademy-components/src/atom/review-presentation/test/on-key-down.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/test/on-key-down.js
@@ -1,0 +1,32 @@
+import test from 'ava';
+import browserEnv from 'browser-env';
+import React from 'react';
+import {render, fireEvent, cleanup} from '@testing-library/react';
+import ReviewPresentation from '..';
+import defaultFixture from './fixtures/default';
+
+browserEnv();
+
+test.after(cleanup);
+
+test('should hide and show toolTip depending on key press event', t => {
+  const toolTipTestId = '[data-testid="review-presentation-tooltip"]';
+  const {getByTestId, container} = render(<ReviewPresentation {...defaultFixture.props} />);
+  const skillsDiv = getByTestId('review-list-item-wrapper-questions');
+  t.truthy(skillsDiv);
+  fireEvent.mouseEnter(skillsDiv);
+  let toolTipDiv = container.querySelector(toolTipTestId);
+  t.truthy(toolTipDiv);
+  fireEvent.keyDown(skillsDiv, {key: 'Escape'});
+  toolTipDiv = container.querySelector(toolTipTestId);
+  t.falsy(toolTipDiv);
+  fireEvent.keyDown(skillsDiv, {key: 'A'});
+  toolTipDiv = container.querySelector(toolTipTestId);
+  t.falsy(toolTipDiv);
+  fireEvent.keyDown(skillsDiv, {key: 'Enter'});
+  toolTipDiv = container.querySelector(toolTipTestId);
+  t.truthy(toolTipDiv);
+  fireEvent.keyDown(skillsDiv, {key: 'Tab'});
+  toolTipDiv = container.querySelector(toolTipTestId);
+  t.falsy(toolTipDiv);
+});

--- a/packages/@coorpacademy-components/src/atom/review-presentation/test/on-key-down.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/test/on-key-down.js
@@ -12,7 +12,7 @@ test.after(cleanup);
 test('should hide and show toolTip depending on key press event', t => {
   const toolTipTestId = '[data-testid="review-presentation-tooltip"]';
   const {getByTestId, container} = render(<ReviewPresentation {...defaultFixture.props} />);
-  const skillsDiv = getByTestId('review-list-item-wrapper-questions');
+  const skillsDiv = getByTestId('review-list-item-tooltip-button-questions');
   t.truthy(skillsDiv);
   fireEvent.mouseEnter(skillsDiv);
   let toolTipDiv = container.querySelector(toolTipTestId);

--- a/packages/@coorpacademy-components/src/atom/review-presentation/test/on-mouse-leave.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/test/on-mouse-leave.js
@@ -12,7 +12,9 @@ test.after(cleanup);
 test('should hide toolTip depending on mouse leave event', t => {
   const toolTipTestId = '[data-testid="review-presentation-tooltip"]';
   const {container} = render(<ReviewPresentation {...defaultFixture.props} />);
-  const skillsDiv = container.querySelector('[data-testid="review-list-item-wrapper-skills"]');
+  const skillsDiv = container.querySelector(
+    '[data-testid="review-list-item-tooltip-button-skills"]'
+  );
   t.truthy(skillsDiv);
   fireEvent.mouseEnter(skillsDiv);
   let toolTipDiv = container.querySelector(toolTipTestId);

--- a/packages/@coorpacademy-components/src/atom/review-presentation/test/on-mouse-leave.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/test/on-mouse-leave.js
@@ -1,0 +1,23 @@
+import test from 'ava';
+import browserEnv from 'browser-env';
+import React from 'react';
+import {render, fireEvent, cleanup} from '@testing-library/react';
+import ReviewPresentation from '..';
+import defaultFixture from './fixtures/default';
+
+browserEnv();
+
+test.after(cleanup);
+
+test('should hide toolTip depending on mouse leave event', t => {
+  const toolTipTestId = '[data-testid="review-presentation-tooltip"]';
+  const {container} = render(<ReviewPresentation {...defaultFixture.props} />);
+  const skillsDiv = container.querySelector('[data-testid="review-list-item-wrapper-skills"]');
+  t.truthy(skillsDiv);
+  fireEvent.mouseEnter(skillsDiv);
+  let toolTipDiv = container.querySelector(toolTipTestId);
+  t.truthy(toolTipDiv);
+  fireEvent.mouseLeave(skillsDiv);
+  toolTipDiv = container.querySelector(toolTipTestId);
+  t.falsy(toolTipDiv);
+});


### PR DESCRIPTION
Final part of this trello card :  [add aria-label for revision dashboard "reviewable list"](https://trello.com/c/ojoyK0Z2/77-add-aria-label-for-revision-dashboard-reviewable-list)

**Detailed purpose of the PR**
Customise the event on keyboard press to match [this RGAA rule about information presentation](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#10.13.1)
- Open the tooltipText content when "Enter" is pressed on the information icon
- Close this area when "Escape" or "Tab" are pressed.

**Result and observation**
![Kapture 2023-01-09 at 15 12 33](https://user-images.githubusercontent.com/113359769/211328315-785f9174-1117-4b3d-b9c5-a59110dda1f6.gif))

**Testing Strategy**
- Already covered by tests
- Manual testing
