### PR TITLE
[review] delete tooltip next to the title in dashboard review

### DIFF
--- a/packages/@coorpacademy-components/src/template/app-review/skills/index.js
+++ b/packages/@coorpacademy-components/src/template/app-review/skills/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import isEmpty from 'lodash/fp/isEmpty';
-import {NovaCompositionCoorpacademyInformationIcon as InformationIcon} from '@coorpacademy/nova-icons';
 import Loader from '../../../atom/loader';
 import ReviewListSkills from '../../../organism/review-skills';
 import ReviewNoSkills from '../../../organism/review-no-skills';
@@ -21,10 +20,7 @@ const ReviewSkills = props => {
 
   return (
     <div className={style.containerReviewSkill} aria-label={ariaLabel}>
-      <div className={style.title}>
-        {title}
-        <InformationIcon className={style.informationIcon} width={12} height={12} />
-      </div>
+      <div className={style.title}>{title}</div>
       {isLoading ? (
         <div className={style.loaderContainer}>
           <Loader className={style.loader} theme="default" aria-label={isLoadingAriaLabel} />

--- a/packages/@coorpacademy-components/src/template/app-review/skills/style.css
+++ b/packages/@coorpacademy-components/src/template/app-review/skills/style.css
@@ -24,11 +24,6 @@
   margin-left: 40px;
 }
 
-.informationIcon {
-  color: cm_grey_500;
-  padding-left: 8px;
-}
-
 .loaderContainer {
   width: 100%;
   height: 50vh;


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR deletes tooltip next to the title in the dashboard review. 
-> https://trello.com/c/bciBZFPv/2928-or-bug-tooltip-non-rempli

**Result and observation**
BEFORE
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/79636283/211822589-b1c6b99b-9ac3-4986-ae0e-037cfe5b5cb3.png">

AFTER
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/79636283/211821987-ba7867ef-b473-4151-b7ee-ccaab3a05a91.png">


**Testing Strategy**

- [x] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
