### PR TITLE
[RGAA] User Preferences Tooltip: 12.11 - Dans chaque page web, les contenus additionnels apparaissant au survol, à la prise de focus ou à l'activation d'un composant d'interface sont-ils, si nécessaire, atteignables au clavier

### DIFF
--- a/packages/@coorpacademy-components/src/atom/input-switch/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-switch/index.js
@@ -65,7 +65,7 @@ const InputSwitch = props => {
             className={style.checkbox}
             aria-labelledby={`title-view-${dataName}`}
           />
-          <label htmlFor={idSwitch} data-name="input-switch-label" />
+          <label htmlFor={idSwitch} data-name="input-switch-label" tabIndex={0} />
         </div>
       </div>
       <div className={!details ? style.alignedTextContainer : null}>

--- a/packages/@coorpacademy-components/src/atom/link/index.js
+++ b/packages/@coorpacademy-components/src/atom/link/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {identity, getOr, noop} from 'lodash/fp';
-import Provider from '../provider';
+import Provider, {GetSkinFromContext} from '../provider';
 import pushToHistory from '../../util/navigation';
 
 class Link extends React.Component {
@@ -65,7 +65,8 @@ class Link extends React.Component {
   };
 
   render() {
-    const {skin, history: {createHref = identity} = {}} = this.context;
+    const {history: {createHref = identity} = {}} = this.context;
+    const skin = GetSkinFromContext(this.context);
     const {
       skinHover,
       hoverColor = getOr('#00B0FF', 'common.primary', skin),

--- a/packages/@coorpacademy-components/src/atom/link/index.js
+++ b/packages/@coorpacademy-components/src/atom/link/index.js
@@ -1,113 +1,109 @@
-import React from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import PropTypes from 'prop-types';
 import {identity, getOr, noop} from 'lodash/fp';
-import Provider from '../provider';
+import Provider, {GetSkinFromContext} from '../provider';
 import pushToHistory from '../../util/navigation';
 
-class Link extends React.Component {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    href: PropTypes.string,
-    'data-name': PropTypes.string,
-    'aria-label': PropTypes.string,
-    target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
-    skinHover: PropTypes.bool,
-    hoverColor: PropTypes.string,
-    download: PropTypes.bool,
-    onClick: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    style: PropTypes.shape({})
-  };
+const Link = (props, legacyContext) => {
+  const skin = GetSkinFromContext(legacyContext);
+  const [hovered, setHovered] = useState(false);
+  const {history: {createHref = identity} = {}} = legacyContext;
+  const {
+    skinHover,
+    hoverColor = getOr('#00B0FF', 'common.primary', skin),
+    'data-name': dataName = 'link',
+    'aria-label': ariaLabel,
+    ...linKElementProps
+  } = props;
+  const {
+    href,
+    onClick = noop,
+    className,
+    style: propsStyle,
+    children,
+    onMouseLeave = noop,
+    onMouseEnter = noop,
+    download
+  } = props;
 
-  static contextTypes = {
-    skin: Provider.childContextTypes.skin,
-    history: Provider.childContextTypes.history
-  };
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      hovered: false
-    };
-  }
-
-  handleMouseEnter = () => {
-    const {onMouseEnter = noop} = this.props;
-
-    this.setState({
-      hovered: true
-    });
+  const handleMouseEnter = useCallback(() => {
+    setHovered(true);
 
     onMouseEnter();
-  };
+  }, [onMouseEnter]);
 
-  handleMouseLeave = () => {
-    const {onMouseLeave = noop} = this.props;
-
-    this.setState({
-      hovered: false
-    });
+  const handleMouseLeave = useCallback(() => {
+    setHovered(false);
 
     onMouseLeave();
-  };
+  }, [onMouseLeave]);
 
-  handleOnClick = e => {
-    const {onClick = noop, download} = this.props;
+  const navigate = useMemo(() => pushToHistory(legacyContext)({href}), [href, legacyContext]);
 
-    onClick(e);
+  const handleOnClick = useCallback(
+    e => {
+      onClick(e);
 
-    if (!download) {
-      const navigate = pushToHistory(this.context)(this.props);
-      navigate(e);
-    }
-  };
+      if (!download) {
+        navigate(e);
+      }
+    },
+    [download, navigate, onClick]
+  );
 
-  render() {
-    const {skin, history: {createHref = identity} = {}} = this.context;
-    const {
-      skinHover,
-      hoverColor = getOr('#00B0FF', 'common.primary', skin),
-      'data-name': dataName = 'link',
-      'aria-label': ariaLabel,
-      ...aProps
-    } = this.props;
-    const {href, onClick, className, style: propsStyle, children} = this.props;
-    const {hovered} = this.state;
-    const _style =
-      href || onClick
-        ? null
-        : {
-            pointerEvents: 'none'
-          };
-    const _hoverStyle =
-      skinHover && hovered
-        ? {
-            color: hoverColor
-          }
-        : null;
+  const _style =
+    href || onClick
+      ? null
+      : {
+          pointerEvents: 'none'
+        };
+  const _hoverStyle =
+    skinHover && hovered
+      ? {
+          color: hoverColor
+        }
+      : null;
 
-    return (
-      <a
-        {...aProps}
-        data-name={dataName}
-        aria-label={ariaLabel}
-        href={href ? createHref(href) : undefined}
-        onClick={this.handleOnClick}
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}
-        className={className}
-        style={{
-          ...propsStyle,
-          ..._style,
-          ..._hoverStyle
-        }}
-      >
-        {children}
-      </a>
-    );
-  }
-}
+  return (
+    <a
+      {...linKElementProps}
+      data-name={dataName}
+      aria-label={ariaLabel}
+      href={href ? createHref(href) : undefined}
+      onClick={handleOnClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      className={className}
+      style={{
+        ...propsStyle,
+        ..._style,
+        ..._hoverStyle
+      }}
+    >
+      {children}
+    </a>
+  );
+};
+
+Link.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  href: PropTypes.string,
+  'data-name': PropTypes.string,
+  'aria-label': PropTypes.string,
+  target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
+  skinHover: PropTypes.bool,
+  hoverColor: PropTypes.string,
+  download: PropTypes.bool,
+  onClick: PropTypes.func,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  style: PropTypes.shape({})
+};
+
+Link.contextTypes = {
+  skin: Provider.childContextTypes.skin,
+  history: Provider.childContextTypes.history
+};
 
 export default Link;

