### PR TITLE
[review] Add append video options function to review options

### DIFF
--- a/packages/@coorpacademy-app-review/sandbox/index.tsx
+++ b/packages/@coorpacademy-app-review/sandbox/index.tsx
@@ -7,7 +7,7 @@ import createTranslate from '@coorpacademy/translate';
 import {WebContext} from '@coorpacademy/components/es/atom/provider';
 import {identity} from 'lodash/fp';
 import localesComponents from '@coorpacademy/components/locales/en/global.json';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {AppOptions, Translate} from '../src/types/common';
 import localesAppReview from '../locales/en/review.json';
 import AppReview from '../src';
@@ -57,7 +57,8 @@ const createSandbox = (options: SandboxOptions): void => {
       onQuitClick: () => {
         location.reload();
       },
-      skin
+      skin,
+      appendVideoOptions
     };
     render(
       <WebContext translate={identity} skin={skin}>

--- a/packages/@coorpacademy-app-review/sandbox/index.tsx
+++ b/packages/@coorpacademy-app-review/sandbox/index.tsx
@@ -39,6 +39,7 @@ const translate: Translate = (key: string, data?: Record<string, string>): strin
     })(key, data);
   }
 };
+
 const isContainerAvailable = (options: SandboxOptions): boolean =>
   !pipe(get('container'), isNil)(options);
 

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-correction.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-correction.test.ts
@@ -2,7 +2,8 @@ import test from 'ava';
 import type {Services} from '@coorpacademy/review-services';
 import {
   getChoicesCorrection,
-  services as mockedServices
+  services as mockedServices,
+  appendVideoOptions
 } from '@coorpacademy/review-services-mocks';
 import type {StoreState} from '../../../reducers';
 import {createTestStore} from '../../test/create-test-store';
@@ -80,7 +81,8 @@ test('should dispatch CORRECTION_FETCH_SUCCESS actions when fetchCorrection retu
     }
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   await dispatch(fetchCorrection);
 });
@@ -115,7 +117,8 @@ test('should dispatch CORRECTION_FETCH_FAILURE action when fetchCorrection fails
     }
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   await dispatch(fetchCorrection);
 });

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-rank.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-rank.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import set from 'lodash/fp/set';
 import type {Services} from '@coorpacademy/review-services';
-import {services as mockedServices} from '@coorpacademy/review-services-mocks';
+import {services as mockedServices, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import type {StoreState} from '../../../reducers';
 import {
   fetchStartRank,
@@ -54,7 +54,8 @@ test('should dispatch FETCH_START_SUCCESS action when fetchStartRank returns the
     }
   ];
 
-  const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, initialState, thunkOptions, expectedActions);
   await dispatch(fetchStartRank);
 
   const newState = getState();
@@ -81,7 +82,8 @@ test('should dispatch FETCH_START_FAILURE action when fetchStartRank fails', asy
     }
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   await dispatch(fetchStartRank);
 });
@@ -106,7 +108,8 @@ test('should dispatch FETCH_END_SUCCESS action when fetchEndRank returns the end
   ];
 
   const _initialState = set('data.rank.start', 93, initialState);
-  const {dispatch, getState} = createTestStore(t, _initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, _initialState, thunkOptions, expectedActions);
 
   await dispatch(fetchEndRank);
   const newState = getState();
@@ -133,7 +136,8 @@ test('should dispatch FETCH_END_FAILURE action when fetchEndRank fails', async t
     }
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   await dispatch(fetchEndRank);
 });

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skill.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skill.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import type {Services, Skill} from '@coorpacademy/review-services';
-import {services as mockedServices} from '@coorpacademy/review-services-mocks';
+import {services as mockedServices, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../test/create-test-store';
 import type {StoreState} from '../../../reducers';
 import {
@@ -51,7 +51,9 @@ test('should dispatch FETCH_SKILL_SUCCESS when fetch skill is call with the corr
     {type: SKILL_FETCH_REQUEST},
     {type: SKILL_FETCH_SUCCESS, payload: fetchSkillResponse}
   ];
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   await dispatch(fetchSkill('skill_NyxtYFYir'));
 });
