### PR TITLE
[RGAA] add missing closeToolTipInformationAriaLabel to label props & update fixtures due to latest changes

### DIFF
--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -152,7 +152,8 @@ ReviewListItemWrapper.propTypes = {
   iconKey: PropTypes.string,
   label: PropTypes.shape({
     tooltipText: PropTypes.string,
-    moreDetailsAriaLabel: PropTypes.string
+    moreDetailsAriaLabel: PropTypes.string,
+    closeToolTipInformationTextAriaLabel: PropTypes.string
   })
 };
 

--- a/packages/@coorpacademy-components/src/atom/review-presentation/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/test/fixtures/default.ts
@@ -8,25 +8,25 @@ export const defaultProps = {
       text: 'Choose 1 Skill',
       tooltipText: 'This is the tooltip text',
       moreDetailsAriaLabel: 'More details',
-      closeToolTipInformationTextAriaLabel: 'Click on Escape to close the information text'
+      closeToolTipInformationTextAriaLabel: 'Press the escape key to close the information text'
     },
     questions: {
       text: 'Answer 5 Questions',
       tooltipText: 'This is the tooltip text',
       moreDetailsAriaLabel: 'More details',
-      closeToolTipInformationTextAriaLabel: 'Click on Escape to close the information text'
+      closeToolTipInformationTextAriaLabel: 'Press the escape key to close the information text'
     },
     lifes: {
       text: 'You have Infinite Lifes',
       tooltipText: 'This is the tooltip text, a tooltip text',
       moreDetailsAriaLabel: 'More details',
-      closeToolTipInformationTextAriaLabel: 'Click on Escape to close the information text'
+      closeToolTipInformationTextAriaLabel: 'Press the escape key to close the information text'
     },
     allright: {
       text: 'Get it all right',
       tooltipText: 'Egestas elementum duis bibendum',
       moreDetailsAriaLabel: 'More details',
-      closeToolTipInformationTextAriaLabel: 'Click on Escape to close the information text'
+      closeToolTipInformationTextAriaLabel: 'Press the escape key to close the information text'
     }
   }
 };


### PR DESCRIPTION
Part of this trello ticket : 

**Detailed purpose of the PR**
- Add the missing closeToolTipInformationAriaLabel proptypes to label type props in review presentation component.
- Update fixtures due to change of trad : [[RGAA] fix aria label of close information text tooltip](https://github.com/CoorpAcademy/coorpacademy/pull/17152)

**Result and observation**

**Testing Strategy**
- [ ] Already covered by tests
- [ ] Unit testing
