### PR TITLE
[RGAA] Battle Opponent Atom + Tooltip: 12.11

### DIFF
--- a/packages/@coorpacademy-components/package.json
+++ b/packages/@coorpacademy-components/package.json
@@ -120,6 +120,7 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/react-native": "^10.1.1",
     "@types/react-native": "~0.68.7",
+    "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.7",

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
@@ -19,7 +19,8 @@ const BattleOpponent = (
     userAvatarSrc,
     onClick,
     displayName,
-    tooltipText
+    tooltipText,
+    'aria-label': ariaLabel
   }: BattleOpponentProps,
   legacyContext: WebContextValues
 ) => {
@@ -107,6 +108,7 @@ const BattleOpponent = (
             data-for={battleOpponentInfoId}
             data-tooltip-place="left"
             data-tip={isAlreadyEngaged}
+            aria-label={ariaLabel}
           >
             <InformationIcon className={style.informationIcon} width={20} height={20} />
           </button>

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
@@ -51,13 +51,7 @@ const BattleOpponent = (
   }, [mouseLeaveTimer]);
 
   const handleMouseLeave = useCallback(() => {
-    setMouseLeaveTimer(
-      setTimeout(() => {
-        setToolTipIsVisible(false);
-        // @ts-expect-error (error: blur does not exists on type never)
-        buttonRef.current.blur();
-      }, 500) as unknown as number
-    );
+    setMouseLeaveTimer(setTimeout(() => setToolTipIsVisible(false), 500) as unknown as number);
   }, []);
 
   const handleKeyPress = useCallback(

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
@@ -51,7 +51,13 @@ const BattleOpponent = (
   }, [mouseLeaveTimer]);
 
   const handleMouseLeave = useCallback(() => {
-    setMouseLeaveTimer(setTimeout(() => setToolTipIsVisible(false), 500) as unknown as number);
+    setMouseLeaveTimer(
+      setTimeout(() => {
+        setToolTipIsVisible(false);
+        // @ts-expect-error (error: blur does not exists on type never)
+        buttonRef?.current?.blur();
+      }, 500) as unknown as number
+    );
   }, []);
 
   const handleKeyPress = useCallback(

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useMemo, useState, useRef} from 'react';
 import classnames from 'classnames';
 import {v5 as uuidV5} from 'uuid';
+import has from 'lodash/fp/has';
 import {
   NovaCompositionNavigationArrowRight as ArrowRight,
   NovaCompositionCoorpacademyInformationIcon as InformationIcon
@@ -46,7 +47,7 @@ const BattleOpponent = (
   const handleMouseOver = useCallback(() => {
     mouseLeaveTimer && clearTimeout(mouseLeaveTimer);
     // @ts-expect-error (error: focus does not exists on type never)
-    buttonRef.current.focus();
+    /* istanbul ignore next */ has(['current', 'focus'], buttonRef) && buttonRef.current.focus();
     setToolTipIsVisible(true);
   }, [mouseLeaveTimer]);
 
@@ -55,7 +56,7 @@ const BattleOpponent = (
       setTimeout(() => {
         setToolTipIsVisible(false);
         // @ts-expect-error (error: blur does not exists on type never)
-        buttonRef?.current?.blur();
+        /* istanbul ignore next */ has(['current', 'blur'], buttonRef) && buttonRef.current.blur();
       }, 500) as unknown as number
     );
   }, []);

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
@@ -1,0 +1,65 @@
+import React, {useMemo} from 'react';
+import classnames from 'classnames';
+import {NovaCompositionNavigationArrowRight as ArrowRight} from '@coorpacademy/nova-icons';
+import ToolTip from '../tooltip';
+import Provider, {GetTranslateFromContext} from '../provider';
+import {WebContextValues} from '../provider/web-context';
+import propTypes, {BattleOpponentProps} from './prop-types';
+import style from './style.css';
+
+const BattleOpponent = (
+  {
+    isAlreadyEngaged,
+    isRandom,
+    userAvatarSrc,
+    onClick,
+    displayName,
+    tooltipText
+  }: BattleOpponentProps,
+  legacyContext: WebContextValues
+) => {
+  const translate: Required<WebContextValues>['translate'] = GetTranslateFromContext(legacyContext);
+  const wrapperClassnames = useMemo(
+    () => classnames(style.card, style['opponent-card'], isRandom ? style.random : null),
+    [isRandom]
+  );
+
+  const displayNameClassnames = useMemo(
+    () => classnames(style.name, isAlreadyEngaged ? style.alreadyEngaged : null),
+    [isAlreadyEngaged]
+  );
+
+  return (
+    <div
+      {...(!isAlreadyEngaged && {onClick})}
+      className={wrapperClassnames}
+      data-testid="battle-opponent-wrapper"
+    >
+      <div className={style.avatar}>
+        {isRandom ? null : <img src={userAvatarSrc} aria-hidden="true" />}
+      </div>
+      <p className={displayNameClassnames}> {displayName}</p>
+      {isAlreadyEngaged ? (
+        <ToolTip
+          fontSize={12}
+          iconSize="big"
+          TooltipContent={tooltipText}
+          closeToolTipInformationTextAriaLabel={translate(
+            'Press the escape key to close the information text'
+          )}
+          iconContainerClassName={style.infoIconTooltip}
+        />
+      ) : (
+        <ArrowRight className={style.rightArrow} width={16} height={16} />
+      )}
+    </div>
+  );
+};
+
+BattleOpponent.propTypes = propTypes;
+
+BattleOpponent.contextTypes = {
+  translate: Provider.childContextTypes.translate
+};
+
+export default BattleOpponent;

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
@@ -30,7 +30,7 @@ const BattleOpponent = (
   );
 
   return (
-    <div
+    <li
       {...(!isAlreadyEngaged && {onClick})}
       className={wrapperClassnames}
       data-testid="battle-opponent-wrapper"
@@ -52,7 +52,7 @@ const BattleOpponent = (
       ) : (
         <ArrowRight className={style.rightArrow} width={16} height={16} />
       )}
-    </div>
+    </li>
   );
 };
 

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/prop-types.ts
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/prop-types.ts
@@ -6,7 +6,8 @@ const propTypes = {
   userAvatarSrc: PropTypes.string,
   onClick: PropTypes.func,
   displayName: PropTypes.string,
-  tooltipText: PropTypes.string
+  tooltipText: PropTypes.string,
+  'aria-label': PropTypes.string
 };
 
 export type BattleOpponentProps = {
@@ -16,6 +17,7 @@ export type BattleOpponentProps = {
   onClick?: () => void;
   displayName: string;
   tooltipText?: string;
+  'aria-label'?: string;
 };
 
 export default propTypes;

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/prop-types.ts
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/prop-types.ts
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  isAlreadyEngaged: PropTypes.bool,
+  isRandom: PropTypes.bool,
+  userAvatarSrc: PropTypes.string,
+  onClick: PropTypes.func,
+  displayName: PropTypes.string,
+  tooltipText: PropTypes.string
+};
+
+export type BattleOpponentProps = {
+  isAlreadyEngaged?: boolean;
+  isRandom?: boolean;
+  userAvatarSrc?: string;
+  onClick?: () => void;
+  displayName: string;
+  tooltipText?: string;
+};
+
+export default propTypes;

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/style.css
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/style.css
@@ -99,8 +99,17 @@
   background-color: cm_grey_75;
 }
 