@@ -72,6 +74,7 @@ test('should dispatch FETCH_SKILL_FAILURE when fetch skill failed', async t => {
     {type: SKILL_FETCH_FAILURE, payload: new Error('Fetch skill action failed'), error: true}
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
   await dispatch(fetchSkill('123'));
 });

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slide.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import type {Services} from '@coorpacademy/review-services';
-import {services as mockedServices} from '@coorpacademy/review-services-mocks';
+import {services as mockedServices, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {
   fetchSlide,
   SLIDE_FETCH_FAILURE,
@@ -54,7 +54,8 @@ test('should dispatch FETCH_SUCCESS and SET_CURRENT_SLIDE actions when fetchSlid
     {type: SET_CURRENT_SLIDE, payload: freeTextSlide}
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   await dispatch(fetchSlide('sli_VJYjJnJhg'));
 });
@@ -80,7 +81,8 @@ test('should dispatch SLIDE_FETCH_FAILURE action when fetchSlide fails', async t
     }
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   await dispatch(fetchSlide('slide_ref'));
 });

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slides-to-review-by-skill-ref.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slides-to-review-by-skill-ref.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import type {Services} from '@coorpacademy/review-services';
-import {services as mockedServices} from '@coorpacademy/review-services-mocks';
+import {services as mockedServices, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../test/create-test-store';
 import {
   fetchSlidesToReviewBySkillRef,
@@ -95,7 +95,8 @@ test('should dispatch SLIDES_TO_REVIEW_FETCH_SUCCESS action when fetchSlidesToRe
     }
   ];
 
-  const {dispatch} = createTestStore(t, state, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, state, thunkOptions, expectedActions);
 
   await dispatch(fetchSlidesToReviewBySkillRef);
 });
@@ -121,7 +122,8 @@ test('should dispatch SLIDES_TO_REVIEW_FETCH_FAILURE action when fetchSlidesToRe
     }
   ];
 
-  const {dispatch} = createTestStore(t, state, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, state, thunkOptions, expectedActions);
 
   await dispatch(fetchSlidesToReviewBySkillRef);
 });

--- a/packages/@coorpacademy-app-review/src/actions/api/test/post-answer.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/post-answer.test.ts
@@ -1,7 +1,11 @@
 import test from 'ava';
 import {AnyAction} from 'redux';
 import type {ReviewEngine, ReviewContent, ProgressionFromAPI} from '@coorpacademy/review-services';
-import {getChoicesCorrection, services} from '@coorpacademy/review-services-mocks';
+import {
+  getChoicesCorrection,
+  services,
+  appendVideoOptions
+} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../test/create-test-store';
 import {
   postAnswer,
@@ -169,7 +173,8 @@ test('should dispatch post-answer, fetch-slide and fetch-correction and fetch-st
     }
   ];
 
-  const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   await dispatch(postAnswer);
 
@@ -341,7 +346,13 @@ test('should dispatch post-answer, fetch-correction, fetch-end-rank and fetch-sl
     }
   ];
 
-  const {dispatch, getState} = createTestStore(t, stateBeforeExitNode, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(
+    t,
+    stateBeforeExitNode,
+    thunkOptions,
+    expectedActions
+  );
 
   await dispatch(postAnswer);
 
@@ -377,7 +388,8 @@ test('should dispatch POST_ANSWER_REQUEST, then POST_ANSWER_FAILURE on error', a
           t.pass();
           return Promise.reject(new Error('unexpected'));
         }
-      }
+      },
+      appendVideoOptions
     },
     expectedActions
   );
@@ -389,12 +401,11 @@ test('should not dispatch any action && throw an error if progression does not e
   t.plan(1);
   const expectedActions: AnyAction[] = [];
 
+  const thunkOptions = {services, appendVideoOptions};
   const {dispatch} = createTestStore(
     t,
     {...initialState, data: {...initialState.data, progression: null}},
-    {
-      services
-    },
+    thunkOptions,
     expectedActions
   );
 

--- a/packages/@coorpacademy-app-review/src/actions/api/test/post-progression.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/post-progression.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import type {ProgressionFromAPI, Services} from '@coorpacademy/review-services';
-import {services as mockedServices} from '@coorpacademy/review-services-mocks';
+import {services as mockedServices, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {
   postProgression,
   POST_PROGRESSION_REQUEST,
@@ -100,7 +100,8 @@ test('should dispatch POST_PROGRESSION_SUCCESS and SLIDE_FETCH_REQUEST actions w
     {type: SKILL_FETCH_SUCCESS, payload: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}}
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   await dispatch(postProgression('skill_NyxtYFYir'));
 });
@@ -127,7 +128,8 @@ test('should dispatch POST_PROGRESSION_FAILURE action when postProgression fails
     {type: SKILL_FETCH_FAILURE, payload: new Error('Fetch skill action failed'), error: true}
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   await dispatch(postProgression('skill_12345'));
 });

--- a/packages/@coorpacademy-app-review/src/actions/data/test/token.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/data/test/token.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../test/create-test-store';
 import {StoreState} from '../../../reducers';
 import {storeToken, STORE_TOKEN} from '../token';
