### PR TITLE
[Review] compute slide video props

### DIFF
--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-video-props.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-video-props.ts
@@ -53,6 +53,7 @@ export const fetchPropsVideo =
 
       const props = await appendVideoOptions(slideMedia);
       props.src[0].loading = false; // set to false to not show it until the next slide is unstack
+      props.src[0].type = 'video';
       dispatch(
         setVideoProps({
           slideId,

--- a/packages/@coorpacademy-app-review/src/actions/api/fetch-video-props.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/fetch-video-props.ts
@@ -1,0 +1,64 @@
+import type {Dispatch} from 'redux';
+import get from 'lodash/fp/get';
+import type {SlideMedia} from '@coorpacademy/review-services';
+import type {ThunkOptions, VideoPropsForPlayer} from '../../types/common';
+import type {StoreState} from '../../reducers';
+
+export const SET_VIDEO_PROPS = '@@slide/SET_VIDEO_PROPS' as const;
+export const SHOW_VIDEO = '@@slide/SHOW_VIDEO' as const;
+
+export type VideoPropsPayload = {
+  slideId: string;
+  props: VideoPropsForPlayer;
+};
+
+export type SetVideoPropsAction = {
+  type: typeof SET_VIDEO_PROPS;
+  payload: VideoPropsPayload;
+};
+export const setVideoProps = (payload: VideoPropsPayload): SetVideoPropsAction => ({
+  type: SET_VIDEO_PROPS,
+  payload
+});
+
+export type ShowVideoAction = {
+  type: typeof SHOW_VIDEO;
+  payload: {slideId: string};
+};
+export const showVideo = (slideId: string): ShowVideoAction => ({
+  type: SHOW_VIDEO,
+  payload: {slideId}
+});
+
+export const fetchPropsVideo =
+  (slideId: string) =>
+  async (
+    dispatch: Dispatch,
+    getState: () => StoreState,
+    {appendVideoOptions}: ThunkOptions
+  ): Promise<void> => {
+    const state = getState();
+    const slideFromAPI = get(['data', 'slides', slideId], state);
+    if (!slideFromAPI) {
+      return;
+    }
+
+    const slideMedia = get(['question', 'medias', '0'], slideFromAPI) as SlideMedia;
+    if (slideMedia && slideMedia.type === 'video') {
+      const videoProps = get(['data', 'videos', slideId], state);
+      if (videoProps) {
+        dispatch(showVideo(slideId));
+        return;
+      }
+
+      const props = await appendVideoOptions(slideMedia);
+      props.src[0].loading = false; // set to false to not show it until the next slide is unstack
+      dispatch(
+        setVideoProps({
+          slideId,
+          props
+        })
+      );
+    }
+    return;
+  };

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-correction.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-correction.test.ts
@@ -31,7 +31,8 @@ const initialState: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: skillRef, name: skillRef}
+    currentSkill: {ref: skillRef, name: skillRef},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-rank.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-rank.test.ts
@@ -14,27 +14,13 @@ import {
   RANK_FETCH_END_FAILURE
 } from '../fetch-rank';
 import {createTestStore} from '../../test/create-test-store';
+import {initialState as _initialState_} from '../../../test/fixtures';
 
-const initialState: StoreState = {
-  data: {
-    progression: null,
-    slides: {},
-    token: '1234',
-    corrections: {},
-    rank: {start: Number.NaN, end: Number.NaN},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
-  },
-  ui: {
-    showCongrats: false,
-    positions: [0, 1, 2, 3, 4],
-    currentSlideRef: '',
-    navigation: [],
-    answers: {},
-    slide: {},
-    showQuitPopin: false,
-    showButtonRevising: false
-  }
-};
+const initialState: StoreState = set(
+  'data.currentSkill',
+  {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+  _initialState_
+);
 
 test('should dispatch FETCH_START_SUCCESS action when fetchStartRank returns the start rank', async t => {
   t.plan(4);

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skill.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-skill.test.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import type {Services, Skill} from '@coorpacademy/review-services';
 import {services as mockedServices, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../test/create-test-store';
-import type {StoreState} from '../../../reducers';
+import {initialState} from '../../../test/fixtures';
 import {
   fetchSkill,
   SKILL_FETCH_FAILURE,
@@ -13,27 +13,6 @@ import {
 export const fetchSkillResponse: Skill = {
   ref: 'skill_NyxtYFYir',
   name: 'Digital Awareness'
-};
-
-const initialState: StoreState = {
-  data: {
-    progression: null,
-    slides: {},
-    token: '1234',
-    corrections: {},
-    rank: {start: Number.NaN, end: Number.NaN},
-    currentSkill: null
-  },
-  ui: {
-    showCongrats: false,
-    positions: [0, 1, 2, 3, 4],
-    currentSlideRef: '',
-    navigation: [],
-    answers: {},
-    slide: {},
-    showQuitPopin: false,
-    showButtonRevising: false
-  }
 };
 
 test('should dispatch FETCH_SKILL_SUCCESS when fetch skill is call with the correct skill', async t => {

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slide.test.ts
@@ -7,34 +7,14 @@ import {
   SLIDE_FETCH_REQUEST,
   SLIDE_FETCH_SUCCESS
 } from '../fetch-slide';
-import type {StoreState} from '../../../reducers';
+import {initialState} from '../../../test/fixtures';
 import {SET_CURRENT_SLIDE} from '../../ui/slides';
 import {createTestStore} from '../../test/create-test-store';
 import {freeTextSlide} from '../../../views/slides/test/fixtures/free-text';
-
-const initialState: StoreState = {
-  data: {
-    progression: null,
-    slides: {},
-    token: '1234',
-    corrections: {},
-    rank: {start: 10, end: Number.NaN},
-    currentSkill: null
-  },
-  ui: {
-    showCongrats: false,
-    positions: [0, 1, 2, 3, 4],
-    currentSlideRef: '',
-    navigation: [],
-    answers: {},
-    slide: {},
-    showQuitPopin: false,
-    showButtonRevising: false
-  }
-};
+import {SET_VIDEO_PROPS} from '../fetch-video-props';
 
 test('should dispatch FETCH_SUCCESS and SET_CURRENT_SLIDE actions when fetchSlide return a slide', async t => {
-  t.plan(5);
+  t.plan(6);
   const services: Services = {
     ...mockedServices,
     fetchSlide: (slideRef, token) => {
@@ -51,7 +31,51 @@ test('should dispatch FETCH_SUCCESS and SET_CURRENT_SLIDE actions when fetchSlid
       meta: {slideRef: 'sli_VJYjJnJhg'},
       payload: freeTextSlide
     },
-    {type: SET_CURRENT_SLIDE, payload: freeTextSlide}
+    {type: SET_CURRENT_SLIDE, payload: freeTextSlide},
+    {
+      type: SET_VIDEO_PROPS,
+      payload: {
+        slideId: freeTextSlide._id,
+        props: {
+          type: 'video',
+          src: [
+            {
+              loading: false,
+              type: 'video',
+              mimeType: 'application/jwplayer',
+              videoId: '489S0B87',
+              mediaRef: 'med_free_text',
+              jwpOptions: {
+                playerId: '7IMa4DCK',
+                playerScript: 'https://static.coorpacademy.com/JwPlayer/8.6.3/jwplayer.js',
+                licenseKey: 'QDh3Fb2afiIAFI+XwlncwQDhNEwkXetm1y8tzWn3km8=',
+                playlist: [
+                  {
+                    file: 'https://content.jwplatform.com/manifests/489S0B87.m3u8',
+                    tracks: [
+                      {
+                        file: 'https://content.jwplatform.com/strips/489S0B87-120.vtt',
+                        kind: 'thumbnails'
+                      }
+                    ]
+                  }
+                ],
+                customProps: {
+                  playbackRateControls: true,
+                  playbackRates: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
+                  preload: 'auto',
+                  autostart: 'true',
+                  width: '100%',
+                  height: '343px',
+                  visualplaylist: false,
+                  nextUpDisplay: false
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
   ];
 
   const thunkOptions = {services, appendVideoOptions};

--- a/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slides-to-review-by-skill-ref.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/fetch-slides-to-review-by-skill-ref.test.ts
@@ -28,7 +28,8 @@ const state: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/actions/api/test/post-answer.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/post-answer.test.ts
@@ -66,7 +66,8 @@ const initialState: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: skillRef, name: skillRef}
+    currentSkill: {ref: skillRef, name: skillRef},
+    videos: {}
   },
   ui: {
     showCongrats: false,
@@ -259,7 +260,8 @@ test('should dispatch post-answer, fetch-correction, fetch-end-rank and fetch-sl
       token: '1234',
       corrections: {},
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: skillRef, name: skillRef}
+      currentSkill: {ref: skillRef, name: skillRef},
+      videos: {}
     },
     ui: {
       showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/actions/api/test/post-progression.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/api/test/post-progression.test.ts
@@ -7,36 +7,16 @@ import {
   POST_PROGRESSION_SUCCESS,
   POST_PROGRESSION_FAILURE
 } from '../post-progression';
-import type {StoreState} from '../../../reducers';
+import {initialState} from '../../../test/fixtures';
 import {SLIDE_FETCH_REQUEST, SLIDE_FETCH_SUCCESS} from '../fetch-slide';
 import {SET_CURRENT_SLIDE} from '../../ui/slides';
 import {createTestStore} from '../../test/create-test-store';
 import {SKILL_FETCH_FAILURE, SKILL_FETCH_REQUEST, SKILL_FETCH_SUCCESS} from '../fetch-skill';
 import {freeTextSlide} from '../../../views/slides/test/fixtures/free-text';
-
-const initialState: StoreState = {
-  data: {
-    progression: null,
-    slides: {},
-    token: '1234',
-    corrections: {},
-    rank: {start: 10, end: Number.NaN},
-    currentSkill: null
-  },
-  ui: {
-    showCongrats: false,
-    positions: [0, 1, 2, 3, 4],
-    currentSlideRef: '',
-    navigation: [],
-    answers: {},
-    slide: {},
-    showQuitPopin: false,
-    showButtonRevising: false
-  }
-};
+import {SET_VIDEO_PROPS} from '../fetch-video-props';
 
 test('should dispatch POST_PROGRESSION_SUCCESS and SLIDE_FETCH_REQUEST actions when postProgression returns a progression', async t => {
-  t.plan(11);
+  t.plan(12);
   const progression: ProgressionFromAPI = {
     _id: '62b1d1087aa12f00253f40ee',
     content: {
@@ -96,6 +76,50 @@ test('should dispatch POST_PROGRESSION_SUCCESS and SLIDE_FETCH_REQUEST actions w
       payload: freeTextSlide
     },
     {type: SET_CURRENT_SLIDE, payload: freeTextSlide},
+    {
+      type: SET_VIDEO_PROPS,
+      payload: {
+        slideId: freeTextSlide._id,
+        props: {
+          type: 'video',
+          src: [
+            {
+              loading: false,
+              type: 'video',
+              mimeType: 'application/jwplayer',
+              videoId: '489S0B87',
+              mediaRef: 'med_free_text',
+              jwpOptions: {
+                playerId: '7IMa4DCK',
+                playerScript: 'https://static.coorpacademy.com/JwPlayer/8.6.3/jwplayer.js',
+                licenseKey: 'QDh3Fb2afiIAFI+XwlncwQDhNEwkXetm1y8tzWn3km8=',
+                playlist: [
+                  {
+                    file: 'https://content.jwplatform.com/manifests/489S0B87.m3u8',
+                    tracks: [
+                      {
+                        file: 'https://content.jwplatform.com/strips/489S0B87-120.vtt',
+                        kind: 'thumbnails'
+                      }
+                    ]
+                  }
+                ],
+                customProps: {
+                  playbackRateControls: true,
+                  playbackRates: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
+                  preload: 'auto',
+                  autostart: 'true',
+                  width: '100%',
+                  height: '343px',
+                  visualplaylist: false,
+                  nextUpDisplay: false
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
     {type: SKILL_FETCH_REQUEST},
     {type: SKILL_FETCH_SUCCESS, payload: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}}
   ];

--- a/packages/@coorpacademy-app-review/src/actions/data/test/token.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/data/test/token.test.ts
@@ -1,29 +1,8 @@
 import test from 'ava';
 import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../test/create-test-store';
-import {StoreState} from '../../../reducers';
+import {initialState} from '../../../test/fixtures';
 import {storeToken, STORE_TOKEN} from '../token';
-
-const initialState: StoreState = {
-  data: {
-    progression: null,
-    slides: {},
-    token: '1234',
-    corrections: {},
-    rank: {start: Number.NaN, end: Number.NaN},
-    currentSkill: null
-  },
-  ui: {
-    showCongrats: false,
-    positions: [0, 1, 2, 3, 4],
-    currentSlideRef: '',
-    navigation: [],
-    answers: {},
-    slide: {},
-    showQuitPopin: false,
-    showButtonRevising: false
-  }
-};
 
 test('should dispatch STORE_TOKEN action when storeToken is called', async t => {
   const expectedActions = [{type: STORE_TOKEN, payload: 'JWT.token'}];

--- a/packages/@coorpacademy-app-review/src/actions/ui/next-slide.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/next-slide.ts
@@ -5,6 +5,7 @@ import type {ProgressionFromAPI, ProgressionAnswerItem} from '@coorpacademy/revi
 import {fetchEndRank} from '../api/fetch-rank';
 import {fetchSlidesToReviewBySkillRef} from '../api/fetch-slides-to-review-by-skill-ref';
 import type {StoreState} from '../../reducers';
+import {fetchPropsVideo} from '../api/fetch-video-props';
 
 export const NEXT_SLIDE = '@@slide/NEXT_SLIDE' as const;
 
@@ -21,10 +22,7 @@ export type NextSlideAction = {
   payload: NextSlidePayload;
 };
 
-export const nextSlide = async (
-  dispatch: Dispatch,
-  getState: () => StoreState
-): Promise<NextSlideAction> => {
+export const nextSlide = async (dispatch: Dispatch, getState: () => StoreState): Promise<void> => {
   const state = getState();
   const progression = state.data.progression as ProgressionFromAPI;
   const {isCorrect, allAnswers, slides} = progression.state;
@@ -49,7 +47,9 @@ export const nextSlide = async (
   if (nextSlideRef === 'successExitNode') {
     await dispatch(fetchEndRank);
     await dispatch(fetchSlidesToReviewBySkillRef);
+    dispatch(action);
+  } else {
+    dispatch(action);
+    await dispatch(fetchPropsVideo(payload.nextSlideRef));
   }
-
-  return dispatch(action);
 };

--- a/packages/@coorpacademy-app-review/src/actions/ui/slides.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/slides.ts
@@ -1,5 +1,7 @@
+import type {Dispatch} from 'redux';
 import type {SlideFromAPI} from '@coorpacademy/review-services';
 import {AnswerUI} from '../../types/slides';
+import {fetchPropsVideo} from '../api/fetch-video-props';
 
 type SlideUIAnimations = 'unstack' | 'restack';
 
@@ -20,7 +22,14 @@ export type SetCurrentSlideAction = {
   type: typeof SET_CURRENT_SLIDE;
   payload: SlideFromAPI;
 };
-export const setCurrentSlide = (payload: SlideFromAPI): SetCurrentSlideAction => ({
-  type: SET_CURRENT_SLIDE,
-  payload
-});
+
+export const setCurrentSlide =
+  (slideFromAPI: SlideFromAPI) =>
+  async (dispatch: Dispatch): Promise<void> => {
+    dispatch({
+      type: SET_CURRENT_SLIDE,
+      payload: slideFromAPI
+    });
+    await dispatch(fetchPropsVideo(slideFromAPI._id));
+    return;
+  };

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/answers.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/answers.test.ts
@@ -48,7 +48,8 @@ const initialState: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: '_skill-ref', name: '_skill-ref'}
+    currentSkill: {ref: '_skill-ref', name: '_skill-ref'},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/navigation.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/navigation.test.ts
@@ -1,31 +1,12 @@
 import test from 'ava';
 import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
+import {set} from 'lodash/fp';
 import {createTestStore} from '../../test/create-test-store';
-import type {StoreState} from '../../../reducers';
+import {initialState as _initialState_} from '../../../test/fixtures';
 import {navigateBack, navigateTo} from '../navigation';
 
 const thunkOptions = {services, appendVideoOptions};
-
-const initialState: StoreState = {
-  data: {
-    progression: null,
-    slides: {},
-    token: '1234',
-    corrections: {},
-    rank: {start: 10, end: Number.NaN},
-    currentSkill: null
-  },
-  ui: {
-    positions: [0, 1, 2, 3, 4],
-    currentSlideRef: '',
-    navigation: ['loader', 'slides'],
-    answers: {},
-    slide: {},
-    showCongrats: false,
-    showQuitPopin: false,
-    showButtonRevising: false
-  }
-};
+const initialState = set('ui.navigation', ['loader', 'slides'], _initialState_);
 
 test('should dispatch NAVIGATE_TO', async t => {
   const expectedActions = [

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/next-slide.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/next-slide.test.ts
@@ -28,7 +28,8 @@ const state: StoreState = {
     token: '1234',
     corrections: {[freeTextSlide.universalRef]: getChoicesCorrection(freeTextSlide.universalRef)},
     rank: {start: 93, end: Number.NaN},
-    currentSkill: {ref: skillRef, name: skillRef}
+    currentSkill: {ref: skillRef, name: skillRef},
+    videos: {}
   },
   ui: {
     showCongrats: false,
@@ -51,7 +52,8 @@ const state: StoreState = {
   }
 };
 
-test('should dispatch NEXT_SLIDE action when nextSlide is called and the progression state is correct', t => {
+test('should dispatch NEXT_SLIDE action when nextSlide is called and the progression state is correct', async t => {
+  t.plan(1);
   const expectedActions = [
     {
       type: NEXT_SLIDE,
@@ -65,10 +67,11 @@ test('should dispatch NEXT_SLIDE action when nextSlide is called and the progres
     }
   ];
   const {dispatch} = createTestStore(t, state, thunkOptions, expectedActions);
-  dispatch(nextSlide);
+  await dispatch(nextSlide);
 });
 
-test('should dispatch NEXT_SLIDE action when nextSlide is called and the progression state is not correct', t => {
+test('should dispatch NEXT_SLIDE action when nextSlide is called and the progression state is not correct', async t => {
+  t.plan(1);
   const stateWithWrongAnswer = pipe(
     set(['data', 'progression', 'state', 'isCorrect'], false),
     set(['data', 'progression', 'state', 'allAnswers', 0, 'isCorrect'], false)
@@ -87,5 +90,5 @@ test('should dispatch NEXT_SLIDE action when nextSlide is called and the progres
     }
   ];
   const {dispatch} = createTestStore(t, stateWithWrongAnswer, thunkOptions, expectedActions);
-  dispatch(nextSlide);
+  await dispatch(nextSlide);
 });

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/quit-popin.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/quit-popin.test.ts
@@ -1,31 +1,17 @@
 import test from 'ava';
 import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
+import {set} from 'lodash/fp';
 import {createTestStore} from '../../test/create-test-store';
-import type {StoreState} from '../../../reducers';
+import {initialState as _initialState_} from '../../../test/fixtures';
 import {closeQuitPopin, CLOSE_POPIN, openQuitPopin, OPEN_POPIN} from '../quit-popin';
 
 const thunkOptions = {services, appendVideoOptions};
 
-const initialState: StoreState = {
-  data: {
-    progression: null,
-    slides: {},
-    token: '1234',
-    corrections: {},
-    rank: {start: Number.NaN, end: Number.NaN},
-    currentSkill: {ref: '_skill-ref', name: '_skill-ref'}
-  },
-  ui: {
-    showCongrats: false,
-    currentSlideRef: '',
-    navigation: [],
-    answers: {},
-    slide: {},
-    positions: [],
-    showQuitPopin: false,
-    showButtonRevising: false
-  }
-};
+const initialState = set(
+  'data.currentSkill',
+  {ref: '_skill-ref', name: '_skill-ref'},
+  _initialState_
+);
 
 test('should dispatch OPEN_POPIN when openQuitPopin action is called', async t => {
   const expectedAction = [{type: OPEN_POPIN}];

--- a/packages/@coorpacademy-app-review/src/actions/ui/test/slides.test.ts
+++ b/packages/@coorpacademy-app-review/src/actions/ui/test/slides.test.ts
@@ -1,32 +1,11 @@
 import test from 'ava';
 import {services, appendVideoOptions} from '@coorpacademy/review-services-mocks';
 import {createTestStore} from '../../test/create-test-store';
-import {StoreState} from '../../../reducers';
+import {initialState} from '../../../test/fixtures';
 import {setCurrentSlide, SET_CURRENT_SLIDE} from '../slides';
 import {freeTextSlide} from '../../../views/slides/test/fixtures/free-text';
 
 const thunkOptions = {services, appendVideoOptions};
-
-const initialState: StoreState = {
-  data: {
-    progression: null,
-    slides: {},
-    token: '1234',
-    corrections: {},
-    rank: {start: Number.NaN, end: Number.NaN},
-    currentSkill: null
-  },
-  ui: {
-    showCongrats: false,
-    currentSlideRef: '',
-    navigation: [],
-    positions: [0, 1, 2, 3, 4],
-    answers: {},
-    slide: {},
-    showQuitPopin: false,
-    showButtonRevising: false
-  }
-};
 
 test('should dispatch SET_CURRENT_SLIDE action when setCurrentSlide is called', async t => {
   const expectedActions = [{type: SET_CURRENT_SLIDE, payload: freeTextSlide}];

--- a/packages/@coorpacademy-app-review/src/reducers/data/index.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/data/index.ts
@@ -6,6 +6,7 @@ import slides, {SlidesState} from './slides';
 import token, {TokenState} from './token';
 import rank, {RankState} from './rank';
 import currentSkill, {CurrentSkillState} from './current-skill';
+import videos, {VideoPropsState} from './videos';
 
 export type DataState = {
   corrections: CorrectionsState;
@@ -14,6 +15,7 @@ export type DataState = {
   token: TokenState;
   rank: RankState;
   currentSkill: CurrentSkillState;
+  videos: VideoPropsState;
 };
 
 export default combineReducers({
@@ -22,5 +24,6 @@ export default combineReducers({
   slides,
   token,
   rank,
-  currentSkill
+  currentSkill,
+  videos
 });

--- a/packages/@coorpacademy-app-review/src/reducers/data/test/videos.test.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/data/test/videos.test.ts
@@ -1,0 +1,148 @@
+import test from 'ava';
+import {NEXT_SLIDE} from '../../../actions/ui/next-slide';
+import {SET_VIDEO_PROPS, ShowVideoAction, SHOW_VIDEO} from '../../../actions/api/fetch-video-props';
+import reducer from '../videos';
+import {VideoPropsForPlayer} from '../../../types/common';
+
+const videoProps: VideoPropsForPlayer = {
+  type: 'video',
+  src: [
+    {
+      mimeType: 'application/jwplayer',
+      videoId: '12345',
+      jwpOptions: {
+        playerId: '7IMa4DCK',
+        playerScript: 'https://static.coorpacademy.com/JwPlayer/8.6.3/jwplayer.js'
+      },
+      loading: false,
+      type: 'video'
+    }
+  ]
+};
+
+test('should have initial value', t => {
+  const state = reducer({}, {} as ShowVideoAction);
+  t.deepEqual(state, {});
+});
+
+test('should set the value of Video Props for a slide when SET_VIDEO_PROPS action was dispatched', t => {
+  const state = reducer(
+    {},
+    {
+      type: SET_VIDEO_PROPS,
+      payload: {
+        slideId: 'sli_with_media',
+        props: videoProps
+      }
+    }
+  );
+  t.deepEqual(state, {
+    sli_with_media: videoProps
+  });
+});
+
+test('should return same state when NEXT_SLIDE action is called but no video belongs to the currentSlideRef', t => {
+  const initialState = {
+    anserewed_slide_with_media: videoProps
+  };
+  const state = reducer(initialState, {
+    type: NEXT_SLIDE,
+    payload: {
+      currentSlideRef: 'slide_without_media',
+      nextSlideRef: 'next_slide',
+      animationType: 'restack',
+      totalCorrectAnswers: 0,
+      answeredSlides: []
+    }
+  });
+  t.deepEqual(state, initialState);
+});
+
+test('should hide a video when NEXT_SLIDE action is called and currentSlideRef has video', t => {
+  const initialState = {
+    current_slide: videoProps
+  };
+  const state = reducer(initialState, {
+    type: NEXT_SLIDE,
+    payload: {
+      currentSlideRef: 'current_slide',
+      nextSlideRef: 'next_slide',
+      animationType: 'restack',
+      totalCorrectAnswers: 0,
+      answeredSlides: []
+    }
+  });
+  t.deepEqual(state, {
+    current_slide: {
+      type: 'video',
+      src: [
+        {
+          mimeType: 'application/jwplayer',
+          videoId: '12345',
+          jwpOptions: {
+            playerId: '7IMa4DCK',
+            playerScript: 'https://static.coorpacademy.com/JwPlayer/8.6.3/jwplayer.js'
+          },
+          loading: true,
+          type: 'video'
+        }
+      ]
+    }
+  });
+});
+
+test('should return same state when SHOW_VIDEO action is called but no video belongs to the currentSlideRef', t => {
+  const initialState = {
+    anserewed_slide_with_media: videoProps
+  };
+  const state = reducer(initialState, {
+    type: SHOW_VIDEO,
+    payload: {
+      slideId: 'slide_without_media'
+    }
+  });
+  t.deepEqual(state, initialState);
+});
+
+test('should show a video when SHOW_VIDEO action is called and slideId has video', t => {
+  const initialState = {
+    current_slide: {
+      type: 'video',
+      src: [
+        {
+          mimeType: 'application/jwplayer',
+          videoId: '12345',
+          jwpOptions: {
+            playerId: '7IMa4DCK',
+            playerScript: 'https://static.coorpacademy.com/JwPlayer/8.6.3/jwplayer.js'
+          },
+          loading: true,
+          type: 'video'
+        }
+      ]
+    }
+  };
+  const state = reducer(initialState, {
+    type: SHOW_VIDEO,
+    payload: {
+      slideId: 'current_slide'
+    }
+  });
+  t.deepEqual(state, {
+    current_slide: {
+      type: 'video',
+      src: [
+        {
+          mimeType: 'application/jwplayer',
+          videoId: '12345',
+          jwpOptions: {
+            playerId: '7IMa4DCK',
+            playerScript: 'https://static.coorpacademy.com/JwPlayer/8.6.3/jwplayer.js'
+          },
+          loading: false,
+          type: 'video'
+        }
+      ]
+    }
+  });
+});

--- a/packages/@coorpacademy-app-review/src/reducers/data/videos.ts
+++ b/packages/@coorpacademy-app-review/src/reducers/data/videos.ts
@@ -1,0 +1,46 @@
+import {get, set} from 'lodash/fp';
+import {VideoPropsForPlayer} from '../../types/common';
+import {
+  SetVideoPropsAction,
+  SET_VIDEO_PROPS,
+  ShowVideoAction,
+  SHOW_VIDEO
+} from '../../actions/api/fetch-video-props';
+import {NextSlideAction, NEXT_SLIDE} from '../../actions/ui/next-slide';
+import {SetCurrentSlideAction} from '../../actions/ui/slides';
+
+export type VideoPropsState = Record<string, VideoPropsForPlayer>;
+export const initialState: VideoPropsState = {};
+
+const reducer = (
+  // eslint-disable-next-line default-param-last
+  state: VideoPropsState = initialState,
+  action: SetVideoPropsAction | NextSlideAction | SetCurrentSlideAction | ShowVideoAction
+): VideoPropsState => {
+  switch (action.type) {
+    case SET_VIDEO_PROPS: {
+      const {slideId, props} = action.payload;
+      return set(slideId, props, state);
+    }
+    case NEXT_SLIDE: {
+      const {currentSlideRef} = action.payload;
+      const isMediaVideo = get(currentSlideRef, state);
+      if (isMediaVideo) {
+        return set([currentSlideRef, 'src', '0', 'loading'], true, state);
+      }
+      return state;
+    }
+    case SHOW_VIDEO: {
+      const {slideId} = action.payload;
+      const isMediaVideo = get(slideId, state);
+      if (isMediaVideo) {
+        return set([slideId, 'src', '0', 'loading'], false, state);
+      }
+      return state;
+    }
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/packages/@coorpacademy-app-review/src/test/fixtures.ts
+++ b/packages/@coorpacademy-app-review/src/test/fixtures.ts
@@ -4,6 +4,7 @@ import type {
   ReviewEngine,
   SlideIdFromAPI
 } from '@coorpacademy/review-services';
+import {StoreState} from '../reducers';
 import {freeTextSlide} from '../views/slides/test/fixtures/free-text';
 import {qcmSlide} from '../views/slides/test/fixtures/qcm';
 import {qcmDragSlide} from '../views/slides/test/fixtures/qcm-drag';
@@ -261,5 +262,27 @@ export const incorrectFreeTextPostAnswerResponse: ProgressionFromAPI = {
     ],
     pendingSlides: [freeTextSlide.universalRef],
     stars: 0
+  }
+};
+
+export const initialState: StoreState = {
+  data: {
+    progression: null,
+    slides: {},
+    token: '1234',
+    corrections: {},
+    rank: {start: Number.NaN, end: Number.NaN},
+    currentSkill: null,
+    videos: {}
+  },
+  ui: {
+    showCongrats: false,
+    positions: [0, 1, 2, 3, 4],
+    currentSlideRef: '',
+    navigation: [],
+    answers: {},
+    slide: {},
+    showQuitPopin: false,
+    showButtonRevising: false
   }
 };

--- a/packages/@coorpacademy-app-review/src/types/common.ts
+++ b/packages/@coorpacademy-app-review/src/types/common.ts
@@ -1,4 +1,4 @@
-import type {Services, VideoMedia, VideoPropsForPlayer} from '@coorpacademy/review-services';
+import type {Services, VideoMedia} from '@coorpacademy/review-services';
 
 export type WithRequired<T, K extends keyof T> = T & {
   // the "-" is a Mapping Modifier, removes optionality from a prop
@@ -15,6 +15,26 @@ export type Skin = {
   common: {
     primary: string;
   };
+};
+
+type VideoSrcPropsForPlayer = {
+  mimeType: string;
+  videoId: string;
+  jwpOptions: unknown;
+  loading?: boolean;
+  type: string;
+};
+
+export type VideoPropsForPlayer = {
+  type: string;
+  src: VideoSrcPropsForPlayer[];
+};
+
+export type MediaPropsForPlayer = {
+  type: 'img' | 'audio';
+  url: string;
+  _id: string;
+  mimeType: string;
 };
 
 export type ConnectedOptions = {

--- a/packages/@coorpacademy-app-review/src/views/slides/map-api-slide-to-ui.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/map-api-slide-to-ui.ts
@@ -32,8 +32,7 @@ import type {
   SlideFromAPI,
   SliderQuestion,
   TemplateQuestion,
-  ChoiceItem,
-  SlideMedia
+  ChoiceItem
 } from '@coorpacademy/review-services';
 import {
   AnswerUI,
@@ -47,7 +46,7 @@ import {
   TextTemplate
 } from '../../types/slides';
 import {editAnswer} from '../../actions/ui/answers';
-import {Translate} from '../../types/common';
+import {MediaPropsForPlayer, Translate, VideoPropsForPlayer} from '../../types/common';
 
 const qcmProps =
   (dispatch: Dispatch) =>
@@ -281,33 +280,21 @@ const getAnswerUIModel = (
   }
 };
 
-const getMedia = (media: SlideMedia): unknown | void => {
-  if (!media) return;
-  const {type} = media;
-  const resource = get('src.0', media);
-  switch (type) {
-    case 'img':
-    case 'audio':
-      return {
-        ...resource,
-        type,
-        url: get('url', resource)
-      };
-  }
-};
-
 export const mapApiSlideToUi =
   (dispatch: Dispatch, translate: Translate) =>
-  (slide: SlideFromAPI, answers: string[]): {questionText: string; answerUI: AnswerUI} => {
+  (
+    slide: SlideFromAPI,
+    answers: string[],
+    media: MediaPropsForPlayer | VideoPropsForPlayer | void
+  ): {questionText: string; answerUI: AnswerUI} => {
     const questionText = getOr('', 'question.header', slide);
-    const media = get('question.medias.0', slide);
 
     return {
       questionText,
       answerUI: {
         model: getAnswerUIModel(slide.question, answers, dispatch, translate),
         help: getHelp(slide),
-        media: getMedia(media)
+        media
       }
     };
   };

--- a/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/button-revising.on-click.test.ts
@@ -19,6 +19,7 @@ import {StoreState} from '../../../reducers';
 import {mapStateToSlidesProps} from '..';
 import {translate} from '../../../test/utils/translation.mock';
 import {postAnswerResponses} from '../../../test/fixtures';
+import {SHOW_VIDEO} from '../../../actions/api/fetch-video-props';
 import {skin} from './fixtures/skin';
 import {qcmGraphicSlide} from './fixtures/qcm-graphic';
 import {freeTextSlide} from './fixtures/free-text';
@@ -47,7 +48,46 @@ const state: StoreState = {
       [templateSlide.universalRef]: getChoicesCorrection(templateSlide._id)
     },
     rank: {start: 10, end: 10},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+    videos: {
+      [freeTextSlide._id]: {
+        type: 'video',
+        src: [
+          {
+            mimeType: 'application/jwplayer',
+            type: 'video',
+            videoId: '489S0B87',
+            loading: true,
+            jwpOptions: {
+              playerId: '7IMa4DCK',
+              playerScript: 'https://static.coorpacademy.com/JwPlayer/8.6.3/jwplayer.js',
+              licenseKey: 'QDh3Fb2afiIAFI+XwlncwQDhNEwkXetm1y8tzWn3km8=',
+              playlist: [
+                {
+                  file: 'https://content.jwplatform.com/manifests/489S0B87.m3u8',
+                  tracks: [
+                    {
+                      file: 'https://content.jwplatform.com/strips/489S0B87-120.vtt',
+                      kind: 'thumbnails'
+                    }
+                  ]
+                }
+              ],
+              customProps: {
+                playbackRateControls: true,
+                playbackRates: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
+                preload: 'auto',
+                autostart: 'true',
+                width: '100%',
+                height: '343px',
+                visualplaylist: false,
+                nextUpDisplay: false
+              }
+            }
+          }
+        ]
+      }
+    }
   },
   ui: {
     showCongrats: true,
@@ -149,6 +189,7 @@ test('should dispatch POST_PROGRESSION_REQUEST action via the property onclick o
       payload: freeTextSlide
     },
     {type: SET_CURRENT_SLIDE, payload: freeTextSlide},
+    {type: SHOW_VIDEO, payload: {slideId: freeTextSlide._id}},
     {type: SKILL_FETCH_REQUEST},
     {type: SKILL_FETCH_SUCCESS, payload: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}}
   ];

--- a/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/header.on-click.test.ts
@@ -29,7 +29,8 @@ test('should dispatch OPEN_POPIN action after a click on close button in header'
       token: '1234',
       corrections: {},
       rank: {start: Number.NaN, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       currentSlideRef: '',
@@ -90,7 +91,8 @@ test('should dispatch onQuitClick function after a click on close button in head
         [templateSlide.universalRef]: getChoicesCorrection(templateSlide._id)
       },
       rank: {start: 10, end: 9},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: true,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -40,7 +40,8 @@ test('should create initial props when fetched slide is not still received', t =
       token: '1234',
       corrections: {},
       rank: {start: Number.NaN, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -136,7 +137,8 @@ test('should create initial props when fetched slide is not still received for m
       token: '1234',
       corrections: {},
       rank: {start: Number.NaN, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -233,7 +235,8 @@ test('should create props when first slide is on the state', t => {
       token: '1234',
       corrections: {},
       rank: {start: Number.NaN, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -347,7 +350,8 @@ test('should create props when slide is on the state and user has selected answe
       token: '1234',
       corrections: {},
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -462,7 +466,8 @@ test('should verify props when first slide was answered correctly and next slide
       token: '1234',
       corrections: {},
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -587,7 +592,8 @@ test('should verify props when first slide was answered with error and next slid
       token: '1234',
       corrections: {},
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -666,7 +672,8 @@ test('should verify props when first slide was answered, next slide is fetched &
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id)
       },
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -807,7 +814,8 @@ test('should verify props when first slide was answered incorrectly, next slide 
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id, true)
       },
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -951,7 +959,8 @@ test('should verify props when currentSlideRef has changed to nextContent of pro
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id)
       },
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -1067,7 +1076,8 @@ test('should verify props when progression is in success, showing last correctio
         [templateSlide.universalRef]: getChoicesCorrection(templateSlide._id)
       },
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -1195,7 +1205,8 @@ test('should verify props showing congrats', t => {
         [templateSlide.universalRef]: getChoicesCorrection(templateSlide._id)
       },
       rank: {start: 10, end: 9},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: true,
@@ -1338,7 +1349,8 @@ test('should verify props showing congrats, with only stars card, if user has no
         [templateSlide.universalRef]: getChoicesCorrection(templateSlide._id)
       },
       rank: {start: 10, end: 10},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: true,
@@ -1457,7 +1469,8 @@ test('should verify props when progression has answered a current pendingSlide',
         [templateSlide.universalRef]: getChoicesCorrection(templateSlide._id)
       },
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -1570,7 +1583,8 @@ test('should verify props when progression still has a pendingSlide', t => {
         [templateSlide.universalRef]: getChoicesCorrection(templateSlide._id)
       },
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -1672,7 +1686,8 @@ test('should verify that props quitPopin is not undefined when popin is displaye
       token: '1234',
       corrections: {},
       rank: {start: Number.NaN, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/map-api-slide-to-ui.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/map-api-slide-to-ui.test.ts
@@ -3,6 +3,7 @@ import identity from 'lodash/fp/identity';
 import type {SlideFromAPI} from '@coorpacademy/review-services';
 import {mapApiSlideToUi} from '../map-api-slide-to-ui';
 import {ReviewSlide} from '..';
+import {MediaPropsForPlayer, VideoPropsForPlayer} from '../../../types/common';
 import {qcmSlide, qcmUISlide} from './fixtures/qcm';
 import {qcmDragSlide, qcmDragUISlide} from './fixtures/qcm-drag';
 import {freeTextSlide, freeTextUISlide} from './fixtures/free-text';
@@ -22,10 +23,11 @@ const macro = test.macro({
       slide: SlideFromAPI;
       answers: string[];
       expectedUiSlide: Partial<ReviewSlide>;
+      media?: MediaPropsForPlayer | VideoPropsForPlayer;
     }
   ) {
     t.deepEqual(
-      JSON.parse(JSON.stringify(_mapApiSlideToUi(arg.slide, arg.answers))),
+      JSON.parse(JSON.stringify(_mapApiSlideToUi(arg.slide, arg.answers, arg.media))),
       JSON.parse(JSON.stringify(arg.expectedUiSlide))
     );
   }
@@ -44,7 +46,20 @@ test('template', macro, {
   expectedUiSlide: templateUISlide
 });
 test('free text', macro, {slide: freeTextSlide, answers: [], expectedUiSlide: freeTextUISlide});
-test('slider', macro, {slide: sliderSlide, answers: [], expectedUiSlide: sliderUISlide});
+
+const media: MediaPropsForPlayer = {
+  _id: '6377c7f7c76a8a017fac4364',
+  mimeType: 'image/jpeg',
+  url: '//static.coorpacademy.com/content/CoorpAcademy/content/cockpit-partner-wedemain/default/shutterstock_181414391-1480431629586.jpg',
+  type: 'img'
+};
+
+test('slider', macro, {
+  slide: sliderSlide,
+  answers: [],
+  expectedUiSlide: sliderUISlide,
+  media
+});
 
 test('should throw an error if the question type can not be handled', t => {
   const faultySlide = {...qcmSlide, question: {type: 'lol'}};

--- a/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/on-quit-popin.on-click.test.ts
@@ -24,7 +24,8 @@ const state: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -98,7 +98,8 @@ const initialState: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
@@ -46,7 +46,8 @@ test('correction popin actions after click', async t => {
         [freeTextSlide._id]: getChoicesCorrection(freeTextSlide._id, true)
       },
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,
@@ -136,7 +137,8 @@ test('correction popin actions after click when progression is finished', async 
         [templateSlide.universalRef]: getChoicesCorrection(templateSlide._id)
       },
       rank: {start: 10, end: Number.NaN},
-      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+      currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+      videos: {}
     },
     ui: {
       showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -46,7 +46,8 @@ const initialState: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -46,7 +46,8 @@ const initialState: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -46,7 +46,8 @@ const initialState: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -46,7 +46,8 @@ const initialState: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -46,7 +46,8 @@ const initialState: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -47,7 +47,8 @@ const initialState: StoreState = {
     token: '1234',
     corrections: {},
     rank: {start: 10, end: Number.NaN},
-    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'}
+    currentSkill: {ref: 'skill_NyxtYFYir', name: 'Digital Awareness'},
+    videos: {}
   },
   ui: {
     showCongrats: false,

--- a/packages/@coorpacademy-review-services-mocks/src/index.ts
+++ b/packages/@coorpacademy-review-services-mocks/src/index.ts
@@ -280,6 +280,7 @@ export const appendVideoOptions = (media: VideoMedia): Promise<VideoPropsForPlay
         mimeType: 'application/jwplayer',
         videoId,
         mediaRef,
+        type: 'video',
         jwpOptions: {
           playerId: '7IMa4DCK',
           playerScript: 'https://static.coorpacademy.com/JwPlayer/8.6.3/jwplayer.js',

--- a/packages/@coorpacademy-review-services-mocks/src/index.ts
+++ b/packages/@coorpacademy-review-services-mocks/src/index.ts
@@ -10,8 +10,7 @@ import type {
   Skill,
   SlideFromAPI,
   SlideIdFromAPI,
-  VideoMedia,
-  VideoPropsForPlayer
+  VideoMedia
 } from '@coorpacademy/review-services';
 import {
   computeNextStepAfterAnswerForReview,
@@ -268,6 +267,19 @@ const getPostAnswer = (progression: ProgressionFromAPI, answer: string[]): Progr
   const newState: ProgressionState = updateState(reviewConfig, progression.state, action);
   const response: ProgressionFromAPI = {...progression, state: newState};
   return response;
+};
+
+type VideoSrcPropsForPlayer = {
+  mimeType: string;
+  videoId: string;
+  jwpOptions: unknown;
+  loading?: boolean;
+  type: string;
+};
+
+type VideoPropsForPlayer = {
+  type: string;
+  src: VideoSrcPropsForPlayer[];
 };
 
 export const appendVideoOptions = (media: VideoMedia): Promise<VideoPropsForPlayer> => {

--- a/packages/@coorpacademy-review-services/src/index.ts
+++ b/packages/@coorpacademy-review-services/src/index.ts
@@ -11,7 +11,6 @@ import type {
   SlideMedia as SlideMedia_,
   MediaSrc as MediaSrc_,
   VideoSrc as VideoSrc_,
-  VideoPropsForPlayer as VideoPropsForPlayer_,
   AudioMedia as _AudioMedia,
   ImageMedia as _ImageMedia,
   VideoMedia as _VideoMedia,
@@ -62,7 +61,6 @@ export type SlideFromAPI = SlideFromAPI_;
 export type SlideIdFromAPI = SlideIdFromAPI_;
 export type MediaSrc = MediaSrc_;
 export type VideoSrc = VideoSrc_;
-export type VideoPropsForPlayer = VideoPropsForPlayer_;
 export type SlideMedia = SlideMedia_;
 export type AudioMedia = _AudioMedia;
 export type ImageMedia = _ImageMedia;

--- a/packages/@coorpacademy-review-services/src/types/services-types.ts
+++ b/packages/@coorpacademy-review-services/src/types/services-types.ts
@@ -61,7 +61,8 @@ type VideoSrcPropsForPlayer = {
   mimeType: string;
   videoId: string;
   jwpOptions: unknown;
-  hide?: boolean;
+  loading?: boolean;
+  type: string;
 };
 
 export type VideoPropsForPlayer = {

--- a/packages/@coorpacademy-review-services/src/types/services-types.ts
+++ b/packages/@coorpacademy-review-services/src/types/services-types.ts
@@ -57,19 +57,6 @@ type BaseContent = {
   answers: string[][];
 };
 
-type VideoSrcPropsForPlayer = {
-  mimeType: string;
-  videoId: string;
-  jwpOptions: unknown;
-  loading?: boolean;
-  type: string;
-};
-
-export type VideoPropsForPlayer = {
-  type: string;
-  src: VideoSrcPropsForPlayer[];
-};
-
 export type MediaSrc = {_id: string; mimeType: string; url: string};
 export type VideoSrc = {
   _id: string;


### PR DESCRIPTION
https://trello.com/c/tFtAgEL6/2934-or-bug-non-affichage-des-m%C3%A9dias-sur-les-slides

**Detailed purpose of the PR**

This PR adds the action which is dispatched to compute the properties for a video, and **adds the reducer videos** to handle the payload with this result (tests updated after adding this reducer).

```
├── data
│   ├── corrections.ts
│   ├── current-skill.ts
│   ├── index.ts
│   ├── progression.ts
│   ├── rank.ts
│   ├── slides.ts
│   ├── token.ts
│   └── videos.ts
└── ui
    ├── answers.ts
    ├── current-slide-ref.ts
    ├── index.ts
    ├── navigation.ts
    ├── positions.ts
    ├── quit-popin.ts
    ├── show-button-revising.ts
    ├── show-congrats.ts
    └── slide.ts
```

It also handles the actions of hide video on current slide during unstack, and show the next video if the next slide has one.

**Result and observation**

![review-slides-videos](https://user-images.githubusercontent.com/7602475/215453772-acc148f7-e17a-4137-87f5-de066ee07c49.gif)

**Testing Strategy**

- Already covered by tests
- Manual testing
- Unit testing