--- a/packages/@coorpacademy-components/src/atom/link/index.js
+++ b/packages/@coorpacademy-components/src/atom/link/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {identity, getOr, noop} from 'lodash/fp';
-import Provider, {GetSkinFromContext} from '../provider';
+import Provider from '../provider';
 import pushToHistory from '../../util/navigation';
 
 class Link extends React.Component {
@@ -65,8 +65,7 @@ class Link extends React.Component {
   };
 
   render() {
-    const {history: {createHref = identity} = {}} = this.context;
-    const skin = GetSkinFromContext(this.context);
+    const {skin, history: {createHref = identity} = {}} = this.context;
     const {
       skinHover,
       hoverColor = getOr('#00B0FF', 'common.primary', skin),

--- a/packages/@coorpacademy-components/src/atom/review-presentation/test/on-mouse-leave.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/test/on-mouse-leave.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import browserEnv from 'browser-env';
 import React from 'react';
+import delay from 'delay';
 import {render, fireEvent, cleanup} from '@testing-library/react';
 import ReviewPresentation from '..';
 import defaultFixture from './fixtures/default';
@@ -9,7 +10,7 @@ browserEnv();
 
 test.after(cleanup);
 
-test('should hide toolTip depending on mouse leave event', t => {
+test('should hide toolTip depending on mouse leave event', async t => {
   const toolTipTestId = '[data-testid="tooltip"]';
   const {container} = render(<ReviewPresentation {...defaultFixture.props} />);
   const skillsDiv = container.querySelector(
@@ -17,9 +18,15 @@ test('should hide toolTip depending on mouse leave event', t => {
   );
   t.truthy(skillsDiv);
   fireEvent.mouseEnter(skillsDiv);
+  fireEvent.mouseOver(skillsDiv);
   let toolTipDiv = container.querySelector(toolTipTestId);
   t.truthy(toolTipDiv);
+  fireEvent.mouseEnter(toolTipDiv);
+  fireEvent.mouseOver(toolTipDiv);
   fireEvent.mouseLeave(skillsDiv);
+  fireEvent.mouseOver(skillsDiv);
+  fireEvent.mouseLeave(skillsDiv);
+  await delay(1000);
   toolTipDiv = container.querySelector(toolTipTestId);
   t.falsy(toolTipDiv);
 });

--- a/packages/@coorpacademy-components/src/atom/tooltip/style.css
+++ b/packages/@coorpacademy-components/src/atom/tooltip/style.css
@@ -67,6 +67,15 @@
   text-align: center;
 }
 
+.tooltipContentFontSize14 {
+  font-size: 14px;
+}
+
+.tooltipContentFontSize12 {
+  font-size: 12px;
+}
+
+
 .informationIcon {
   color: cm_grey_500;
 }

--- a/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/small-font.ts
+++ b/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/small-font.ts
@@ -4,8 +4,7 @@ const fixture = {
     'data-testid': 'tooltip-data-testid',
     TooltipContent: 'This is the tooltip text, a tooltip text',
     closeToolTipInformationTextAriaLabel: 'Press the escape key to close the information text',
-    delayHide: 0,
-    iconContainerClassName: '.someClass'
+    fontSize: 12
   }
 };
 

--- a/packages/@coorpacademy-components/src/organism/user-preferences/index.js
+++ b/packages/@coorpacademy-components/src/organism/user-preferences/index.js
@@ -1,28 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {map, isEmpty} from 'lodash/fp';
-import {NovaCompositionCoorpacademyInformationIcon as InfoIcon} from '@coorpacademy/nova-icons';
+import isEmpty from 'lodash/fp/isEmpty';
+import map from 'lodash/fp/map';
+import {GetTranslateFromContext} from '../../atom/provider';
+import ToolTip from '../../atom/tooltip';
 import InputSwitch from '../../atom/input-switch';
 import style from './style.css';
 
 const Settings = props => {
+  const translate = GetTranslateFromContext();
   const {label, description, moreInfoAriaLabel, ...settings} = props;
   return (
     <div className={style.settings}>
       <InputSwitch {...settings} />
-      <span className={style.label}>{label}</span>
+      <span className={style.label} tabIndex={0}>
+        {label}
+      </span>
       {isEmpty(description) ? null : (
-        <div className={style.infoIconWrapper}>
-          <InfoIcon
-            height={16}
-            width={16}
-            className={style.infoIcon}
-            aria-label={moreInfoAriaLabel}
-          />
-          <div className={style.showToolTip}>
-            <div className={style.descriptionLabel}>{description}</div>
-          </div>
-        </div>
+        <ToolTip
+          TooltipContent={description}
+          closeToolTipInformationTextAriaLabel={translate(
+            'Press the escape key to close the information text'
+          )}
+          data-testid="user-preferences-tooltip"
+          aria-label={moreInfoAriaLabel}
+          iconContainerClassName={style.infoIconTooltip}
+          fontSize={12}
+        />
       )}
     </div>
   );
@@ -35,11 +39,11 @@ Settings.propTypes = {
 };
 
 const UserPreferences = props => {
-  const {preferences = [], moreInfoAriaLabel, groupAriaLabel} = props;
+  const {preferences, moreInfoAriaLabel, groupAriaLabel} = props;
 
   return (
     <form>
-      <div className={style.preferences} role="group" aria-label={groupAriaLabel}>
+      <div className={style.preferences} role="group" aria-label={groupAriaLabel} tabIndex={0}>
         {map(
           settings => (
             <Settings {...settings} key={settings.label} moreInfoAriaLabel={moreInfoAriaLabel} />

--- a/packages/@coorpacademy-components/src/organism/user-preferences/style.css
+++ b/packages/@coorpacademy-components/src/organism/user-preferences/style.css
@@ -1,6 +1,7 @@
 @value colors: "../../variables/colors.css";
 @value dark from colors;
 @value light from colors;
+@value transparent from colors;
 
 .preferences {
   display: flex;
@@ -25,64 +26,12 @@
 
 .label {
   composes: fontBase;
+  position: relative;
+  top: 1px;
   margin-left: 15px;
   min-height: 18px;
 }
 
-.infoIconWrapper {
-  display: flex;
-  align-items: center;
-  overflow: visible;
-}
-
-.showToolTip {
-  margin-top: 5px;
-  text-align: center;
-  visibility: hidden;
-  opacity: 0;
-  transition: opacity 0.8s;
-}
-
-.infoIcon {
-  cursor: pointer;
-  padding-left: 10px;
-  padding-right: 4px;
-  color: dark;
-}
-
-.showToolTip::before {
-  content: '';
-  display: inline-block;
-  visibility: hidden;
-  opacity: 0;
-  width: 7px;
-  height: 8px;
-  margin: 7.5px -4px 7.5px 0;
-  transform: rotate(-45deg);
-  transition: opacity 0.8s;
-  background-color: light;
-}
-
-.infoIcon:hover  ~ .showToolTip {
-  visibility: visible;
-  opacity: 1;
-}
-
-.infoIcon:hover  ~ .showToolTip::before {
-  visibility: visible;
-  opacity: 1;
-}
-
-.descriptionLabel {
-  composes: fontBase;
-  display: inline-block;
-  background-color: light;
-  padding: 4px 8px;
-  border-radius: 3px;
-  word-wrap: break-word;
-  color: dark;
-  max-width: 220px;
-  overflow: hidden;
-  text-align: left;
-  position: absolute;
+.infoIconTooltip {
+  background: transparent;
 }

--- a/packages/@coorpacademy-components/src/template/activity/progression-item.js
+++ b/packages/@coorpacademy-components/src/template/activity/progression-item.js
@@ -16,7 +16,7 @@ import {
   NovaCompositionCoorpacademyMicrophone as PodcastIcon,
   NovaCompositionCoorpacademyRevision as RevisionIcon
 } from '@coorpacademy/nova-icons';
-import Provider from '../../atom/provider';
+import Provider, {GetSkinFromContext} from '../../atom/provider';
 import ProgressBar from '../../molecule/progress-bar';
 import Link from '../../atom/link';
 import style from './progression-item.css';
@@ -33,8 +33,8 @@ const ICONS = {
   review: RevisionIcon
 };
 
-const ProgressionItem = (props, context) => {
-  const {skin} = context;
+const ProgressionItem = (props, legacyContext) => {
+  const skin = GetSkinFromContext(legacyContext);
   const {
     disabled = false,
     adaptive,


### PR DESCRIPTION
Dans chaque page web, les contenus additionnels apparaissant au survol, à la prise de focus ou à l'activation d'un composant d'interface sont-ils, si nécessaire, atteignables au clavier.

**Detailed purpose of the PR**

- Replaces user preferences tooltip w/ Atom Tooltip
- Refactors Link

**Result and observation**
<img width="292" alt="Screenshot 2023-02-08 at 11 02 35" src="https://user-images.githubusercontent.com/33550261/217498363-35767fce-d197-4d52-b0c9-041e59cd72d6.png">


**Testing Strategy**

- [x] Already covered by tests
- [x] Unit testing