@@ -28,6 +28,7 @@ const initialState: StoreState = {
 test('should dispatch STORE_TOKEN action when storeToken is called', async t => {
   const expectedActions = [{type: STORE_TOKEN, payload: 'JWT.token'}];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
   await dispatch(storeToken('JWT.token'));
 });

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/answers.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/answers.test.ts
@@ -4,7 +4,7 @@ import pipe from 'lodash/fp/pipe';
 import set from 'lodash/fp/set';
 import omit from 'lodash/fp/omit';
 import type {Question, SlideFromAPI} from '@coorpacademy/review-services';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 
 import {editAnswer, ANSWER_EDIT} from '../answers';
 import {StoreState} from '../../../reducers';
@@ -15,6 +15,8 @@ import {qcmDragSlide} from '../../../views/slides/test/fixtures/qcm-drag';
 import {qcmGraphicSlide} from '../../../views/slides/test/fixtures/qcm-graphic';
 import {sliderSlide} from '../../../views/slides/test/fixtures/slider';
 import {templateSlide} from '../../../views/slides/test/fixtures/template';
+
+const thunkOptions = {services, appendVideoOptions};
 
 const initialState: StoreState = {
   data: {
@@ -74,7 +76,7 @@ test('editAnswer should throw an Error if the slide is not found', async t => {
   const {dispatch} = createTestStore(
     t,
     omit(['data', 'slides'], state) as StoreState,
-    {services},
+    thunkOptions,
     expectedActions
   );
   await t.throws(
@@ -89,7 +91,7 @@ test('editAnswer should throw an Error for unsupported questions', async t => {
     ...freeTextSlide,
     question: {...freeTextSlide.question, type: 'unsupportedType'} as unknown as Question
   });
-  const {dispatch} = createTestStore(t, state, {services}, []);
+  const {dispatch} = createTestStore(t, state, thunkOptions, []);
   await t.throws(
     () => dispatch(editAnswer(['Some kind of answer'])),
     undefined,
@@ -102,7 +104,7 @@ test('should dispatch EDIT_BASIC action when editAnswer is called', async t => {
   const expectedActions = [
     {type: ANSWER_EDIT.basic, meta: {slideRef: freeTextSlide.universalRef}, payload: ['My Answer']}
   ];
-  const {dispatch} = createTestStore(t, state, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, state, thunkOptions, expectedActions);
   await dispatch(editAnswer(['My Answer']));
 });
 
@@ -113,7 +115,7 @@ test('should dispatch EDIT_QCM action when editAnswer is called', async t => {
   const expectedActions = [
     {type: ANSWER_EDIT.qcm, meta: {slideRef: qcmSlide.universalRef}, payload: ['My First Answer']}
   ];
-  const {dispatch} = createTestStore(t, state, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, state, thunkOptions, expectedActions);
   await dispatch(editAnswer(['My Second Answer']));
 });
 
@@ -132,7 +134,7 @@ test('should dispatch EDIT_QCM_GRAPHIC action when editAnswer is called', async 
       payload: ['My First Answer', 'My Third Answer']
     }
   ];
-  const {dispatch} = createTestStore(t, state, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, state, thunkOptions, expectedActions);
   await dispatch(editAnswer(['My Second Answer']));
 });
 
@@ -147,7 +149,7 @@ test('should dispatch EDIT_QCM_DRAG action when editAnswer is called', async t =
       payload: ['My First Answer', 'My Second Answer', 'My Third Answer']
     }
   ];
-  const {dispatch} = createTestStore(t, state, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, state, thunkOptions, expectedActions);
   await dispatch(editAnswer(['My Third Answer']));
 });
 
@@ -156,7 +158,7 @@ test('should dispatch EDIT_SLIDER action when editAnswer is called', async t => 
   const expectedActions = [
     {type: ANSWER_EDIT.slider, meta: {slideRef: sliderSlide.universalRef}, payload: ['5']}
   ];
-  const {dispatch} = createTestStore(t, state, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, state, thunkOptions, expectedActions);
   await dispatch(editAnswer(['5']));
 });
 
@@ -170,6 +172,6 @@ test('should dispatch EDIT_TEMPLATE action when editAnswer is called', async t =
       payload: ['Catalogue', 'My Answer', 'étoiles']
     }
   ];
-  const {dispatch} = createTestStore(t, state, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, state, thunkOptions, expectedActions);
   await dispatch(editAnswer(['Catalogue', 'My Answer', 'étoiles']));
 });

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/navigation.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/navigation.test.ts
@@ -1,8 +1,10 @@
 import test from 'ava';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../test/create-test-store';
 import type {StoreState} from '../../../reducers';
 import {navigateBack, navigateTo} from '../navigation';
