### PR TITLE
[mobile] add a button in the header to display popin

### DIFF
--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -305,7 +305,7 @@ const buildQuitPopinProps =
         label: translate('Continue learning'),
         type: 'primary',
         customStyle: {
-          backgroundColor: skin.common.primary
+          backgroundColor: get(['common', 'primary'], skin)
         },
         handleOnclick: (): void => {
           dispatch(closeQuitPopin);

--- a/packages/@coorpacademy-components/src/organism/review-header/index.native.tsx
+++ b/packages/@coorpacademy-components/src/organism/review-header/index.native.tsx
@@ -1,31 +1,64 @@
 import React from 'react';
 import {StyleSheet, View, ViewStyle} from 'react-native';
+import {NovaSolidStatusClose as CloseIcon} from '@coorpacademy/nova-icons';
 import Step from '../../atom/review-header-step-item/index.native';
+import Touchable from '../../hoc/touchable/index.native';
 import {HeaderProps} from './types';
 
 type StyleSheetType = {
+  container: ViewStyle;
   header: ViewStyle;
+  iconContainer: ViewStyle;
+  icon: ViewStyle;
 };
 
 const style: StyleSheetType = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    alignContent: 'center'
+  },
   header: {
-    width: '100%',
+    width: '80%',
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     height: 70,
     paddingTop: 25
+  },
+  iconContainer: {
+    position: 'absolute',
+    right: 5,
+    bottom: 10,
+    borderRadius: 12,
+    padding: 5
+  },
+  icon: {
+    width: 12,
+    height: 12
   }
 });
 
 const ReviewHeader = (props: HeaderProps) => {
-  const {steps} = props;
+  const {steps, onQuitClick} = props;
 
   return (
-    <View style={style.header}>
-      {steps.map(step => (
-        <Step {...step} key={step.value} />
-      ))}
+    <View style={style.container}>
+      <View style={style.header}>
+        {steps.map(step => (
+          <Step {...step} key={step.value} />
+        ))}
+      </View>
+      <Touchable
+        style={style.iconContainer}
+        isHighlight
+        onPress={onQuitClick}
+        accessibilityLabel="open-popin-button"
+        testID="open-popin-button"
+      >
+        <CloseIcon style={style.icon} color="#06265B" />
+      </Touchable>
     </View>
   );
 };

--- a/packages/@coorpacademy-components/src/organism/review-header/test/on-press.test.tsx
+++ b/packages/@coorpacademy-components/src/organism/review-header/test/on-press.test.tsx
@@ -1,0 +1,22 @@
+import test from 'ava';
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react-native';
+import ReviewHeader from '../index.native';
+import mockedGestureEvent from '../../../test/helpers/mocked-gesture-event';
+import defaultFixture from './fixtures/all-questions-ok';
+
+test('should handle onPress on button', t => {
+  t.plan(1);
+
+  const props = {
+    ...defaultFixture.props,
+    onQuitClick: () => t.pass()
+  };
+
+  const component = <ReviewHeader {...props} />;
+
+  const {getByTestId} = render(component);
+  const openPopinButton = getByTestId('open-popin-button');
+
+  fireEvent.press(openPopinButton, mockedGestureEvent);
+});


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR adds a button in the header of the player to display popin when clicked. 
-> https://trello.com/c/gahQt4vU/2857-or-popin-onquit-mobile

**Result and observation**
![Kapture 2023-01-11 at 11 17 53](https://user-images.githubusercontent.com/79636283/211780949-719839c6-d273-4c54-bff7-4993695b0178.gif)

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [x] Unit testing