-.card .infoIconTooltip {
+.informationIcon {
+  color: cm_grey_500;
+}
+
+.tooltipIconContainer {
+  display: flex;
+  justify-content: flex-end;
+  border: none;
   background: transparent;
+  height: 25px;
+  align-items: center;
 }
 
 @media mobile {

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/style.css
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/style.css
@@ -50,7 +50,6 @@
   margin-left: 20px;
 }
 
-/* div:not(.random) */
 .avatar {
   width: 50px;
   height: 50px;
@@ -102,7 +101,6 @@
 
 .card .infoIconTooltip {
   background: transparent;
-  /* height: 100%; */
 }
 
 @media mobile {

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/style.css
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/style.css
@@ -1,0 +1,126 @@
+@value breakpoints: "../../variables/breakpoints.css";
+@value mobile from breakpoints;
+@value colors: "../../variables/colors.css";
+@value white from colors;
+@value dark from colors;
+@value black from colors;
+@value cm_grey_75 from colors;
+@value medium from colors;
+@value light from colors;
+@value brand from colors;
+
+.rightArrow {
+  position: flex;
+  padding: 9px;
+  cursor: pointer;
+  opacity: 1;
+  user-select: none;
+  text-align: right;
+  color: dark;
+}
+
+.card {
+  margin: 5px;
+}
+
+.opponent-card {
+  flex: 1 1 350px;
+  height: 80px;
+  background-color: white;
+  box-shadow: 0 0 4px 1px rgba(0,0,0,0.10);
+  border-radius: 3px;
+  padding: 20px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.opponent-card .name {
+  font-family: 'Gilroy';
+  font-size: 15px;
+  font-weight: 700;
+  color: black;
+  flex-grow: 1;
+}
+
+
+.opponent-card .rightArrow {
+  margin-left: 20px;
+}
+
+/* div:not(.random) */
+.avatar {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: light;
+  margin-right: 20px;
+  flex-shrink: 0;
+}
+
+.avatar img {
+  width: 100%;
+  height: auto;
+}
+
+
+.random {
+  color: medium;
+}
+
+.alreadyEngaged.name,
+.random .name {
+  color: medium;
+}
+
+.random .avatar {
+  background-color: brand;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.random .avatar:before {
+  content: '?';
+  font-family: 'Gilroy';
+  font-size: 32px;
+  font-weight: 600;
+  color: white;
+  text-align: center;
+}
+
+.random .avatar img {
+  display: none;
+}
+
+.opponent-card:hover {
+  background-color: cm_grey_75;
+}
+
+.card .infoIconTooltip {
+  background: transparent;
+  /* height: 100%; */
+}
+
+@media mobile {
+  .opponent-card {
+    width: 100%;
+    padding: 10px;
+  }
+
+  .opponent-card .avatar {
+    margin-right: 10px;
+  }
+
+  .opponent-card .rightArrow {
+    margin-left: 10px;
+  }
+
+  .card {
+    margin: 0 0 10px;
+  }
+}
+

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/test/already-engaged-opponent-click.tsx
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/test/already-engaged-opponent-click.tsx
@@ -1,0 +1,34 @@
+import test from 'ava';
+import browserEnv from 'browser-env';
+import React from 'react';
+import {fireEvent} from '@testing-library/react';
+import {renderWithContext} from '../../../util/render-with-context';
+import BattleOpponent from '..';
+import alreadyEngagedFixture from './fixtures/opponent-already-engaged';
+
+browserEnv();
+
+test('should not launch onClick on click event, for an already engaged opponent', t => {
+  t.plan(2);
+
+  const props = {
+    ...alreadyEngagedFixture.props,
+    onClick: () => t.fail()
+  };
+
+  const context = {
+    translate: (key: string) => {
+      t.pass();
+      return key;
+    }
+  };
+
+  const {container} = renderWithContext(<BattleOpponent {...props} />, context);
+
+  const battleOpponentWrapper = container.querySelector('[data-testid="battle-opponent-wrapper"]');
+  t.truthy(battleOpponentWrapper);
+
+  fireEvent.click(battleOpponentWrapper as Element);
+
+  t.pass();
+});

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/test/already-engaged-opponent-click.tsx
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/test/already-engaged-opponent-click.tsx
@@ -1,6 +1,7 @@
 import test from 'ava';
 import browserEnv from 'browser-env';
 import React from 'react';
+import delay from 'delay';
 import {fireEvent} from '@testing-library/react';
 import {renderWithContext} from '../../../util/render-with-context';
 import BattleOpponent from '..';
@@ -8,8 +9,8 @@ import alreadyEngagedFixture from './fixtures/opponent-already-engaged';
 
 browserEnv();
 
-test('should not launch onClick on click event, for an already engaged opponent', t => {
-  t.plan(2);
+test('should not launch onClick on click event, for an already engaged opponent, should show the tooltip on interaction with the information button', async t => {
+  t.plan(9);
 
   const props = {
     ...alreadyEngagedFixture.props,
@@ -23,12 +24,47 @@ test('should not launch onClick on click event, for an already engaged opponent'
     }
   };
 
+  const reactToolTipContent = '[data-testid="battle-opponent-tooltip-content"]';
+
   const {container} = renderWithContext(<BattleOpponent {...props} />, context);
 
   const battleOpponentWrapper = container.querySelector('[data-testid="battle-opponent-wrapper"]');
   t.truthy(battleOpponentWrapper);
 
   fireEvent.click(battleOpponentWrapper as Element);
+
+  const informationButton = container.querySelector(
+    '[data-testid="battle-engaged-opponent-information-button"]'
+  ) as Element;
+  t.truthy(informationButton);
+  fireEvent.mouseEnter(informationButton);
+  let reactToolTip: Element | null = container.querySelector(reactToolTipContent) as Element;
+  t.truthy(reactToolTip);
+
+  fireEvent.mouseOver(reactToolTip);
+  fireEvent.mouseLeave(reactToolTip);
+  fireEvent.mouseLeave(informationButton);
+  await delay(500);
+
+  reactToolTip = container.querySelector(reactToolTipContent);
+  t.falsy(reactToolTip);
+
+  fireEvent.mouseEnter(informationButton);
+  fireEvent.keyDown(informationButton, {key: 'Escape'});
+  reactToolTip = container.querySelector(reactToolTipContent);
+  t.falsy(reactToolTip);
+
+  fireEvent.keyDown(informationButton, {key: 'A'});
+  reactToolTip = container.querySelector(reactToolTipContent);
+  t.falsy(reactToolTip);
+
+  fireEvent.keyDown(informationButton, {key: 'Enter'});
+  reactToolTip = container.querySelector(reactToolTipContent);
+  t.truthy(reactToolTip);
+
+  fireEvent.keyDown(informationButton, {key: 'Tab'});
+  reactToolTip = container.querySelector(reactToolTipContent);
+  t.falsy(reactToolTip);
 
   t.pass();
 });

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/test/available-opponent-click copy.tsx
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/test/available-opponent-click copy.tsx
@@ -1,0 +1,34 @@
+import test from 'ava';
+import browserEnv from 'browser-env';
+import React from 'react';
+import {fireEvent} from '@testing-library/react';
+import {renderWithContext} from '../../../util/render-with-context';
+import BattleOpponent from '..';
+import defaultFixture from './fixtures/available-opponent';
+
+browserEnv();
+
+test('should launch onClick on click event, for an available opponent', t => {
+  t.plan(3);
+
+  const props = {
+    ...defaultFixture.props,
+    onClick: () => t.pass()
+  };
+
+  const context = {
+    translate: (key: string) => {
+      t.pass();
+      return key;
+    }
+  };
+
+  const {container} = renderWithContext(<BattleOpponent {...props} />, context);
+
+  const battleOpponentWrapper = container.querySelector('[data-testid="battle-opponent-wrapper"]');
+  t.truthy(battleOpponentWrapper);
+
+  fireEvent.click(battleOpponentWrapper as Element);
+
+  t.pass();
+});

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/available-opponent.ts
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/available-opponent.ts
@@ -6,7 +6,8 @@ const fixture: {props: BattleOpponentProps} = {
     isRandom: false,
     userAvatarSrc: 'https://via.placeholder.com/150/FF7043/FAFAFA?text=Ph',
     displayName: 'Phineas Flynn',
-    onClick: () => console.log('Battle Opponent click')
+    onClick: () => console.log('Battle Opponent click'),
+    'aria-label': 'battle opponent button aria label'
   }
 };
 

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/available-opponent.ts
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/available-opponent.ts
@@ -1,0 +1,13 @@
+import {BattleOpponentProps} from '../../prop-types';
+
+const fixture: {props: BattleOpponentProps} = {
+  props: {
+    isAlreadyEngaged: false,
+    isRandom: false,
+    userAvatarSrc: 'https://via.placeholder.com/150/FF7043/FAFAFA?text=Ph',
+    displayName: 'Phineas Flynn',
+    onClick: () => console.log('Battle Opponent click')
+  }
+};
+
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/opponent-already-engaged.ts
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/opponent-already-engaged.ts
@@ -4,7 +4,8 @@ const fixture: {props: BattleOpponentProps} = {
   props: {
     isAlreadyEngaged: true,
     userAvatarSrc: 'https://via.placeholder.com/150/16ac8c/FAFAFA?text=Fe',
-    tooltipText: 'This is the tooltip text, some explanation about engaged opponents',
+    tooltipText:
+      "Vous avez déjà une battle en cours sur ce sujet avec cette personne. Vous pouvez choisir quelqu'un d'autre ou sélectionner un cours différent.",
     displayName: 'Ferb Fletcher'
   }
 };

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/opponent-already-engaged.ts
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/opponent-already-engaged.ts
@@ -6,7 +6,8 @@ const fixture: {props: BattleOpponentProps} = {
     userAvatarSrc: 'https://via.placeholder.com/150/16ac8c/FAFAFA?text=Fe',
     tooltipText:
       "Vous avez déjà une battle en cours sur ce sujet avec cette personne. Vous pouvez choisir quelqu'un d'autre ou sélectionner un cours différent.",
-    displayName: 'Ferb Fletcher'
+    displayName: 'Ferb Fletcher',
+    'aria-label': 'battle opponent button aria label'
   }
 };
 

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/opponent-already-engaged.ts
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/opponent-already-engaged.ts
@@ -1,0 +1,12 @@
+import {BattleOpponentProps} from '../../prop-types';
+
+const fixture: {props: BattleOpponentProps} = {
+  props: {
+    isAlreadyEngaged: true,
+    userAvatarSrc: 'https://via.placeholder.com/150/16ac8c/FAFAFA?text=Fe',
+    tooltipText: 'This is the tooltip text, some explanation about engaged opponents',
+    displayName: 'Ferb Fletcher'
+  }
+};
+
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/random-opponent.ts
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/random-opponent.ts
@@ -1,0 +1,11 @@
+import {BattleOpponentProps} from '../../prop-types';
+
+const fixture: {props: BattleOpponentProps} = {
+  props: {
+    isRandom: true,
+    displayName: 'A random platypus?',
+    onClick: () => console.log('Battle Opponent click, random')
+  }
+};
+
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/random-opponent.ts
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/test/fixtures/random-opponent.ts
@@ -4,7 +4,8 @@ const fixture: {props: BattleOpponentProps} = {
   props: {
     isRandom: true,
     displayName: 'A random platypus?',
-    onClick: () => console.log('Battle Opponent click, random')
+    onClick: () => console.log('Battle Opponent click, random'),
+    'aria-label': 'battle opponent button aria label'
   }
 };
 

--- a/packages/@coorpacademy-components/src/atom/tooltip/index.js
+++ b/packages/@coorpacademy-components/src/atom/tooltip/index.js
@@ -181,6 +181,7 @@ ToolTip.propTypes = {
   // ----------  React Tooltip exclusive  --------------
   // externalHandling: if passed down, React Tooltip is used instead, due to limitations on
   // parents overflow hidden controls
+  // data-for={anchorId} && data-tooltip-place="left" are needed on the anchored component
   anchorId: PropTypes.string,
   toolTipIsVisible: PropTypes.bool
 };

--- a/packages/@coorpacademy-components/src/atom/tooltip/index.js
+++ b/packages/@coorpacademy-components/src/atom/tooltip/index.js
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
 import isString from 'lodash/fp/isString';
+import keys from 'lodash/fp/keys';
 import {NovaCompositionCoorpacademyInformationIcon as InformationIcon} from '@coorpacademy/nova-icons';
 import style from './style.css';
 
@@ -11,12 +12,18 @@ const FontSizes = {
   14: style.tooltipContentFontSize14
 };
 
+const IconSizes = {
+  small: 12,
+  big: 20
+};
+
 const ToolTipWrapper = ({
   toolTipIsVisible,
   anchorId,
   closeToolTipInformationTextAriaLabel,
   content,
-  handleContentMouseOver
+  handleContentMouseOver,
+  iconSize
 }) => {
   if (!toolTipIsVisible) return null;
   if (anchorId) {
@@ -35,7 +42,10 @@ const ToolTipWrapper = ({
   } else {
     return (
       <div
-        className={style.toolTip}
+        className={classnames(
+          style.toolTip,
+          iconSize === 'big' ? style.bigIconToolTip : style.smallIconToolTip
+        )}
         data-testid="tooltip"
         aria-label={closeToolTipInformationTextAriaLabel}
         onMouseOver={handleContentMouseOver}
@@ -51,7 +61,8 @@ ToolTipWrapper.propTypes = {
   anchorId: PropTypes.string,
   closeToolTipInformationTextAriaLabel: PropTypes.string.isRequired,
   content: PropTypes.node,
-  handleContentMouseOver: PropTypes.func
+  handleContentMouseOver: PropTypes.func,
+  iconSize: PropTypes.oneOf(keys(IconSizes))
 };
 
 export const toggleStateOnKeyPress = (state, setState, ref) => event => {
@@ -74,7 +85,8 @@ const ToolTip = ({
   toolTipIsVisible: _toolTipIsVisible,
   iconContainerClassName,
   delayHide = 250,
-  fontSize = 14
+  fontSize = 14,
+  iconSize = 'small'
 }) => {
   const isComponent = useMemo(
     () => !isString(TooltipContent) && isValidElement(TooltipContent()),
@@ -138,8 +150,8 @@ const ToolTip = ({
       >
         <InformationIcon
           className={style.informationIcon}
-          width={12}
-          height={12}
+          width={IconSizes[iconSize]}
+          height={IconSizes[iconSize]}
           aria-label={ariaLabel}
         />
       </button>
@@ -150,6 +162,7 @@ const ToolTip = ({
         content={content}
         handleContentMouseOver={handleContentMouseOver}
         fontSize={fontSize}
+        iconSize={iconSize}
       />
     </div>
   );
@@ -164,6 +177,7 @@ ToolTip.propTypes = {
   iconContainerClassName: PropTypes.string,
   delayHide: PropTypes.number,
   fontSize: PropTypes.oneOf([12, 14]),
+  iconSize: PropTypes.oneOf(keys(IconSizes)),
   // ----------  React Tooltip exclusive  --------------
   // externalHandling: if passed down, React Tooltip is used instead, due to limitations on
   // parents overflow hidden controls

--- a/packages/@coorpacademy-components/src/atom/tooltip/style.css
+++ b/packages/@coorpacademy-components/src/atom/tooltip/style.css
@@ -34,10 +34,18 @@
   position: absolute;
   border-radius: 7px;
   background-color: cm_grey_700;
-  right: -75px;
-  bottom: 32px;
   height: auto;
   width: 200px;
+}
+
+.bigIconToolTip {
+  right: -71px;
+  bottom: 31px;
+}
+
+.smallIconToolTip {
+  right: -75px;
+  bottom: 32px;
 }
 
 .toolTip::before {

--- a/packages/@coorpacademy-components/src/atom/tooltip/style.css
+++ b/packages/@coorpacademy-components/src/atom/tooltip/style.css
@@ -96,6 +96,7 @@
   visibility: visible !important;
   opacity: 1 !important;
   left: 5px;
+  max-width: 400px;
 }
 
 /* for keyboard navigation, the position can't be obtained from the mouse */

--- a/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/small-font-big-icon.ts
+++ b/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/small-font-big-icon.ts
@@ -1,0 +1,12 @@
+const fixture = {
+  props: {
+    'aria-label': 'tooltip aria label',
+    'data-testid': 'tooltip-data-testid',
+    TooltipContent: 'This is the tooltip text, a tooltip text',
+    closeToolTipInformationTextAriaLabel: 'Press the escape key to close the information text',
+    fontSize: 12,
+    iconSize: 20
+  }
+};
+
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/small-font-big-icon.ts
+++ b/packages/@coorpacademy-components/src/atom/tooltip/test/fixtures/small-font-big-icon.ts
@@ -5,7 +5,7 @@ const fixture = {
     TooltipContent: 'This is the tooltip text, a tooltip text',
     closeToolTipInformationTextAriaLabel: 'Press the escape key to close the information text',
     fontSize: 12,
-    iconSize: 20
+    iconSize: 'big'
   }
 };
 

--- a/packages/@coorpacademy-components/src/globals.d.ts
+++ b/packages/@coorpacademy-components/src/globals.d.ts
@@ -2,6 +2,7 @@ declare module '@coorpacademy/nova-icons';
 declare module '@coorpacademy/react-native-slider';
 declare module '@react-native-community/blur';
 declare module '@coorpacademy/translate';
+declare module 'browser-env';
 declare module 'react-native/*';
 declare module 'color';
 declare module 'classnames';

--- a/packages/@coorpacademy-components/src/molecule/battle-opponent-list/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/battle-opponent-list/index.tsx
@@ -4,6 +4,7 @@ import map from 'lodash/fp/map';
 import {v5 as uuidV5} from 'uuid';
 import BattleOpponent from '../../atom/battle-opponent';
 import propTypes, {BattleOpponentListProps} from './prop-types';
+import style from './style.css';
 
 const BattleOpponentList = ({opponents}: BattleOpponentListProps) => {
   const opponentList = useMemo(
@@ -21,7 +22,7 @@ const BattleOpponentList = ({opponents}: BattleOpponentListProps) => {
     [opponents]
   );
 
-  return opponentList;
+  return <ul className={style.opponentList}>{opponentList}</ul>;
 };
 
 BattleOpponentList.propTypes = propTypes;

--- a/packages/@coorpacademy-components/src/molecule/battle-opponent-list/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/battle-opponent-list/index.tsx
@@ -1,0 +1,29 @@
+import React, {useMemo} from 'react';
+import get from 'lodash/fp/get';
+import map from 'lodash/fp/map';
+import {v5 as uuidV5} from 'uuid';
+import BattleOpponent from '../../atom/battle-opponent';
+import propTypes, {BattleOpponentListProps} from './prop-types';
+
+const BattleOpponentList = ({opponents}: BattleOpponentListProps) => {
+  const opponentList = useMemo(
+    () =>
+      map(
+        opponent => (
+          <BattleOpponent
+            {...opponent}
+            key={uuidV5('battle-', uuidV5.URL)}
+            userAvatarSrc={get('photo', opponent)}
+          />
+        ),
+        opponents
+      ),
+    [opponents]
+  );
+
+  return opponentList;
+};
+
+BattleOpponentList.propTypes = propTypes;
+
+export default BattleOpponentList;

--- a/packages/@coorpacademy-components/src/molecule/battle-opponent-list/prop-types.ts
+++ b/packages/@coorpacademy-components/src/molecule/battle-opponent-list/prop-types.ts
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  opponents: PropTypes.arrayOf(
+    PropTypes.shape({
+      isAlreadyEngaged: PropTypes.bool,
+      isRandom: PropTypes.bool,
+      photo: PropTypes.string,
+      onClick: PropTypes.func,
+      displayName: PropTypes.string,
+      tooltipText: PropTypes.string,
+      user_id: PropTypes.string
+    })
+  )
+};
+
+type MoocBattleOpponent = {
+  isAlreadyEngaged?: boolean;
+  isRandom?: boolean;
+  photo?: string;
+  onClick?: () => void;
+  displayName: string;
+  tooltipText: string;
+  user_id: string;
+};
+
+export type BattleOpponentListProps = {opponents: MoocBattleOpponent[]};
+
+export default propTypes;

--- a/packages/@coorpacademy-components/src/molecule/battle-opponent-list/style.css
+++ b/packages/@coorpacademy-components/src/molecule/battle-opponent-list/style.css
@@ -1,0 +1,5 @@
+.opponentList {
+  margin: 0;
+  padding: 0;
+  display: contents;
+}

--- a/packages/@coorpacademy-components/src/molecule/battle-opponent-list/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/molecule/battle-opponent-list/test/fixtures/default.ts
@@ -1,0 +1,28 @@
+import omit from 'lodash/fp/omit';
+import {BattleOpponentListProps} from '../../prop-types';
+import availableOpponent from '../../../../atom/battle-opponent/test/fixtures/available-opponent';
+import engagedOpponent from '../../../../atom/battle-opponent/test/fixtures/opponent-already-engaged';
+import randomOpponent from '../../../../atom/battle-opponent/test/fixtures/random-opponent';
+
+const availableOpponentProps = {
+  ...omit(['userAvatarSrc'], availableOpponent.props),
+  photo: availableOpponent.props.userAvatarSrc
+};
+
+const engagedOpponentProps = {
+  ...omit(['userAvatarSrc'], engagedOpponent.props),
+  photo: engagedOpponent.props.userAvatarSrc
+};
+
+const fixture: {props: BattleOpponentListProps} = {
+  props: {
+    opponents: [
+      {...engagedOpponentProps, user_id: '001'},
+      {...randomOpponent.props, user_id: '002'},
+      {...availableOpponentProps, user_id: '003'},
+      {...availableOpponentProps, user_id: '004'}
+    ] as BattleOpponentListProps['opponents']
+  }
+};
+
+export default fixture;

--- a/packages/@coorpacademy-components/src/organism/user-preferences/index.js
+++ b/packages/@coorpacademy-components/src/organism/user-preferences/index.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/fp/isEmpty';
 import map from 'lodash/fp/map';
-import {GetTranslateFromContext} from '../../atom/provider';
+import Provider, {GetTranslateFromContext} from '../../atom/provider';
 import ToolTip from '../../atom/tooltip';
 import InputSwitch from '../../atom/input-switch';
 import style from './style.css';
 
-const Settings = props => {
-  const translate = GetTranslateFromContext();
+const Settings = (props, legacyContext) => {
+  const translate = GetTranslateFromContext(legacyContext);
   const {label, description, moreInfoAriaLabel, ...settings} = props;
   return (
     <div className={style.settings}>
@@ -36,6 +36,10 @@ Settings.propTypes = {
   ...InputSwitch.propTypes,
   label: PropTypes.string.isRequired,
   description: PropTypes.string
+};
+
+Settings.contextTypes = {
+  translate: Provider.childContextTypes.translate
 };
 
 const UserPreferences = props => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4638,6 +4638,11 @@
   resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.19.tgz#2789369799907fc11e2bc6e3a00f6478c2281b95"
   integrity sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg==
 
+"@types/uuid@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz#53ef263e5239728b56096b0a869595135b7952d2"
+  integrity sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==
+
 "@types/webpack-env@^1.16.0":
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.0.tgz#ed6ecaa8e5ed5dfe8b2b3d00181702c9925f13fb"


### PR DESCRIPTION
Crit 12.11:
Dans chaque page web, les contenus additionnels apparaissant au survol, à la prise de focus ou à l'activation d'un composant d'interface sont-ils, si nécessaire, atteignables au clavier

**Detailed purpose of the PR**

- Adds Battle Opponent Atom + Tooltip
- Adds Battle Opponent List

**Result and observation**
![Screen Recording 2023-02-14 at 19 11 11](https://user-images.githubusercontent.com/33550261/218823260-70ac4357-5f1c-488c-8e19-30e87cb5a759.gif)

<img width="555" alt="Screenshot 2023-02-16 at 08 51 44" src="https://user-images.githubusercontent.com/33550261/219301912-83b9b5d1-6056-4fb8-b3dc-8b387becfd63.png">

**Testing Strategy**

- [x] Manual testing
- [x] Unit testing