+
+const thunkOptions = {services, appendVideoOptions};
 
 const initialState: StoreState = {
   data: {
@@ -33,7 +35,7 @@ test('should dispatch NAVIGATE_TO', async t => {
     }
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
   await dispatch(navigateTo('slides'));
 });
 
@@ -44,7 +46,7 @@ test('should dispatch NAVIGATE_BACK', t => {
     }
   ];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
   dispatch(navigateBack);
 });
 
@@ -65,7 +67,7 @@ test('should dispatch NAVIGATE_TO with callbackOnViewChanged', async t => {
   const {dispatch} = createTestStore(
     t,
     initialState,
-    {callbackOnViewChanged, services},
+    {callbackOnViewChanged, services, appendVideoOptions},
     expectedActions
   );
 
@@ -88,7 +90,7 @@ test('should dispatch NAVIGATE_BACK with callbackOnViewChanged', async t => {
   const {dispatch} = createTestStore(
     t,
     initialState,
-    {callbackOnViewChanged, services},
+    {callbackOnViewChanged, services, appendVideoOptions},
     expectedActions
   );
 

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/next-slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/next-slide.test.ts
@@ -1,7 +1,11 @@
 import test from 'ava';
 import pipe from 'lodash/fp/pipe';
 import set from 'lodash/fp/set';
-import {getChoicesCorrection, services} from '@coorpacademy/review-services-mocks';
+import {
+  getChoicesCorrection,
+  services,
+  appendVideoOptions
+} from '@coorpacademy/review-services-mocks';
 import {StoreState} from '../../../reducers';
 import {nextSlide, NEXT_SLIDE} from '../next-slide';
 import {createTestStore} from '../../test/create-test-store';
@@ -12,6 +16,7 @@ import {postAnswerResponses} from '../../../test/fixtures';
 const progression = postAnswerResponses[freeTextSlide.universalRef];
 const skillRef = '_skill-ref';
 const answer = ['Vous isoler dans un lieu calme'];
+const thunkOptions = {services, appendVideoOptions};
 
 const state: StoreState = {
   data: {
@@ -59,7 +64,7 @@ test('should dispatch NEXT_SLIDE action when nextSlide is called and the progres
       }
     }
   ];
-  const {dispatch} = createTestStore(t, state, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, state, thunkOptions, expectedActions);
   dispatch(nextSlide);
 });
 
@@ -81,6 +86,6 @@ test('should dispatch NEXT_SLIDE action when nextSlide is called and the progres
       }
     }
   ];
-  const {dispatch} = createTestStore(t, stateWithWrongAnswer, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, stateWithWrongAnswer, thunkOptions, expectedActions);
   dispatch(nextSlide);
 });

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/quit-popin.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/quit-popin.test.ts
@@ -1,8 +1,10 @@
 import test from 'ava';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../test/create-test-store';
 import type {StoreState} from '../../../reducers';
 import {closeQuitPopin, CLOSE_POPIN, openQuitPopin, OPEN_POPIN} from '../quit-popin';
+
+const thunkOptions = {services, appendVideoOptions};
 
 const initialState: StoreState = {
   data: {
@@ -28,13 +30,13 @@ const initialState: StoreState = {
 test('should dispatch OPEN_POPIN when openQuitPopin action is called', async t => {
   const expectedAction = [{type: OPEN_POPIN}];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedAction);
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedAction);
   await dispatch(openQuitPopin);
 });
 
 test('should dispatch CLOSE_POPIN when closeQuitPopin action is called', async t => {
   const expectedAction = [{type: CLOSE_POPIN}];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedAction);
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedAction);
   await dispatch(closeQuitPopin);
 });

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/slides.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/slides.test.ts
@@ -1,9 +1,11 @@
 import test from 'ava';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../test/create-test-store';
 import {StoreState} from '../../../reducers';
 import {setCurrentSlide, SET_CURRENT_SLIDE} from '../slides';
 import {freeTextSlide} from '../../../views/slides/test/fixtures/free-text';
