### PR TITLE
adapt button link icon only to support bulk import design

### DIFF
--- a/packages/@coorpacademy-components/src/atom/button-link-icon-only/index.js
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon-only/index.js
@@ -4,6 +4,7 @@ import {getOr, keys} from 'lodash/fp';
 import classnames from 'classnames';
 import {ICONS} from '../../util/button-icons';
 import Link from '../link';
+// eslint-disable-next-line css-modules/no-unused-class
 import style from './style.css';
 
 const getButtonContent = icon => {
@@ -47,7 +48,7 @@ const ButtonLinkIconOnly = props => {
     getSizeStyle(size),
     link && style.link,
     disabled && style.disabled,
-    className
+    style[className]
   );
 
   const handleOnClick = useMemo(() => () => onClick(), [onClick]);

--- a/packages/@coorpacademy-components/src/atom/button-link-icon-only/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon-only/style.css
@@ -91,3 +91,26 @@
   width: 12px;
   height: 12px;
 }
+
+/* ----------------- CM bulk style ------------------------- */
+
+.bulkArrowDown {
+  composes: button;
+  width: 24px;
+  height: 24px;
+  background-color: white;
+  border: 1px solid cm_grey_200;
+  border-radius: 5px;
+  padding: 10px;
+  opacity: 0.5;
+}
+
+.bulkArrowDown .icon {
+  width: 8px;
+  height: 8px;
+}
+
+.bulkArrowUp {
+  composes: bulkArrowDown;
+  transform: rotate(180deg);
+}

--- a/packages/@coorpacademy-components/src/atom/button-link-icon-only/test/fixtures/bulk-arrow-down.js
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon-only/test/fixtures/bulk-arrow-down.js
@@ -1,0 +1,10 @@
+export default {
+  props: {
+    size: 'default',
+    'data-name': 'arrowDown-button',
+    'aria-label': 'aria button',
+    icon: 'down',
+    onClick: () => console.log('click'),
+    className: 'bulkArrowDown'
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/button-link-icon-only/test/fixtures/bulk-arrow-up.js
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon-only/test/fixtures/bulk-arrow-up.js
@@ -1,0 +1,10 @@
+export default {
+  props: {
+    size: 'default',
+    'data-name': 'arrowDown-button',
+    'aria-label': 'aria button',
+    icon: 'down',
+    onClick: () => console.log('click'),
+    className: 'bulkArrowUp'
+  }
+};

--- a/packages/@coorpacademy-components/src/util/button-icons.js
+++ b/packages/@coorpacademy-components/src/util/button-icons.js
@@ -14,7 +14,8 @@ import {
   NovaSolidComputersSdCard as SaveIcon,
   NovaLineLoginKey1 as KlfIcon,
   NovaSolidFilesFoldersFolders as FoldersIcon,
-  NovaSolidFilesBasicFileUpload2 as UploadIcon
+  NovaSolidFilesBasicFileUpload2 as UploadIcon,
+  NovaCompositionNavigationArrowDown as ArrowDown
 } from '@coorpacademy/nova-icons';
 
 export const ICONS = {
@@ -33,5 +34,6 @@ export const ICONS = {
   save: SaveIcon,
   see: EyeIcon,
   folders: FoldersIcon,
-  upload: UploadIcon
+  upload: UploadIcon,
+  down: ArrowDown
 };


### PR DESCRIPTION
[Ticket](https://trello.com/c/YbO0HtBE/1188-composant-inspect)
Purpose 1:
in order to respect bulk import design (inspect page), we need to have these graphic objects:
![image](https://user-images.githubusercontent.com/111736786/218511553-1d630bfd-662d-4f25-bad8-ea4c854ecae5.png) ![image](https://user-images.githubusercontent.com/111736786/218511663-7a4ae260-71bd-4cee-acd7-07360286ef2f.png) ![image](https://user-images.githubusercontent.com/111736786/218513702-93f74d2e-99e8-4ff0-baa4-3ca119eadcbe.png)

"button link icon only" uses similar objects, but with different styles, so the purpose is to make the component (button link icon only ) usable for bulk import.

**To do this:**

- I added "down" icon to the possible set icon props
- I created needed classes "bulkArrowDown" "bulkArrowUp" 
- These classes could be set in props (example : icon: 'down', className: bulkArrowDown)
- I created fixtures