### PR TITLE
[RGAA] Aria label and description in review header step items

### DIFF
--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -79,7 +79,10 @@
   "mandatory_fields": "*Mandatory fields",
   "something_went_wrong": "Oh Snap! Something went wrong.",
   "review_header_step_item": {
-    "aria_label": "Question ${headerStepValue}",
-    "aria_description": "Question ${headerStepValue} is ${questionIconStatus}"
+    "aria_label": "Question {{headerStepValue}}",
+    "current_question": "Question {{headerStepValue}} is the current question",
+    "correct_question": "Question {{headerStepValue}} is correct",
+    "incorrect_question": "Question {{headerStepValue}} is incorrect",
+    "not_answered_question": "Question {{headerStepValue}} is not answered yet"
   }
 }

--- a/packages/@coorpacademy-components/src/atom/review-header-step-item/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/review-header-step-item/index.tsx
@@ -5,26 +5,42 @@ import {
   NovaSolidStatusClose as WrongIcon
 } from '@coorpacademy/nova-icons';
 import style from './style.css';
-import propTypes, {HeaderStepItemProps} from './types';
+import propTypes, {contextTypes, HeaderStepItemProps} from './types';
 
-const Content = ({icon, current, value}: HeaderStepItemProps) => {
+// HeaderStepItemContextTypes to context
+const Content = (props: HeaderStepItemProps, context: any) => {
+  const {icon, current, value} = props;
+  const {translate} = context;
   let child;
-
+  let ariaDescription;
   switch (icon) {
     case 'no-answer':
       child = value;
+      ariaDescription = current
+        ? translate('review_header_step_item.current_question', {
+            headerStepValue: value
+          })
+        : translate('review_header_step_item.not_answered_question', {
+            headerStepValue: value
+          });
       break;
 
     case 'right':
       child = (
         <RightIcon className={classnames(style.rightIcon, current && style.currentRightIcon)} />
       );
+      ariaDescription = translate('review_header_step_item.correct_question', {
+        headerStepValue: value
+      });
       break;
 
     case 'wrong':
       child = (
         <WrongIcon className={classnames(style.wrongIcon, current && style.currentWrongIcon)} />
       );
+      ariaDescription = translate('review_header_step_item.incorrect_question', {
+        headerStepValue: value
+      });
       break;
 
     default:
@@ -32,7 +48,13 @@ const Content = ({icon, current, value}: HeaderStepItemProps) => {
   }
 
   return (
-    <span className={style.value} aria-label={`step ${value}`}>
+    <span
+      className={style.value}
+      aria-label={translate('review_header_step_item.aria_label', {
+        headerStepValue: value
+      })}
+      aria-describedby={ariaDescription}
+    >
       {child}
     </span>
   );
@@ -56,5 +78,6 @@ const ReviewHeaderStepItem = (props: HeaderStepItemProps) => {
 };
 
 ReviewHeaderStepItem.propTypes = propTypes;
+Content.contextTypes = contextTypes;
 
 export default ReviewHeaderStepItem;

--- a/packages/@coorpacademy-components/src/atom/review-header-step-item/types.ts
+++ b/packages/@coorpacademy-components/src/atom/review-header-step-item/types.ts
@@ -1,9 +1,14 @@
 import PropTypes from 'prop-types';
+import Provider from '../provider';
 
 const propTypes = {
   current: PropTypes.bool,
   icon: PropTypes.oneOf(['no-answer', 'right', 'wrong']),
   value: PropTypes.string
+};
+
+export const contextTypes = {
+  translate: PropTypes.func
 };
 
 export default propTypes;
@@ -13,6 +18,8 @@ export type HeaderStepItemProps = {
   icon: 'no-answer' | 'right' | 'wrong';
   value: string;
 };
+
+export type HeaderStepItemContextTypes = {translate: typeof Provider.childContextTypes.translate};
 
 export type Fixture = {
   props: HeaderStepItemProps;


### PR DESCRIPTION
Part of this trello card : [RewiewHeader Step Items: are missing aria labels descriptions](https://trello.com/c/RS7ScfcC/115-rewiewheader-step-items-are-missing-aria-labels-descriptions)

**Detailed purpose of the PR**
Add the aria description and aria label translated in review header step items.

**Result and observation**
![Capture d’écran 2023-01-17 à 23 41 43](https://user-images.githubusercontent.com/113359769/213031799-1501d8c6-4e4a-47c3-b91a-f27521438837.png)

**Testing Strategy**
- [ ] Unit testing
