### PR TITLE
Activity tooltip: 12.11 - Dans chaque page web, les contenus additionnels apparaissant au survol, à la prise de focus ou à l'activation d'un composant d'interface sont-ils, si nécessaire, atteignables au clavier 

### DIFF
--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -38,6 +38,7 @@
   "payment_form_submit": "Start Coorpacademy subscription",
   "Post": "Post",
   "premium_unsubscribe_confirmation": "We confirm the cancelling of your subscription which will be effective starting from next month.\n\nIn the meantime, you can continue to enjoy our content on the Coorpacademy platform.",
+  "Press the escape key to close the information text": "Press the escape key to close the information text",
   "product_cancel": "Cancel at any time.",
   "product_desc_battle": "Battle mode",
   "product_desc_certificates": "Coorpacademy certificates",

--- a/packages/@coorpacademy-components/package.json
+++ b/packages/@coorpacademy-components/package.json
@@ -78,7 +78,8 @@
     "qs": "6.11.0",
     "react-autosuggest": "^10.0.2",
     "react-dropzone": "^9.0.0",
-    "react-tooltip": "^4.2.6"
+    "react-tooltip": "4.5.1",
+    "uuid": "^9.0.0"
   },
   "peerDependencies": {
     "react": "^17.0.2"

--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -1,14 +1,14 @@
-import React, {useState, useCallback} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import getOr from 'lodash/fp/getOr';
 import map from 'lodash/fp/map';
 import {
   NovaSolidStatusCheckCircle2 as CheckIcon,
   NovaSolidVoteRewardsVoteHeart as HeartIcon,
-  NovaCompositionCoorpacademyInformationIcon as InformationIcon,
   NovaSolidInterfaceFeedbackInterfaceQuestionMark as QuestionIcon,
   NovaLineSelectionCursorsCursorArrowTarget as TargetIcon
 } from '@coorpacademy/nova-icons';
+import ToolTip from '../tooltip';
 import style from './style.css';
 import propTypes from './prop-types';
 
@@ -29,64 +29,6 @@ const ReviewIcon = ({icon}) => {
   return <Icon className={style.labelIcon} />;
 };
 
-const ToolTip = ({
-  tooltipText,
-  'aria-label': moreDetailsAriaLabel,
-  'data-testid': dataTestId,
-  closeToolTipInformationTextAriaLabel
-}) => {
-  const [toolTipIsVisible, setToolTipIsVisible] = useState(false);
-  const handleKeyPress = useCallback(
-    event => {
-      if (event.key === 'Enter') {
-        setToolTipIsVisible(!toolTipIsVisible);
-      } else if (event.key === 'Tab' || event.key === 'Escape') {
-        setToolTipIsVisible(false);
-      }
-    },
-    [setToolTipIsVisible, toolTipIsVisible]
-  );
-  const handleMouseOver = useCallback(() => {
-    setToolTipIsVisible(true);
-  }, [setToolTipIsVisible]);
-
-  const handleMouseLeave = useCallback(() => {
-    setToolTipIsVisible(false);
-  }, [setToolTipIsVisible]);
-
-  return (
-    <div
-      className={style.tooltipContainer}
-      onMouseLeave={handleMouseLeave}
-      onMouseOver={handleMouseOver}
-    >
-      <button
-        type="button"
-        className={style.tooltipIconContainer}
-        data-testid={dataTestId}
-        onKeyDown={handleKeyPress}
-        tabIndex={0}
-      >
-        <InformationIcon
-          className={style.informationIcon}
-          width={12}
-          height={12}
-          aria-label={moreDetailsAriaLabel}
-        />
-      </button>
-      {toolTipIsVisible ? (
-        <div
-          className={style.toolTip}
-          data-testid="review-presentation-tooltip"
-          aria-label={closeToolTipInformationTextAriaLabel}
-        >
-          <p className={style.tooltipText}>{tooltipText}</p>
-        </div>
-      ) : null}
-    </div>
-  );
-};
-
 const ReviewListItemWrapper = ({iconKey, label}) => {
   return (
     <div className={style.reviewListItemWrapper} data-tip data-for="reviewListItem" tabIndex={0}>
@@ -94,10 +36,10 @@ const ReviewListItemWrapper = ({iconKey, label}) => {
         <ReviewIcon icon={iconKey} /> {label.text}
       </div>
       <ToolTip
-        tooltipText={label.tooltipText}
-        aria-label={label.moreDetailsAriaLabel}
+        TooltipContent={label.tooltipText}
         closeToolTipInformationTextAriaLabel={label.closeToolTipInformationTextAriaLabel}
         data-testid={`review-list-item-tooltip-button-${iconKey}`}
+        aria-label={label.moreDetailsAriaLabel}
       />
     </div>
   );
@@ -136,24 +78,17 @@ const ReviewPresentation = props => {
   );
 };
 
-ToolTip.propTypes = {
-  tooltipText: PropTypes.string,
-  'aria-label': PropTypes.string,
-  'data-testid': PropTypes.string,
-  closeToolTipInformationTextAriaLabel: PropTypes.string
-};
-
 ReviewIcon.propTypes = {
   icon: PropTypes.string
 };
 
 ReviewListItemWrapper.propTypes = {
-  ...ToolTip.propTypes,
   iconKey: PropTypes.string,
   label: PropTypes.shape({
-    tooltipText: PropTypes.string,
-    moreDetailsAriaLabel: PropTypes.string,
-    closeToolTipInformationTextAriaLabel: PropTypes.string
+    tooltipText: ToolTip.propTypes.tooltipText,
+    moreDetailsAriaLabel: ToolTip.propTypes['aria-label'],
+    closeToolTipInformationTextAriaLabel: ToolTip.propTypes.closeToolTipInformationTextAriaLabel,
+    text: PropTypes.string
   })
 };
 

--- a/packages/@coorpacademy-components/src/atom/review-presentation/style.css
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/style.css
@@ -3,25 +3,20 @@
 @value mobile from breakpoints;
 @value colors: "../../variables/colors.css";
 @value xtraLightGrey from colors;
-@value cm_blue_900 from colors;
 @value cm_grey_75 from colors;
-@value cm_grey_500 from colors;
-@value cm_grey_700 from colors;
-@value white from colors;
-
-
-.textBase {
-  font-family: "Gilroy";
-  font-style: normal;
-  color: cm_blue_900;
-  user-select: none;
-}
 
 .reviewWrapper {
   width: 100%;
   border-radius: 16px;
   background-color: xtraLightGrey;
   padding-bottom: 40px;
+}
+
+.textBase {
+  font-family: "Gilroy";
+  font-style: normal;
+  color: cm_blue_900;
+  user-select: none;
 }
 
 .reviewTitle {
@@ -75,61 +70,6 @@
   padding-right: 12px;
   height: 16px;
   width: 16px;
-}
-
-.informationIcon {
-  color: cm_grey_500;
-}
-
-.toolTip {
-  transition: opacity 0.8s;
-  position: absolute;
-  height: auto;
-  width: 200px;
-  border-radius: 7px;
-  background-color: cm_grey_700;
-  right: -81px;
-  bottom: 32px;
-}
-
-.toolTip::before {
-  content: '';
-  display: inline-block;
-  visibility: inherit;
-  opacity: inherit;
-  width: 15px;
-  height: 15px;
-  transform: rotate(-45deg);
-  background-color: cm_grey_700;
-  position: inherit;
-  bottom: -5px;
-  right: 40%;
-  border-radius: 2px;
-}
-
-.tooltipText {
-  composes: textBase;
-  font-weight: 500;
-  font-size: 14px;
-  display: inline-block;
-  border-radius: 3px;
-  word-wrap: break-word;
-  color: white;
-  padding: 8px 14px;
-  text-align: center;
-}
-
-.tooltipContainer {
-  overflow: visible;
-  position: relative;
-}
-
-.tooltipIconContainer {
-  display: flex;
-  justify-content: flex-end;
-  border: none;
-  background: cm_grey_75;
-  height: 25px;
 }
 
 @media tablet {

--- a/packages/@coorpacademy-components/src/atom/review-presentation/test/on-key-down.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/test/on-key-down.js
@@ -10,7 +10,7 @@ browserEnv();
 test.after(cleanup);
 
 test('should hide and show toolTip depending on key press event', t => {
-  const toolTipTestId = '[data-testid="review-presentation-tooltip"]';
+  const toolTipTestId = '[data-testid="tooltip"]';
   const {getByTestId, container} = render(<ReviewPresentation {...defaultFixture.props} />);
   const skillsDiv = getByTestId('review-list-item-tooltip-button-questions');
   t.truthy(skillsDiv);

--- a/packages/@coorpacademy-components/src/atom/review-presentation/test/on-mouse-leave.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/test/on-mouse-leave.js
@@ -10,7 +10,7 @@ browserEnv();
 test.after(cleanup);
 
 test('should hide toolTip depending on mouse leave event', t => {
-  const toolTipTestId = '[data-testid="review-presentation-tooltip"]';
+  const toolTipTestId = '[data-testid="tooltip"]';
   const {container} = render(<ReviewPresentation {...defaultFixture.props} />);
   const skillsDiv = container.querySelector(
     '[data-testid="review-list-item-tooltip-button-skills"]'

--- a/packages/@coorpacademy-components/src/atom/tooltip/index.js
+++ b/packages/@coorpacademy-components/src/atom/tooltip/index.js
@@ -1,0 +1,155 @@
+import React, {isValidElement, useState, useCallback, useMemo} from 'react';
+import PropTypes from 'prop-types';
+import ReactTooltip from 'react-tooltip';
+import isString from 'lodash/fp/isString';
+import {NovaCompositionCoorpacademyInformationIcon as InformationIcon} from '@coorpacademy/nova-icons';
+import style from './style.css';
+
+const ToolTipWrapper = ({
+  toolTipIsVisible,
+  anchorId,
+  closeToolTipInformationTextAriaLabel,
+  content
+}) => {
+  if (!toolTipIsVisible) return null;
+  if (anchorId) {
+    // const element = document.getElementById('anchorId');
+    // const element = document.getElementById('anchorId');
+    // element.style.left = "100px";
+    // element.style.top = "200px";
+    return (
+      <ReactTooltip
+        id={anchorId}
+        // anchorId={anchorId}
+        className={style.toolTipReact}
+        data-event-off="click"
+        place="left"
+        // delayHide={500}
+        effect="solid"
+        aria-label={closeToolTipInformationTextAriaLabel}
+      >
+        {content}
+      </ReactTooltip>
+    );
+  } else {
+    return (
+      <div
+        className={style.toolTip}
+        data-testid="tooltip"
+        aria-label={closeToolTipInformationTextAriaLabel}
+      >
+        {content}
+      </div>
+    );
+  }
+};
+
+ToolTipWrapper.propTypes = {
+  toolTipIsVisible: PropTypes.bool,
+  anchorId: PropTypes.string,
+  closeToolTipInformationTextAriaLabel: PropTypes.string.isRequired,
+  content: PropTypes.node
+};
+
+export const toggleStateOnKeyPress = (state, setState, ref) => event => {
+  if (event.key === 'Enter') {
+    if (ref) ref.current.focus();
+    event.stopPropagation();
+    event.preventDefault();
+    setState(!state);
+  } else if (event.key === 'Tab' || event.key === 'Escape') {
+    setState(false);
+  }
+};
+
+// expose hooks for events
+const ToolTip = ({
+  anchorId,
+  TooltipContent,
+  'aria-label': ariaLabel,
+  'data-testid': dataTestId,
+  closeToolTipInformationTextAriaLabel,
+  toolTipIsVisible: _toolTipIsVisible
+}) => {
+  const isComponent = useMemo(
+    () => !isString(TooltipContent) && isValidElement(TooltipContent()),
+    [TooltipContent]
+  );
+
+  const [toolTipIsVisible, setToolTipIsVisible] = useState(false);
+
+  const handleKeyPress = useCallback(
+    event => {
+      toggleStateOnKeyPress(toolTipIsVisible, setToolTipIsVisible)(event);
+    },
+    [toolTipIsVisible]
+  );
+
+  const handleMouseOver = useCallback(() => {
+    setToolTipIsVisible(true);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    setToolTipIsVisible(false);
+  }, []);
+
+  const content = useMemo(() => {
+    return isComponent ? (
+      <TooltipContent />
+    ) : (
+      <p className={style.tooltipContent}>{TooltipContent}</p>
+    );
+  }, [TooltipContent, isComponent]);
+
+  return anchorId ? (
+    <ToolTipWrapper
+      toolTipIsVisible={_toolTipIsVisible}
+      anchorId={anchorId}
+      closeToolTipInformationTextAriaLabel={closeToolTipInformationTextAriaLabel}
+      content={content}
+      onMouseLeave={handleMouseLeave}
+      onMouseOver={handleMouseOver}
+    />
+  ) : (
+    <div
+      className={style.tooltipContainer}
+      onMouseLeave={handleMouseLeave}
+      onMouseOver={handleMouseOver}
+    >
+      <button
+        type="button"
+        className={style.tooltipIconContainer}
+        data-testid={dataTestId}
+        onKeyDown={handleKeyPress}
+        tabIndex={0}
+      >
+        <InformationIcon
+          className={style.informationIcon}
+          width={12}
+          height={12}
+          aria-label={ariaLabel}
+        />
+      </button>
+      <ToolTipWrapper
+        toolTipIsVisible={toolTipIsVisible}
+        anchorId={anchorId}
+        closeToolTipInformationTextAriaLabel={closeToolTipInformationTextAriaLabel}
+        content={content}
+      />
+    </div>
+  );
+};
+
+ToolTip.propTypes = {
+  TooltipContent: PropTypes.oneOfType([PropTypes.func, PropTypes.node, PropTypes.string]),
+  'data-testid': PropTypes.string,
+  'aria-label': PropTypes.string,
+  closeToolTipInformationTextAriaLabel: PropTypes.string.isRequired,
+  // ---------- externalHandling --------------
+  // if passed down, React Tooltip is used instead, due to limitations on
+  // parents overflow hidden controls
+  anchorId: PropTypes.string,
+  toolTipIsVisible: PropTypes.bool
+};
+
+export default ToolTip;

--- a/packages/@coorpacademy-components/src/atom/tooltip/index.js
+++ b/packages/@coorpacademy-components/src/atom/tooltip/index.js
@@ -13,18 +13,12 @@ const ToolTipWrapper = ({
 }) => {
   if (!toolTipIsVisible) return null;
   if (anchorId) {
-    // const element = document.getElementById('anchorId');
-    // const element = document.getElementById('anchorId');
-    // element.style.left = "100px";
-    // element.style.top = "200px";
     return (
       <ReactTooltip
         id={anchorId}
-        // anchorId={anchorId}
         className={style.toolTipReact}
         data-event-off="click"
         place="left"
-        // delayHide={500}
         effect="solid"
         aria-label={closeToolTipInformationTextAriaLabel}
       >
@@ -62,7 +56,6 @@ export const toggleStateOnKeyPress = (state, setState, ref) => event => {
   }
 };
 
-// expose hooks for events
 const ToolTip = ({
   anchorId,
   TooltipContent,

--- a/packages/@coorpacademy-components/src/atom/tooltip/style.css
+++ b/packages/@coorpacademy-components/src/atom/tooltip/style.css
@@ -1,0 +1,81 @@
+@value colors: "../../variables/colors.css";
+@value cm_blue_900 from colors;
+@value cm_grey_75 from colors;
+@value cm_grey_500 from colors;
+@value cm_grey_700 from colors;
+
+.textBase {
+  font-family: "Gilroy";
+  font-style: normal;
+  color: cm_blue_900;
+  user-select: none;
+}
+
+.tooltipContainer {
+  overflow: visible;
+  position: relative;
+  z-index: 10;
+  display: flex;
+  justify-content: center;
+  justify-self: center;
+}
+
+.tooltipIconContainer {
+  display: flex;
+  justify-content: flex-end;
+  border: none;
+  background: cm_grey_75;
+  height: 25px;
+  align-items: center;
+}
+
+.toolTip {
+  transition: opacity 0.8s;
+  position: absolute;
+  border-radius: 7px;
+  background-color: cm_grey_700;
+  right: -75px;
+  bottom: 32px;
+  height: auto;
+  width: 200px;
+}
+
+.toolTip::before {
+  content: '';
+  display: inline-block;
+  visibility: inherit;
+  opacity: inherit;
+  width: 15px;
+  height: 15px;
+  transform: rotate(-45deg);
+  background-color: cm_grey_700;
+  position: inherit;
+  border-radius: 2px;
+  bottom: -5px;
+  right: 40%;
+}
+
+.tooltipContent {
+  composes: textBase;
+  font-weight: 500;
+  font-size: 14px;
+  display: inline-block;
+  border-radius: 3px;
+  word-wrap: break-word;
+  color: white;
+  padding: 8px 14px;
+  text-align: center;
+}
+
+.informationIcon {
+  color: cm_grey_500;
+}
+
+.toolTipReact {
+  pointer-events: all !important;
+  background-color: cm_grey_700;
+  border-radius: 7px !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  left: 5px;
+}

--- a/packages/@coorpacademy-components/src/atom/tooltip/style.css
+++ b/packages/@coorpacademy-components/src/atom/tooltip/style.css
@@ -71,6 +71,7 @@
   color: cm_grey_500;
 }
 
+/* ----------------------- ReactToolTip exclusive classes ------------------------- */
 .toolTipReact {
   pointer-events: all !important;
   background-color: cm_grey_700;
@@ -78,4 +79,18 @@
   visibility: visible !important;
   opacity: 1 !important;
   left: 5px;
+}
+
+/* for keyboard navigation, the position can't be obtained from the mouse */
+[class*="__react_component_tooltip"]:not(.toolTipReact) {
+  border-radius: 7px !important;
+  top: 97px!important;
+  left: 628px!important;
+  visibility: visible !important;
+  opacity: 1!important;
+}
+
+/* same reason, arrow can't be placed effectively */
+[class*="__react_component_tooltip"]:not(.toolTipReact)::after {
+  content: none !important;
 }

--- a/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/default.ts
@@ -1,0 +1,10 @@
+const fixture = {
+  props: {
+    'aria-label': 'tooltip aria label',
+    'data-testid': 'tooltip-data-testid',
+    TooltipContent: 'This is the tooltip text, a tooltip text',
+    closeToolTipInformationTextAriaLabel: 'Press the escape key to close the information text'
+  }
+};
+
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/react-tooltip-not-visible.ts
+++ b/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/react-tooltip-not-visible.ts
@@ -1,0 +1,12 @@
+const fixture = {
+  props: {
+    anchorId: '12345678',
+    toolTipIsVisible: false,
+    'aria-label': 'react tooltip aria label',
+    'data-testid': 'react-tooltip-data-testid',
+    TooltipContent: 'This is the tooltip text, a tooltip text',
+    closeToolTipInformationTextAriaLabel: 'Press the escape key to close the information text'
+  }
+};
+
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/react-tooltip.ts
+++ b/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/react-tooltip.ts
@@ -1,0 +1,12 @@
+const fixture = {
+  props: {
+    anchorId: '12345678',
+    toolTipIsVisible: true,
+    'aria-label': 'react tooltip aria label',
+    'data-testid': 'react-tooltip-data-testid',
+    TooltipContent: 'This is the tooltip text, a tooltip text',
+    closeToolTipInformationTextAriaLabel: 'Press the escape key to close the information text'
+  }
+};
+
+export default fixture;

--- a/packages/@coorpacademy-components/src/template/activity/engine-stars.css
+++ b/packages/@coorpacademy-components/src/template/activity/engine-stars.css
@@ -21,6 +21,10 @@
 
   user-select: none;
   position: relative;
+  border-bottom: none;
+  border-right: 0px;
+  border-width: 1px 0 0 1px;
+  background: inherit;
 }
 
 .engineIcon {
@@ -156,28 +160,22 @@
   opacity: 0.4;
 }
 
-.toolTip {
-  opacity: 1 !important;
-  padding: 0;
-  pointer-events: all;
-  background-color: transparent !important;
-}
-
-.toolTip::after {
-  border-left-color: transparent !important;
+.textBase {
+  font-family: "Gilroy";
+  font-style: normal;
+  color: white;
 }
 
 .toolTipContent {
-  padding: 10px;
-  margin: 0;
-  border-radius: 3px;
-  font-family: 'Gilroy';
-  font-size: 12px;
+  composes: textBase;
   width: 270px;
-  background-color: white;
-  border: 1px solid white;
-  color: dark;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 8px 3px 10px rgba(0, 0, 0, 0.23);
+  font-weight: 500;
+  font-size: 14px;
+  display: inline-block;
+  border-radius: 3px;
+  word-wrap: break-word;
+  padding: 8px 14px;
+  text-align: center;
 }
 
 .toolTipContent > a {
@@ -189,21 +187,6 @@
 
 .toolTipContent > a:hover {
   text-decoration: underline;
-}
-
-.toolTipContent::after {
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border-left-color: inherit;
-  border-left-style: solid;
-  border-left-width: 6px;
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  right: -6px;
-  top: 50%;
-  margin-top: -4px;
 }
 
 /* ------------------------------------------------------ */

--- a/packages/@coorpacademy-components/src/template/activity/engine-stars.js
+++ b/packages/@coorpacademy-components/src/template/activity/engine-stars.js
@@ -16,7 +16,7 @@ import {
   NovaCompositionCoorpacademyMicrophone as PodcastIcon,
   NovaCompositionCoorpacademyRevision as RevisionIcon
 } from '@coorpacademy/nova-icons';
-import Provider, {GetSkinFromContext} from '../../atom/provider';
+import Provider, {GetSkinFromContext, GetTranslateFromContext} from '../../atom/provider';
 import ToolTip, {toggleStateOnKeyPress} from '../../atom/tooltip';
 import Link from '../../atom/link';
 import style from './engine-stars.css';
@@ -71,6 +71,7 @@ ToolTipContent.propTypes = {
 
 const EngineStars = (props, legacyContext) => {
   const skin = GetSkinFromContext(legacyContext);
+  const translate = GetTranslateFromContext(legacyContext);
   const {
     toolTip = null,
     disabled,
@@ -136,9 +137,9 @@ const EngineStars = (props, legacyContext) => {
   );
 
   const toolTipProps = {
-    'aria-label': '',
-    'data-testid': '',
-    closeToolTipInformationTextAriaLabel: ''
+    closeToolTipInformationTextAriaLabel: translate(
+      'Press the escape key to close the information text'
+    )
   };
 
   const TooltipContent = useCallback(

--- a/packages/@coorpacademy-components/src/template/activity/engine-stars.js
+++ b/packages/@coorpacademy-components/src/template/activity/engine-stars.js
@@ -1,8 +1,8 @@
 import classnames from 'classnames';
-import React from 'react';
-import ReactTooltip from 'react-tooltip';
+import React, {useCallback, useMemo, useState, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {get, noop} from 'lodash/fp';
+import {v5 as uuidV5} from 'uuid';
 import {
   NovaCompositionCoorpacademyStar as StarIcon,
   NovaCompositionCoorpacademyTimer as TimerIcon,
@@ -16,7 +16,8 @@ import {
   NovaCompositionCoorpacademyMicrophone as PodcastIcon,
   NovaCompositionCoorpacademyRevision as RevisionIcon
 } from '@coorpacademy/nova-icons';
-import Provider from '../../atom/provider';
+import Provider, {GetSkinFromContext} from '../../atom/provider';
+import ToolTip, {toggleStateOnKeyPress} from '../../atom/tooltip';
 import Link from '../../atom/link';
 import style from './engine-stars.css';
 
@@ -33,142 +34,196 @@ const ICONS = {
   review: RevisionIcon
 };
 
-const ToolTip = ({toolTip, id}, context) => {
-  if (!toolTip) {
-    return null;
-  }
+const ToolTipContent = ({
+  preMessage,
+  linkMessage,
+  endMessage,
+  onClick,
+  color,
+  handleContentMouseOver
+}) => (
+  <p
+    className={style.toolTipContent}
+    onMouseOver={handleContentMouseOver}
+    data-testid="react-tooltip-content"
+  >
+    <span>{preMessage}</span>
+    <Link
+      onClick={onClick}
+      style={{
+        color
+      }}
+    >
+      {linkMessage}
+    </Link>
+    <span>{endMessage}</span>
+  </p>
+);
 
-  const {skin} = context;
-  const {preMessage, endMessage, linkMessage, onClick} = toolTip;
+ToolTipContent.propTypes = {
+  preMessage: PropTypes.string,
+  linkMessage: PropTypes.string,
+  endMessage: PropTypes.string,
+  color: PropTypes.string,
+  onClick: PropTypes.func,
+  handleContentMouseOver: PropTypes.func
+};
+
+const EngineStars = (props, legacyContext) => {
+  const skin = GetSkinFromContext(legacyContext);
+  const {
+    toolTip = null,
+    disabled,
+    type,
+    stars,
+    title,
+    active = false,
+    onClick = noop,
+    className
+  } = props;
+
+  const handleClick = e => {
+    e.stopPropagation();
+    e.preventDefault();
+    onClick(e);
+  };
+  const dark = get('common.dark', skin);
+  const light = get('common.light', skin);
+  const IconType = ICONS[type];
+
   const primary = get('common.primary', skin);
 
-  const handleClick = onClick;
+  // to replace by useId when React17 is bumped to React18
+  const [engineStarsContentId] = useState(
+    disabled ? uuidV5('engine-stars', uuidV5.URL) : undefined
+  );
+  const [toolTipIsVisible, setToolTipIsVisible] = useState(false);
+  const [mouseLeaveTimer, setMouseLeaveTimer] = useState(undefined);
+  const buttonRef = useRef(null);
+
+  const handleKeyPress = useCallback(
+    event => {
+      toggleStateOnKeyPress(toolTipIsVisible, setToolTipIsVisible, buttonRef)(event);
+    },
+    [toolTipIsVisible]
+  );
+
+  const handleMouseOver = useCallback(() => {
+    mouseLeaveTimer && clearTimeout(mouseLeaveTimer);
+    setToolTipIsVisible(true);
+  }, [mouseLeaveTimer]);
+
+  const handleContentMouseOver = useCallback(() => {
+    mouseLeaveTimer && /* istanbul ignore next */ clearTimeout(mouseLeaveTimer);
+  }, [mouseLeaveTimer]);
+
+  const handleMouseLeave = useCallback(() => {
+    setMouseLeaveTimer(setTimeout(() => setToolTipIsVisible(false), 500));
+  }, []);
+
+  const toolTipContentProps = useMemo(
+    () =>
+      toolTip
+        ? {
+            preMessage: toolTip.preMessage,
+            linkMessage: toolTip.linkMessage,
+            endMessage: toolTip.endMessage,
+            color: primary,
+            onClick: toolTip.onClick
+          }
+        : null,
+    [primary, toolTip]
+  );
+
+  const toolTipProps = {
+    'aria-label': '',
+    'data-testid': '',
+    closeToolTipInformationTextAriaLabel: ''
+  };
+
+  const TooltipContent = useCallback(
+    _props => (
+      <ToolTipContent
+        {...{...toolTipContentProps, ..._props}}
+        handleContentMouseOver={handleContentMouseOver}
+      />
+    ),
+    [handleContentMouseOver, toolTipContentProps]
+  );
 
   return (
-    <ReactTooltip
-      id={id}
-      className={style.toolTip}
-      data-event-off="click"
-      place="left"
-      effect="solid"
-      delayHide={500}
+    <button
+      ref={buttonRef}
+      data-tip={disabled}
+      data-engine={type}
+      data-testid={`engine-stars-${type}`}
+      // eslint-disable-next-line no-nested-ternary
+      onClick={disabled ? handleKeyPress : active ? noop : handleClick}
+      data-for={engineStarsContentId}
+      className={classnames([
+        style.engineStars,
+        disabled ? style.disabled : '',
+        active ? style.active : '',
+        onClick !== noop ? style.clickable : null,
+        className
+      ])}
+      type="button"
+      data-tooltip-place="left"
+      onKeyDown={handleKeyPress}
+      onMouseLeave={handleMouseLeave}
+      onMouseOver={handleMouseOver}
     >
-      <p className={style.toolTipContent}>
-        <span>{`${preMessage}`}</span>
-        <Link
-          onClick={handleClick}
-          style={{
-            color: primary
-          }}
-        >
-          {`${linkMessage}`}
-        </Link>
-        <span>{`${endMessage}`}</span>
-      </p>
-    </ReactTooltip>
+      {disabled ? (
+        <ToolTip
+          {...toolTipProps}
+          anchorId={engineStarsContentId}
+          toolTipIsVisible={toolTipIsVisible}
+          TooltipContent={TooltipContent}
+          mouseLeaveTimer={mouseLeaveTimer}
+        />
+      ) : null}
+      <span
+        className={style.engineIcon}
+        style={{
+          backgroundColor: onClick === noop ? light : primary
+        }}
+      >
+        <IconType className={style.iconHeader} width="30" />
+      </span>
+      <div
+        className={style.score}
+        style={{
+          color: active ? primary : dark
+        }}
+      >
+        <p data-name="star-counter">{stars}</p>
+        <span>
+          <StarIcon className={style.iconStar} color={active ? primary : dark} />
+        </span>
+      </div>
+      <div className={style.scoreTitle}>{title}</div>
+    </button>
   );
 };
 
-ToolTip.contextTypes = {
-  skin: Provider.childContextTypes.skin
-};
-
-ToolTip.propTypes = {
+EngineStars.propTypes = {
+  type: PropTypes.string.isRequired,
+  stars: PropTypes.number.isRequired,
+  title: PropTypes.string.isRequired,
+  active: PropTypes.bool,
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func,
+  className: PropTypes.string,
   toolTip: PropTypes.shape({
     preMessage: PropTypes.string,
     linkMessage: PropTypes.string,
     endMessage: PropTypes.string,
     onClick: PropTypes.func
-  }),
-  id: PropTypes.string.isRequired
+  })
 };
 
-class EngineStars extends React.Component {
-  static propTypes = {
-    type: PropTypes.string.isRequired,
-    stars: PropTypes.number.isRequired,
-    title: PropTypes.string.isRequired,
-    active: PropTypes.bool,
-    disabled: PropTypes.bool,
-    onClick: PropTypes.func,
-    toolTip: PropTypes.shape({
-      preMessage: PropTypes.string,
-      linkMessage: PropTypes.string,
-      endMessage: PropTypes.string,
-      onClick: PropTypes.func
-    })
-  };
-
-  static contextTypes = {
-    skin: Provider.childContextTypes.skin
-  };
-
-  constructor(props, context) {
-    super(props, context);
-    this.handleClick = this.handleClick.bind(this);
-  }
-
-  handleClick = e => {
-    e.stopPropagation();
-    e.preventDefault();
-    const {onClick} = this.props;
-    onClick && onClick(e);
-  };
-
-  render() {
-    const {skin} = this.context;
-    const {
-      disabled,
-      type,
-      stars,
-      title,
-      active = false,
-      onClick = noop,
-      toolTip = null
-    } = this.props;
-    const dark = get('common.dark', skin);
-    const light = get('common.light', skin);
-    const primary = get('common.primary', skin);
-    const IconType = ICONS[type];
-
-    return (
-      <div
-        data-tip={disabled}
-        data-engine={type}
-        onClick={disabled || active ? noop : this.handleClick}
-        data-for={disabled && type}
-        className={classnames([
-          style.engineStars,
-          disabled ? style.disabled : '',
-          active ? style.active : '',
-          onClick !== noop ? style.clickable : null
-        ])}
-      >
-        <ToolTip toolTip={toolTip} id={type} />
-
-        <span
-          className={style.engineIcon}
-          style={{
-            backgroundColor: onClick === noop ? light : primary
-          }}
-        >
-          <IconType className={style.iconHeader} width="30" />
-        </span>
-        <div
-          className={style.score}
-          style={{
-            color: active ? primary : dark
-          }}
-        >
-          <p data-name="star-counter">{stars}</p>
-          <span>
-            <StarIcon className={style.iconStar} color={active ? primary : dark} />
-          </span>
-        </div>
-        <div className={style.scoreTitle}>{title}</div>
-      </div>
-    );
-  }
-}
+EngineStars.contextTypes = {
+  skin: Provider.childContextTypes.skin
+};
 
 export default EngineStars;

--- a/packages/@coorpacademy-components/src/template/activity/index.js
+++ b/packages/@coorpacademy-components/src/template/activity/index.js
@@ -1,6 +1,8 @@
 import React, {useCallback} from 'react';
 import get from 'lodash/fp/get';
 import isEmpty from 'lodash/fp/isEmpty';
+import map from 'lodash/fp/map';
+import noop from 'lodash/fp/noop';
 import omit from 'lodash/fp/omit';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -12,6 +14,8 @@ import ProgressionItem from './progression-item';
 import EngineStars from './engine-stars';
 import StarsSummary from './stars-summary';
 import style from './style.css';
+
+const mapWithIndex = map.convert({cap: false});
 
 const Progression = (props, legacyContext) => {
   const {
@@ -32,8 +36,8 @@ const Progression = (props, legacyContext) => {
     e => {
       e.stopPropagation();
       e.preventDefault();
-      const {onClick} = recommendation;
-      onClick && onClick(e);
+      const {onClick = noop} = recommendation;
+      onClick(e);
     },
     [recommendation]
   );
@@ -51,13 +55,16 @@ const Progression = (props, legacyContext) => {
       <Loader />
     </div>
   ) : null;
-  const allProgressions = progressions.map(progression => (
-    <ProgressionItem
-      {...omit(['ref'], progression)}
-      key={progression.ref}
-      adaptiveAriaLabel={adaptiveAriaLabel}
-    />
-  ));
+  const allProgressions = mapWithIndex(
+    (progression, index) => (
+      <ProgressionItem
+        {...omit(['ref'], progression)}
+        key={`${index}-${progression.ref}`}
+        adaptiveAriaLabel={adaptiveAriaLabel}
+      />
+    ),
+    progressions
+  );
 
   const coreProgression = (
     <div data-name="activityCore" className={style.core}>
@@ -98,12 +105,12 @@ const Progression = (props, legacyContext) => {
 
   return (
     <div className={style.default}>
-      <div data-name="activity-header">
-        <div className={style.mainTitle}>
+      <div data-name="activity-header" tabIndex={0}>
+        <div className={style.mainTitle} tabIndex={0}>
           <span>{mainTitle}</span> {mainSubtitle}
         </div>
-        <div className={style.headerProgression}>
-          <div className={style.wrapperCta}>
+        <div className={style.headerProgression} tabIndex={0}>
+          <div className={style.wrapperCta} tabIndex={0}>
             {themeSelect}
             {recommendationSection}
           </div>

--- a/packages/@coorpacademy-components/src/template/activity/progression-item.js
+++ b/packages/@coorpacademy-components/src/template/activity/progression-item.js
@@ -70,7 +70,7 @@ const ProgressionItem = (props, context) => {
     () => e => {
       e.stopPropagation();
       e.preventDefault();
-      onClick && onClick(e);
+      onClick(e);
     },
     [onClick]
   );

--- a/packages/@coorpacademy-components/src/template/activity/stars-summary.js
+++ b/packages/@coorpacademy-components/src/template/activity/stars-summary.js
@@ -22,6 +22,7 @@ const EngineTab = ({engine, engineIndex, firstItemIndex}) => {
     <li className={style[state]} key={type} data-name={dataName}>
       <EngineStars
         {...engine}
+        key={type}
         className={engineIndex < firstItemIndex ? style.hidden : style.active}
       />
     </li>
@@ -82,14 +83,15 @@ const StarsSummary = (props, legacyContext) => {
 
   const leftArrowView =
     totalItems > 6 && firstItemIndex > 0 ? (
-      <div
+      <button
         className={style.circle}
         onClick={handleOnLeft}
         data-name="left-arrow"
         data-testid="stars-summary-left-arrow"
+        type="button"
       >
         <ArrowLeft color={dark} className={style.left} width={10} height={10} />
-      </div>
+      </button>
     ) : null;
 
   const rightArrowView =
@@ -105,16 +107,18 @@ const StarsSummary = (props, legacyContext) => {
     ) : null;
 
   return (
-    <div data-name="myStars" className={style.myStars}>
+    <div data-name="myStars" className={style.myStars} tabIndex={0}>
       <div
         data-name="myStars-wrapper"
         className={style.myStarsWrapper}
         data-testid={`stars-summary-engine-index-${firstItemIndex}`}
+        tabIndex={0}
       >
         <ul
           className={style.allStars}
           data-name="engineList"
           data-testid="stars-summary-engine-tabs"
+          tabIndex={0}
         >
           <EngineTabs engines={engines} firstItemIndex={firstItemIndex} />
         </ul>

--- a/packages/@coorpacademy-components/src/template/activity/test/handles-test.js
+++ b/packages/@coorpacademy-components/src/template/activity/test/handles-test.js
@@ -31,6 +31,16 @@ test('should call the onClick function with click on cta', t => {
   wrapper.find(Button).first().simulate('click', clickEvent);
 });
 
+test('should pass even if onClick function is undefined', t => {
+  t.plan(2);
+
+  const clickEvent = {preventDefault: () => t.pass(), stopPropagation: () => t.pass()};
+  const props = set('recommendation.onClick', undefined, defaultFixture.props);
+  const wrapper = shallow(<Activity {...props} />, {context});
+
+  wrapper.find(Button).first().simulate('click', clickEvent);
+});
+
 test('should call onChange with the target value', t => {
   t.plan(1);
 
@@ -63,11 +73,14 @@ test('should call the onClick function with click on engine tab', t => {
   battleTab.simulate('click', clickEvent);
 });
 
-test('should not call the onClick function with click on engine tab', t => {
-  t.plan(3);
-
-  const clickEvent = {preventDefault: () => t.pass(), stopPropagation: () => t.pass()};
-  const props = set('engines[2].onClick', null, defaultFixture.props);
+test('should not call the onClick function with click on engine tab if engine is disabled', t => {
+  const clickEvent = {preventDefault: () => t.fail(), stopPropagation: () => t.fail()};
+  const onClick = () => t.fail();
+  const props = set(
+    'engines[2]',
+    {...defaultFixture.props.engines[2], onClick, disabled: true},
+    defaultFixture.props
+  );
   const wrapper = mount(<Activity {...props} />, {context});
   const battleTab = wrapper.find('[data-engine="battle"]');
   t.is(battleTab.exists(), true);

--- a/packages/@coorpacademy-components/src/template/activity/test/stars-summary-test.js
+++ b/packages/@coorpacademy-components/src/template/activity/test/stars-summary-test.js
@@ -18,7 +18,7 @@ const context = {
   }
 };
 
-test('when mount component, it should initialize state with correct value', t => {
+test('on component mount, it should initialize state with 10 engines, should find the navigation tools', t => {
   const props = {
     engines: fixtures.props.engines,
     total: fixtures.props.total

--- a/packages/@coorpacademy-components/src/template/activity/test/tooltip-keydown.js
+++ b/packages/@coorpacademy-components/src/template/activity/test/tooltip-keydown.js
@@ -1,0 +1,56 @@
+import test from 'ava';
+import browserEnv from 'browser-env';
+import React from 'react';
+import delay from 'delay';
+import {fireEvent, cleanup} from '@testing-library/react';
+import {renderWithContext} from '../../../util/render-with-context';
+import StarsSummary from '../stars-summary';
+import defaultFixture from './fixtures/all-engines';
+
+browserEnv();
+
+test.after(cleanup);
+
+test('should hide and show toolTip depending on key press event', async t => {
+  const props = {
+    engines: defaultFixture.props.engines,
+    total: defaultFixture.props.total
+  };
+
+  const {container} = renderWithContext(<StarsSummary {...props} />);
+
+  const reactToolTipContent =
+    '[data-testid="engine-stars-microlearning"] div [data-testid="react-tooltip-content"]';
+
+  const microlearningButton = container.querySelector('[data-testid="engine-stars-microlearning"]');
+  t.truthy(microlearningButton);
+
+  fireEvent.mouseEnter(microlearningButton);
+  let reactToolTip = container.querySelector(reactToolTipContent);
+  t.truthy(reactToolTip);
+
+  fireEvent.mouseOver(reactToolTip);
+  fireEvent.mouseLeave(reactToolTip);
+  fireEvent.mouseLeave(microlearningButton);
+  await delay(500);
+
+  reactToolTip = container.querySelector(reactToolTipContent);
+  t.falsy(reactToolTip);
+
+  fireEvent.mouseEnter(microlearningButton);
+  fireEvent.keyDown(microlearningButton, {key: 'Escape'});
+  reactToolTip = container.querySelector(reactToolTipContent);
+  t.falsy(reactToolTip);
+
+  fireEvent.keyDown(microlearningButton, {key: 'A'});
+  reactToolTip = container.querySelector(reactToolTipContent);
+  t.falsy(reactToolTip);
+
+  fireEvent.keyDown(microlearningButton, {key: 'Enter'});
+  reactToolTip = container.querySelector(reactToolTipContent);
+  t.truthy(reactToolTip);
+
+  fireEvent.keyDown(microlearningButton, {key: 'Tab'});
+  reactToolTip = container.querySelector(reactToolTipContent);
+  t.falsy(reactToolTip);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -15852,12 +15852,12 @@ react-timer-mixin@^0.13.4:
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
   integrity sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==
 
-react-tooltip@^4.2.6:
-  version "4.2.21"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.21.tgz#840123ed86cf33d50ddde8ec8813b2960bfded7f"
-  integrity sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==
+react-tooltip@4.5.1:
+  version "4.5.1"
+  resolved "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.5.1.tgz#77eccccdf16adec804132e558ec20ca5783b866a"
+  integrity sha512-Zo+CSFUGXar1uV+bgXFFDe7VeS2iByeIp5rTgTcc2HqtuOS5D76QapejNNfx320MCY91TlhTQat36KGFTqgcvw==
   dependencies:
-    prop-types "^15.7.2"
+    prop-types "^15.8.1"
     uuid "^7.0.3"
 
 react@^17.0.2:
@@ -18470,6 +18470,11 @@ uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
**Detailed purpose of the PR**
12.11 - Dans chaque page web, les contenus additionnels apparaissant au survol, à la prise de focus ou à l'activation d'un composant d'interface sont-ils, si nécessaire, atteignables au clavier.

- Adds a new Tooltip atom (native && synthetic fallback contained), used on Activity && Review Dashboard
- Adds coverage
- Refactors components
- Bumps react tooltip lib
- Fixes navigation

**Result and observation**
Result:
![Kapture 2023-02-01 at 17 32 47](https://user-images.githubusercontent.com/33550261/216104802-d75e7432-e5c2-4e75-a002-2a469ffd9a79.gif)
![Kapture 2023-02-01 at 17 34 00](https://user-images.githubusercontent.com/33550261/216104847-bbec8d09-f06d-4c7e-93f9-f8ab7f6df614.gif)


<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [x] **Breaking changes ?**  
       Tooltip is now an Atom, ReactTooltip is available on fallback

- [x] **Extra lib ?**
      uuid -> unique id generation, as our React is on v17, useId is not available yet (v18 has it)

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
