### PR TITLE
[RGAA] add aria label and area description in review header step item

### DIFF
--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -77,5 +77,9 @@
   "zuora_discount_code_submit": "Apply",
   "zuora_discount_code": "Promo code",
   "mandatory_fields": "*Mandatory fields",
-  "something_went_wrong": "Oh Snap! Something went wrong."
+  "something_went_wrong": "Oh Snap! Something went wrong.",
+  "review_header_step_item": {
+    "area_label": "Question ${headerStepValue}",
+    "area_description": "Question ${headerStepValue} is ${questionIconStatus}"
+  }
 }

--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -79,7 +79,7 @@
   "mandatory_fields": "*Mandatory fields",
   "something_went_wrong": "Oh Snap! Something went wrong.",
   "review_header_step_item": {
-    "area_label": "Question ${headerStepValue}",
-    "area_description": "Question ${headerStepValue} is ${questionIconStatus}"
+    "aria_label": "Question ${headerStepValue}",
+    "aria_description": "Question ${headerStepValue} is ${questionIconStatus}"
   }
 }


### PR DESCRIPTION
Part of this trello card : [RewiewHeader Step Items: are missing aria labels descriptions](https://trello.com/c/RS7ScfcC/115-rewiewheader-step-items-are-missing-aria-labels-descriptions)

**Detailed purpose of the PR**
Add labels key to review header step items: 
- aria label is present and set as "step 1,..." but not translated.
- add the missing area description

**Result and observation**
![Capture d’écran 2023-01-17 à 11 31 29](https://user-images.githubusercontent.com/113359769/212876190-76eea6f9-33bf-4329-9dbb-060ba27ae408.png)

**Testing Strategy**
- [ ] Already covered by tests