+
+const thunkOptions = {services, appendVideoOptions};
 
 const initialState: StoreState = {
   data: {
@@ -29,6 +31,6 @@ const initialState: StoreState = {
 test('should dispatch SET_CURRENT_SLIDE action when setCurrentSlide is called', async t => {
   const expectedActions = [{type: SET_CURRENT_SLIDE, payload: freeTextSlide}];
 
-  const {dispatch} = createTestStore(t, initialState, {services}, expectedActions);
+  const {dispatch} = createTestStore(t, initialState, thunkOptions, expectedActions);
   await dispatch(setCurrentSlide(freeTextSlide));
 });

--- a/packages/@coorpacademy-app-review/src/configure-store.ts
+++ b/packages/@coorpacademy-app-review/src/configure-store.ts
@@ -15,7 +15,8 @@ export default function configureStore(options: AppOptions): Store<StoreState, A
 
   const thunkOptions: ThunkOptions = {
     services: options.services || getServices(),
-    callbackOnViewChanged: options.callbackOnViewChanged
+    callbackOnViewChanged: options.callbackOnViewChanged,
+    appendVideoOptions: options.appendVideoOptions
   };
 
   const thunkMiddleware = thunk.withExtraArgument(thunkOptions);

--- a/packages/@coorpacademy-app-review/src/configure-store.ts
+++ b/packages/@coorpacademy-app-review/src/configure-store.ts
@@ -1,6 +1,7 @@
 import {AnyAction, applyMiddleware, compose, createStore, Store} from 'redux';
 import thunk from 'redux-thunk';
 import {getServices} from '@coorpacademy/review-services';
+import {identity} from 'lodash/fp';
 import rootReducer, {StoreState} from './reducers';
 import type {ThunkOptions, AppOptions} from './types/common';
 
@@ -16,7 +17,7 @@ export default function configureStore(options: AppOptions): Store<StoreState, A
   const thunkOptions: ThunkOptions = {
     services: options.services || getServices(),
     callbackOnViewChanged: options.callbackOnViewChanged,
-    appendVideoOptions: options.appendVideoOptions
+    appendVideoOptions: options.appendVideoOptions || identity
   };
 
   const thunkMiddleware = thunk.withExtraArgument(thunkOptions);

--- a/packages/@coorpacademy-app-review/src/configure-store.ts
+++ b/packages/@coorpacademy-app-review/src/configure-store.ts
@@ -18,6 +18,8 @@ export default function configureStore(options: AppOptions): Store<StoreState, A
     services: options.services || getServices(),
     callbackOnViewChanged: options.callbackOnViewChanged,
     appendVideoOptions: options.appendVideoOptions || identity
+    // this identity is temporary added to avoir errors on mobile application,
+    // while the function to compute the props is made
   };
 
   const thunkMiddleware = thunk.withExtraArgument(thunkOptions);

--- a/packages/@coorpacademy-app-review/src/test/index.test.tsx
+++ b/packages/@coorpacademy-app-review/src/test/index.test.tsx
@@ -4,7 +4,7 @@ import test from 'ava';
 import type {ExecutionContext} from 'ava';
 import React from 'react';
 import {render, fireEvent, act} from '@testing-library/react';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import type {AppOptions} from '../types/common';
 import AppReview from '..';
 import {sleep} from './utils/sleep';
@@ -67,7 +67,8 @@ const appOptions: AppOptions = {
     common: {
       primary: '#248e59'
     }
-  }
+  },
+  appendVideoOptions
 };
 
 test('should show the loader while the app is fetching the data', async t => {

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -1,4 +1,4 @@
-import type {Services} from '@coorpacademy/review-services';
+import type {Services, VideoMedia, VideoPropsForPlayer} from '@coorpacademy/review-services';
 
 export type WithRequired<T, K extends keyof T> = T & {
   // the "-" is a Mapping Modifier, removes optionality from a prop
@@ -28,11 +28,13 @@ export type AppOptions = ConnectedOptions & {
   skillRef?: string;
   services?: Services;
   callbackOnViewChanged?: (viewName: ViewName) => void;
+  appendVideoOptions: (media: VideoMedia) => Promise<VideoPropsForPlayer>;
 };
 
 export type ThunkOptions = {
   callbackOnViewChanged?: AppOptions['callbackOnViewChanged'];
   services: Services;
+  appendVideoOptions: (media: VideoMedia) => Promise<VideoPropsForPlayer>;
 };
 
 export type Options = {

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -29,6 +29,7 @@ export type AppOptions = ConnectedOptions & {
   services?: Services;
   callbackOnViewChanged?: (viewName: ViewName) => void;
   appendVideoOptions?: (media: VideoMedia) => Promise<VideoPropsForPlayer>;
+  // set again as mandatory when mobile function would be implemented
 };
 
 export type ThunkOptions = {

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -28,7 +28,7 @@ export type AppOptions = ConnectedOptions & {
   skillRef?: string;
   services?: Services;
   callbackOnViewChanged?: (viewName: ViewName) => void;
-  appendVideoOptions: (media: VideoMedia) => Promise<VideoPropsForPlayer>;
+  appendVideoOptions?: (media: VideoMedia) => Promise<VideoPropsForPlayer>;
 };
 
 export type ThunkOptions = {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
@@ -1,7 +1,11 @@
 import test from 'ava';
 import identity from 'lodash/fp/identity';
 import {ReviewCongratsProps} from '@coorpacademy/components/es/organism/review-congrats/prop-types';
-import {getChoicesCorrection, services} from '@coorpacademy/review-services-mocks';
+import {
+  getChoicesCorrection,
+  services,
+  appendVideoOptions
+} from '@coorpacademy/review-services-mocks';
 import type {ProgressionFromAPI} from '@coorpacademy/review-services';
 import {SKILL_FETCH_REQUEST, SKILL_FETCH_SUCCESS} from '../../../actions/api/fetch-skill';
 import {createTestStore} from '../../../actions/test/create-test-store';
@@ -147,7 +151,8 @@ test('should dispatch POST_PROGRESSION_REQUEST action via the property onclick o
     {type: SKILL_FETCH_REQUEST},
     {type: SKILL_FETCH_SUCCESS, payload: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}}
   ];
-  const {dispatch, getState} = createTestStore(t, state, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, state, thunkOptions, expectedActions);
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   const congrats = props.congrats as ReviewCongratsProps;
   await congrats.buttonRevising?.onClick();

--- a/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
@@ -1,6 +1,10 @@
 import test from 'ava';
 import identity from 'lodash/fp/identity';
-import {services, getChoicesCorrection} from '@coorpacademy/review-services-mocks';
+import {
+  services,
+  getChoicesCorrection,
+  appendVideoOptions
+} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../../actions/test/create-test-store';
 import {StoreState} from '../../../reducers';
 import {OPEN_POPIN} from '../../../actions/ui/quit-popin';
@@ -46,7 +50,8 @@ test('should dispatch OPEN_POPIN action after a click on close button in header'
     }
   };
   const expectedAction = [{type: OPEN_POPIN}];
-  const {dispatch, getState} = createTestStore(t, state, {services}, expectedAction);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, state, thunkOptions, expectedAction);
   const props = mapStateToSlidesProps(getState(), dispatch, {
     translate,
     onQuitClick: identity,
@@ -142,7 +147,8 @@ test('should dispatch onQuitClick function after a click on close button in head
   };
 
   const expectedAction = [{type: NEXT_SLIDE}];
-  const {dispatch, getState} = createTestStore(t, state, {services}, expectedAction);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, state, thunkOptions, expectedAction);
   const props = mapStateToSlidesProps(getState(), dispatch, {
     translate,
     onQuitClick: () => t.pass(),

--- a/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import identity from 'lodash/fp/identity';
 import {CMPopinProps} from '@coorpacademy/components/es/molecule/cm-popin/types';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../../actions/test/create-test-store';
 import {CLOSE_POPIN} from '../../../actions/ui/quit-popin';
 import {StoreState} from '../../../reducers';
@@ -53,7 +53,8 @@ const state: StoreState = {
 
 test('should dispatch CLOSE_POPIN action via the property handleOnclick of secondButton when popin is open', async t => {
   const expectedAction = [{type: CLOSE_POPIN}];
-  const {dispatch, getState} = createTestStore(t, state, {services}, expectedAction);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, state, thunkOptions, expectedAction);
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   const quitPopin = props.quitPopin as CMPopinProps;
   await quitPopin.secondButton?.handleOnclick();
@@ -66,7 +67,8 @@ test('should dispatch CLOSE_POPIN action and call onQuitClick function via the p
   t.plan(4);
 
   const expectedAction = [{type: CLOSE_POPIN}];
-  const {dispatch, getState} = createTestStore(t, state, {services}, expectedAction);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, state, thunkOptions, expectedAction);
   const props = mapStateToSlidesProps(getState(), dispatch, {
     translate,
     onQuitClick: () => t.pass(),

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -2,7 +2,11 @@ import test from 'ava';
 import omit from 'lodash/fp/omit';
 import identity from 'lodash/fp/identity';
 import type {ProgressionFromAPI} from '@coorpacademy/review-services';
-import {getChoicesCorrection, services} from '@coorpacademy/review-services-mocks';
+import {
+  getChoicesCorrection,
+  services,
+  appendVideoOptions
+} from '@coorpacademy/review-services-mocks';
 import {POST_ANSWER_REQUEST, POST_ANSWER_SUCCESS} from '../../../actions/api/post-answer';
 import {SLIDE_FETCH_REQUEST, SLIDE_FETCH_SUCCESS} from '../../../actions/api/fetch-slide';
 import {
@@ -98,7 +102,8 @@ test('should dispatch EDIT_BASIC action via the property onChange of a Free Text
     {type: RANK_FETCH_START_REQUEST},
     {type: RANK_FETCH_START_SUCCESS, payload: {rank: 93}}
   ];
-  const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
@@ -2,7 +2,11 @@ import test from 'ava';
 import identity from 'lodash/fp/identity';
 import {ReviewCorrectionPopinProps} from '@coorpacademy/components/es/molecule/review-correction-popin/prop-types';
 
-import {getChoicesCorrection, services} from '@coorpacademy/review-services-mocks';
+import {
+  getChoicesCorrection,
+  services,
+  appendVideoOptions
+} from '@coorpacademy/review-services-mocks';
 import type {StoreState} from '../../../reducers';
 import {mapStateToSlidesProps} from '..';
 import {createTestStore} from '../../../actions/test/create-test-store';
@@ -70,7 +74,9 @@ test('correction popin actions after click', async t => {
       }
     }
   ];
-  const {dispatch, getState} = createTestStore(t, state, {services}, expectedActions);
+
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, state, thunkOptions, expectedActions);
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   const correctionPopin = props.stack.correctionPopinProps as ReviewCorrectionPopinProps;
   await correctionPopin.next.onClick();
@@ -174,7 +180,9 @@ test('correction popin actions after click when progression is finished', async 
       }
     }
   ];
-  const {dispatch, getState} = createTestStore(t, state, {services}, expectedActions);
+
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, state, thunkOptions, expectedActions);
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   t.is(props.congrats, undefined);
   const correctionPopin = props.stack.correctionPopinProps as ReviewCorrectionPopinProps;

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -3,7 +3,7 @@ import omit from 'lodash/fp/omit';
 import get from 'lodash/fp/get';
 import identity from 'lodash/fp/identity';
 import type {ProgressionFromAPI} from '@coorpacademy/review-services';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {mapStateToSlidesProps} from '..';
 import {createTestStore} from '../../../actions/test/create-test-store';
 import {StoreState} from '../../../reducers';
@@ -77,7 +77,9 @@ test('should dispatch EDIT_QCM_DRAG action via the property onClick of a QCM Dra
       payload: ['La démoralisation']
     }
   ];
-  const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
+
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -3,7 +3,7 @@ import omit from 'lodash/fp/omit';
 import get from 'lodash/fp/get';
 import identity from 'lodash/fp/identity';
 import type {ProgressionFromAPI} from '@coorpacademy/review-services';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {mapStateToSlidesProps} from '..';
 import {createTestStore} from '../../../actions/test/create-test-store';
 import {StoreState} from '../../../reducers';
@@ -77,7 +77,8 @@ test('should dispatch EDIT_QCM_GRAPHIC action via the property onClick of a QCM 
       payload: ['Le retour d’information']
     }
   ];
-  const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -3,7 +3,7 @@ import omit from 'lodash/fp/omit';
 import get from 'lodash/fp/get';
 import identity from 'lodash/fp/identity';
 import type {ProgressionFromAPI} from '@coorpacademy/review-services';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {mapStateToSlidesProps} from '..';
 import {createTestStore} from '../../../actions/test/create-test-store';
 import {StoreState} from '../../../reducers';
@@ -79,7 +79,8 @@ test('should dispatch EDIT_QCM action via the property onClick of a QCM slide', 
       ]
     }
   ];
-  const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -3,7 +3,7 @@ import omit from 'lodash/fp/omit';
 import get from 'lodash/fp/get';
 import identity from 'lodash/fp/identity';
 import type {ProgressionFromAPI} from '@coorpacademy/review-services';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {mapStateToSlidesProps} from '..';
 import {createTestStore} from '../../../actions/test/create-test-store';
 import {StoreState} from '../../../reducers';
@@ -77,7 +77,8 @@ test('should dispatch EDIT_SLIDER action via the property onChange of a Slider s
       payload: ['5']
     }
   ];
-  const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -3,7 +3,7 @@ import get from 'lodash/fp/get';
 import omit from 'lodash/fp/omit';
 import identity from 'lodash/fp/identity';
 import type {ProgressionFromAPI} from '@coorpacademy/review-services';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {StoreState} from '../../../reducers';
 import {mapStateToSlidesProps} from '..';
 import {createTestStore} from '../../../actions/test/create-test-store';
@@ -77,7 +77,8 @@ test('should dispatch EDIT_SLIDER action via the property onSliderChange of a Sl
       payload: ['111']
     }
   ];
