### PR TITLE
[app-review] improved UX on review slide validation

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-slide/test/on-press.test.tsx
+++ b/packages/@coorpacademy-components/src/organism/review-slide/test/on-press.test.tsx
@@ -5,7 +5,7 @@ import Slide from '../index.native';
 import mockedGestureEvent from '../../../test/helpers/mocked-gesture-event';
 import fixtures from './fixtures/initial-state';
 
-test('should handle onPress on validate button', t => {
+test('should handle onPress on validate button', async t => {
   t.plan(1);
 
   const props = fixtures.props;
@@ -18,4 +18,9 @@ test('should handle onPress on validate button', t => {
   const buttonValidate = getByTestId('slide-validate-button-0');
 
   fireEvent.press(buttonValidate, mockedGestureEvent);
+
+  // wait for onclick to be triggered
+  await new Promise(resolve => {
+    setTimeout(resolve, 50);
+  });
 });


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

After having validated, the user could still trigger options in the slide.
This update alloes to act immediately once the validate button is triggered:

- removing textInput focus,
- adding a hidden BG to capture touches,
- triggering the real 'validate' action on the next frame, to be sure the locking BG appears the quickest possible.

before:
![before](https://user-images.githubusercontent.com/910636/218803191-0023174c-2c85-4a76-a95f-200b28094d94.gif)

after:
![after](https://user-images.githubusercontent.com/910636/218803250-e190007f-aea8-4cac-b024-ce739353bf84.gif)
