### PR TITLE
fix misspelled state prop for bailout

### DIFF
--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-slide.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-slide.ts
@@ -33,7 +33,7 @@ export const fetchSlide =
     const action = buildTask({
       types: [SLIDE_FETCH_REQUEST, SLIDE_FETCH_SUCCESS, SLIDE_FETCH_FAILURE],
       bailout: (state: StoreState): boolean => {
-        return has(`data.slide.${slideRef}`, state);
+        return has(`data.slides.${slideRef}`, state);
       },
       task: () => {
         const state = getState();
@@ -45,7 +45,7 @@ export const fetchSlide =
     const response = await dispatch(action);
 
     if (response.type === SLIDE_FETCH_SUCCESS) {
-      const slideFromAPI = response.payload;
+      const slideFromAPI = response.payload as SlideFromAPI;
       const state = getState();
       const slides = get('data.progression.state.slides', state);
       if (isEmpty(slides)) {

--- a/packages/@coorpacademy-app-review/src/reducers/data/slides.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/data/slides.ts
@@ -1,11 +1,6 @@
 import set from 'lodash/fp/set';
 import type {SlideFromAPI} from '@coorpacademy/review-services';
-import {
-  ReceivedSlide,
-  FetchSlide,
-  SLIDE_FETCH_REQUEST,
-  SLIDE_FETCH_SUCCESS
-} from '../../actions/api/fetch-slide';
+import {ReceivedSlide, FetchSlide, SLIDE_FETCH_SUCCESS} from '../../actions/api/fetch-slide';
 import {FetchProgression, POST_PROGRESSION_REQUEST} from '../../actions/api/post-progression';
 
 export type SlidesAction = FetchSlide | ReceivedSlide;
@@ -19,10 +14,6 @@ const reducer = (
   action: SlidesAction | FetchProgression
 ): SlidesState => {
   switch (action.type) {
-    case SLIDE_FETCH_REQUEST: {
-      const {meta} = action;
-      return set([meta.slideRef], null, state);
-    }
     case SLIDE_FETCH_SUCCESS: {
       const slide = action.payload;
       return set([slide._id], slide, state);

--- a/packages/@coorpacademy-app-review/src/reducers/data/test/slides.test.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/data/test/slides.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import {POST_PROGRESSION_REQUEST} from '../../../actions/api/post-progression';
-import {SLIDE_FETCH_REQUEST, SLIDE_FETCH_SUCCESS} from '../../../actions/api/fetch-slide';
+import {SLIDE_FETCH_SUCCESS} from '../../../actions/api/fetch-slide';
 import reducer, {type SlidesAction} from '../slides';
 import {freeTextSlide} from '../../../views/slides/test/fixtures/free-text';
 import {qcmSlide} from '../../../views/slides/test/fixtures/qcm';
@@ -11,14 +11,6 @@ import {templateSlide} from '../../../views/slides/test/fixtures/template';
 test('should have initial value', t => {
   const state = reducer(undefined, {} as SlidesAction);
   t.deepEqual(state, {});
-});
-
-test('should set the value of SLIDE_FETCH_REQUEST action', t => {
-  const slideRef = 'sli_VJYjJnJhg';
-  const state = reducer({}, {type: SLIDE_FETCH_REQUEST, meta: {slideRef}});
-  t.deepEqual(state, {
-    [slideRef]: null
-  });
 });
 
 test('should set the value of SLIDE_FETCH_SUCCESS action', t => {


### PR DESCRIPTION
**Detailed purpose of the PR**

Fix verification on state to avoid fetch again slides that are already on the state (in the case of the slide already wrongly answered)

**Results**

*Avant*
We have the scenario or one question was already answered wrongly, it's already on the state. Currently we see the FETCH_SLIDE_SUCCESS action, which means that we've made a call the api again to recover the slide

![fetch-slide-twice](https://user-images.githubusercontent.com/7602475/214817907-5c97b317-7cfe-4103-8cd7-b5c5006a5b3c.gif)

*After*
![fetch-slide-once](https://user-images.githubusercontent.com/7602475/214821369-67090394-7854-43a0-b3a4-76d1717390a9.gif)


**Testing Strategy**

- Already covered by tests
- Unit testing