-  const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, initialState, thunkOptions, expectedActions);
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
 
   const slideProps = props.stack.slides['0'].answerUI?.model as QuestionRange;

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -4,7 +4,7 @@ import get from 'lodash/fp/get';
 import set from 'lodash/fp/set';
 import identity from 'lodash/fp/identity';
 import type {ProgressionFromAPI} from '@coorpacademy/review-services';
-import {services} from '@coorpacademy/review-services-mocks';
+import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {mapStateToSlidesProps} from '..';
 import {createTestStore} from '../../../actions/test/create-test-store';
 import {StoreState} from '../../../reducers';
@@ -75,7 +75,8 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
     {type: EDIT_TEMPLATE, meta: {slideRef: templateSlide._id}, payload: ['', 'test', '']},
     {type: EDIT_TEMPLATE, meta: {slideRef: templateSlide._id}, payload: ['Catalogue', '', '']}
   ];
-  const {dispatch, getState} = createTestStore(t, initialState, {services}, expectedActions);
+  const thunkOptions = {services, appendVideoOptions};
+  const {dispatch, getState} = createTestStore(t, initialState, thunkOptions, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   t.deepEqual(omit('answerUI', props.stack.slides['0']), {
@@ -103,10 +104,11 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
   const expectedActions = [
     {type: EDIT_TEMPLATE, meta: {slideRef: templateSlide._id}, payload: ['', '', '']}
   ];
+  const thunkOptions = {services, appendVideoOptions};
   const {dispatch, getState} = createTestStore(
     t,
     set(['ui', 'answers', templateSlide._id], ['', 'Test', ''], initialState),
-    {services},
+    thunkOptions,
     expectedActions
   );
 

--- a/packages/@coorpacademy-review-services-mocks/src/index.ts
+++ b/packages/@coorpacademy-review-services-mocks/src/index.ts
@@ -10,7 +10,8 @@ import type {
   Skill,
   SlideFromAPI,
   SlideIdFromAPI,
-  VideoMedia
+  VideoMedia,
+  VideoPropsForPlayer
 } from '@coorpacademy/review-services';
 import {
   computeNextStepAfterAnswerForReview,
@@ -269,7 +270,7 @@ const getPostAnswer = (progression: ProgressionFromAPI, answer: string[]): Progr
   return response;
 };
 
-export const appendVideoOptions = (media: VideoMedia): Promise<unknown> => {
+export const appendVideoOptions = (media: VideoMedia): Promise<VideoPropsForPlayer> => {
   const videoSrc = media.src[0];
   const {videoId, mediaRef} = videoSrc;
   return Promise.resolve({

--- a/packages/@coorpacademy-review-services/src/index.ts
+++ b/packages/@coorpacademy-review-services/src/index.ts
@@ -11,6 +11,7 @@ import type {
   SlideMedia as SlideMedia_,
   MediaSrc as MediaSrc_,
   VideoSrc as VideoSrc_,
+  VideoPropsForPlayer as VideoPropsForPlayer_,
   AudioMedia as _AudioMedia,
   ImageMedia as _ImageMedia,
   VideoMedia as _VideoMedia,
@@ -61,6 +62,7 @@ export type SlideFromAPI = SlideFromAPI_;
 export type SlideIdFromAPI = SlideIdFromAPI_;
 export type MediaSrc = MediaSrc_;
 export type VideoSrc = VideoSrc_;
+export type VideoPropsForPlayer = VideoPropsForPlayer_;
 export type SlideMedia = SlideMedia_;
 export type AudioMedia = _AudioMedia;
 export type ImageMedia = _ImageMedia;

--- a/packages/@coorpacademy-review-services/src/types/services-types.ts
+++ b/packages/@coorpacademy-review-services/src/types/services-types.ts
@@ -57,13 +57,24 @@ type BaseContent = {
   answers: string[][];
 };
 
+type VideoSrcPropsForPlayer = {
+  mimeType: string;
+  videoId: string;
+  jwpOptions: unknown;
+  hide?: boolean;
+};
+
+export type VideoPropsForPlayer = {
+  type: string;
+  src: VideoSrcPropsForPlayer[];
+};
+
 export type MediaSrc = {_id: string; mimeType: string; url: string};
 export type VideoSrc = {
   _id: string;
   mimeType: string;
   videoId: string;
   mediaRef: string;
-  hide?: boolean;
 };
 
 export type VideoMedia = {


### PR DESCRIPTION
https://trello.com/c/tFtAgEL6/2934-or-bug-non-affichage-des-m%C3%A9dias-sur-les-slides

**Detailed purpose of the PR**

Adds the `appendVideoOptions` function within the props of the app-review. This function is necessary to compute the props for the video to be shown as media of a slide. Currently, this function is on the [MediaService](https://github.com/CoorpAcademy/coorpacademy/blob/master/core/public/js/services/MediaService.js#L512) file (angular context of the mooc).

In order to avoir errors on mobile/web implementations of this improvement, this prop is optional. Next PRs would add actions and reducers related to its use.

**Result and observation**

Behavior should be the same as before.

**Testing Strategy**

- Already covered by tests
