### PR TITLE
[RGAA] update svg generator in order to take other roles if set

### DIFF
--- a/packages/@coorpacademy-nova-icons/scripts/generate-icons.js
+++ b/packages/@coorpacademy-nova-icons/scripts/generate-icons.js
@@ -122,7 +122,7 @@ const template =
   `
       : templateAlias.ast`
     ${importsAlias}
-    const ${componentName} = _props => {const {'aria-label':ariaLabel, role, alt, ...rest} = _props; const props = {...rest, ...((ariaLabel || alt) ? {role: role ?? 'img', 'aria-label':ariaLabel, alt} : {
+    const ${componentName} = _props => {const {'aria-label':ariaLabel, role, alt, ...rest} = _props; const props = {...rest, ...((ariaLabel || alt) ? {role: role || 'img', 'aria-label':ariaLabel, alt} : {
       'aria-hidden': 'true'
     })};return ${extendedJsx}}
     ${exportsAlias}

--- a/packages/@coorpacademy-nova-icons/scripts/generate-icons.js
+++ b/packages/@coorpacademy-nova-icons/scripts/generate-icons.js
@@ -122,7 +122,7 @@ const template =
   `
       : templateAlias.ast`
     ${importsAlias}
-    const ${componentName} = _props => {const {'aria-label':ariaLabel, alt, ...rest} = _props; const props = {...rest, ...((ariaLabel || alt) ? {role: 'img', 'aria-label':ariaLabel, alt} : {
+    const ${componentName} = _props => {const {'aria-label':ariaLabel, role, alt, ...rest} = _props; const props = {...rest, ...((ariaLabel || alt) ? {role: role ?? 'img', 'aria-label':ariaLabel, alt} : {
       'aria-hidden': 'true'
     })};return ${extendedJsx}}
     ${exportsAlias}

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/10sec-back.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/10sec-back.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/10sec-back.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/10sec-back.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/10sec-forward.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/10sec-forward.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/10sec-forward.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/10sec-forward.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/adaptive.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/adaptive.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/adaptive.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/adaptive.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/address-error.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/address-error.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/address-error.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/address-error.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/administration.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/administration.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/administration.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/administration.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/analytics.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/analytics.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/analytics.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/analytics.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/animation.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/animation.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/animation.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/animation.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/article.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/article.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/article.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/article.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/attention.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/attention.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/attention.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/attention.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/big-flash-left.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/big-flash-left.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/big-flash-left.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/big-flash-left.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/big-flash-right.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/big-flash-right.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/big-flash-right.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/big-flash-right.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bluetooth.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bluetooth.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bluetooth.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bluetooth.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bolt.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bolt.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bolt.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bolt.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/broken-heart.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/broken-heart.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/broken-heart.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/broken-heart.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bullet-point.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bullet-point.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bullet-point.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/bullet-point.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/charts.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/charts.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/charts.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/charts.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/chat.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/chat.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/chat.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/chat.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/check.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/check.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/check.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/check.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clock-time.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clock-time.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clock-time.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clock-time.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clock.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clock.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clock.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clock.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clue.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clue.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clue.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/clue.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/cm-loader.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/cm-loader.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/cm-loader.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/cm-loader.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/cog.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/cog.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/cog.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/cog.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/content-creation.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/content-creation.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/content-creation.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/content-creation.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/coorp-app.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/coorp-app.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/coorp-app.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/coorp-app.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/coorp-logo.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/coorp-logo.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/coorp-logo.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/coorp-logo.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/dashboard.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/dashboard.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/dashboard.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/dashboard.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/draft.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/draft.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/draft.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/draft.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/editorialization.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/editorialization.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/editorialization.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/editorialization.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/empty-state-home-revision.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/empty-state-home-revision.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/empty-state-home-revision.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/empty-state-home-revision.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/eye.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/eye.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/eye.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/eye.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/facebook.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/facebook.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/facebook.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/facebook.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/filter-video2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/filter-video2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/filter-video2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/filter-video2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/funnel.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/funnel.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/funnel.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/funnel.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/google-plus.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/google-plus.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/google-plus.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/google-plus.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/heart.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/heart.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/heart.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/heart.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/icon-faq.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/icon-faq.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/icon-faq.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/icon-faq.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/import-icon.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/import-icon.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/import-icon.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/import-icon.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/information-icon.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/information-icon.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/information-icon.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/information-icon.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/instagram.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/instagram.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/instagram.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/instagram.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-0.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-0.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-0.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-0.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-3.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/level-3.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/lightbulb.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/lightbulb.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/lightbulb.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/lightbulb.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/linkedin.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/linkedin.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/linkedin.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/linkedin.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/list-bullets-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/list-bullets-3.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/list-bullets-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/list-bullets-3.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/locales.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/locales.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/locales.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/locales.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/lock.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/lock.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/lock.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/lock.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/login-failed.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/login-failed.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/login-failed.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/login-failed.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/logout.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/logout.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/logout.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/logout.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/magic-wand.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail-inbox-document.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail-inbox-document.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail-inbox-document.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail-inbox-document.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail-inbox.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail-inbox.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail-inbox.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail-inbox.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/mail.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/map.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/map.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/map.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/map.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/microphone.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/microphone.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/microphone.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/microphone.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/next.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/next.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/next.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/next.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/open-in-new-tab.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/open-in-new-tab.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/open-in-new-tab.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/open-in-new-tab.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/pictures.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/pictures.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/pictures.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/pictures.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/pinterest.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/pinterest.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/pinterest.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/pinterest.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/places-home-24.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/places-home-24.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/places-home-24.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/places-home-24.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/play.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/play.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/play.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/play.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/prev.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/prev.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/prev.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/prev.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/profile.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/profile.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/profile.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/profile.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/queue.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/queue.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/queue.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/queue.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/reload.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/reload.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/reload.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/reload.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/revision.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/revision.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/revision.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/revision.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/school-graduation.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/school-graduation.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/school-graduation.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/school-graduation.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/scorm.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/scorm.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/scorm.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/scorm.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/search-thin.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/search-thin.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/search-thin.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/search-thin.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/search.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/search.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/search.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/search.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/settings.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/settings.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/settings.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/settings.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/share.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/share.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/share.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/share.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/small-flash-left.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/small-flash-left.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/small-flash-left.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/small-flash-left.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/small-flash-right.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/small-flash-right.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/small-flash-right.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/small-flash-right.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/spiral.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/spiral.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/spiral.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/spiral.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/star.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/star.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/star.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/star.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/start-battle-shape.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/start-battle-shape.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/start-battle-shape.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/start-battle-shape.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/target.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/target.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/target.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/target.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/timer.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/timer.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/timer.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/timer.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/tooltip-corner.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/tooltip-corner.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/tooltip-corner.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/tooltip-corner.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/trophy-cup.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/trophy-cup.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/trophy-cup.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/trophy-cup.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/twitter.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/twitter.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/twitter.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/twitter.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/type-eye.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/type-eye.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/type-eye.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/type-eye.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/validate.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/validate.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/validate.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/validate.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/video.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/video.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/video.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/video.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/vimeo.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/vimeo.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/vimeo.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/vimeo.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/vote-heart-outline.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/vote-heart-outline.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/vote-heart-outline.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/vote-heart-outline.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/warn.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/warn.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/warn.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/warn.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/youtube.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/youtube.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/youtube.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/coorpacademy/youtube.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-down.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-down.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-down.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-down.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-left.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-left.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-left.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-left.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-right.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-right.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-right.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-right.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-top.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-top.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-top.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/arrow-top.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/burger.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/burger.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/burger.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/burger.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/close.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/close.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/close.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/close.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/less.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/less.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/less.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/less.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/more.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/more.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/more.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/more.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/nav-bar.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/nav-bar.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/nav-bar.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-composition/navigation/nav-bar.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-fast-forward.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-fast-forward.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-fast-forward.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-fast-forward.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-pause.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-pause.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-pause.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-pause.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-play.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-play.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-play.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-play.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-rewind.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-rewind.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-rewind.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/audio/audio-control-rewind.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/bookmarks-tags/bookmark-5.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/bookmarks-tags/bookmark-5.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/bookmarks-tags/bookmark-5.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/bookmarks-tags/bookmark-5.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/business/circle-view.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/business/circle-view.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/business/circle-view.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/business/circle-view.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/computers/computer-screen-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/computers/computer-screen-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/computers/computer-screen-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/computers/computer-screen-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/bin.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/bin.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/bin.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/bin.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/hide.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/hide.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/hide.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/hide.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/link-broken.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/link-broken.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/link-broken.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/link-broken.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/pencil-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/pencil-2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/pencil-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/pencil-2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/quill-circle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/quill-circle.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/quill-circle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/content-edition/quill-circle.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/files-office/file-office-pdf.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/files-office/file-office-pdf.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/files-office/file-office-pdf.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/files-office/file-office-pdf.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/interface-feedback/interface-alert-circle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/interface-feedback/interface-alert-circle.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/interface-feedback/interface-alert-circle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/interface-feedback/interface-alert-circle.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/interface-feedback/interface-question-mark.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/interface-feedback/interface-question-mark.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/interface-feedback/interface-question-mark.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/interface-feedback/interface-question-mark.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/leisure/leisure-party-popper.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/leisure/leisure-party-popper.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/leisure/leisure-party-popper.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/leisure/leisure-party-popper.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/login/key-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/login/key-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/login/key-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/login/key-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/mobile-phone-broken.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/mobile-phone-broken.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/mobile-phone-broken.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/mobile-phone-broken.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/mobile-phone-close-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/mobile-phone-close-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/mobile-phone-close-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/mobile-phone-close-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/qr-code.1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/qr-code.1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/qr-code.1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/mobilephone/qr-code.1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/network/network-mobile.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/network/network-mobile.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/network/network-mobile.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/network/network-mobile.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/remove-add/remove-circle-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/remove-add/remove-circle-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/remove-add/remove-circle-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/remove-add/remove-circle-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/selection-cursors/cursor-arrow-target.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/selection-cursors/cursor-arrow-target.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/selection-cursors/cursor-arrow-target.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/selection-cursors/cursor-arrow-target.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/settings/cookie.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/settings/cookie.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/settings/cookie.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/settings/cookie.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/space/ring-planet.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/space/ring-planet.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/space/ring-planet.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/space/ring-planet.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/status/check-circle-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/status/check-circle-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/status/check-circle-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/status/check-circle-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/status/close-circle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/status/close-circle.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/status/close-circle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/status/close-circle.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/status/close.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/status/close.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/status/close.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/status/close.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/tools/wrench-screwdriver.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/tools/wrench-screwdriver.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/tools/wrench-screwdriver.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/tools/wrench-screwdriver.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/videos/video-clip-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/videos/video-clip-3.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-line/videos/video-clip-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-line/videos/video-clip-3.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/applications/window-application-5.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/applications/window-application-5.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/applications/window-application-5.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/applications/window-application-5.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/applications/window-upload-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/applications/window-upload-3.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/applications/window-upload-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/applications/window-upload-3.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-fast-forward.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-fast-forward.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-fast-forward.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-fast-forward.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-pause.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-pause.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-pause.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-pause.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-play.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-play.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-play.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-play.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-rewind.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-rewind.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-rewind.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/audio-control-rewind.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/headphone.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/headphone.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/headphone.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/audio/headphone.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/bookmarks-tags/bookmark-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/bookmarks-tags/bookmark-3.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/bookmarks-tags/bookmark-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/bookmarks-tags/bookmark-3.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/bookmarks-tags/bookmark-5.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/bookmarks-tags/bookmark-5.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/bookmarks-tags/bookmark-5.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/bookmarks-tags/bookmark-5.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/business/business-graph-line-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/business/business-graph-line-2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/business/business-graph-line-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/business/business-graph-line-2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/computers/sd-card.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/computers/sd-card.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/computers/sd-card.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/computers/sd-card.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/bin.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/bin.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/bin.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/bin.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/flash.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/flash.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/flash.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/flash.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/pencil-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/pencil-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/pencil-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/pencil-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/pencil-write.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/pencil-write.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/pencil-write.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content-edition/pencil-write.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-book-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-book-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-book-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-book-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-book-add.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-book-add.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-book-add.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-book-add.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-view-list.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-view-list.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-view-list.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-view-list.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-view-module-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-view-module-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-view-module-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/content/content-view-module-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/data-transfer/data-upload-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/data-transfer/data-upload-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/data-transfer/data-upload-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/data-transfer/data-upload-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/data-transfer/data-upload-11.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/data-transfer/data-upload-11.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/data-transfer/data-upload-11.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/data-transfer/data-upload-11.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/design-actions/redo.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/design-actions/redo.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/design-actions/redo.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/design-actions/redo.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/design/paint-brush-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/design/paint-brush-2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/design/paint-brush-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/design/paint-brush-2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/email/at-sign.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/email/at-sign.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/email/at-sign.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/email/at-sign.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-basic/file-block-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-basic/file-block-2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-basic/file-block-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-basic/file-block-2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-basic/file-upload-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-basic/file-upload-2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-basic/file-upload-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-basic/file-upload-2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-folders/folders.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-folders/folders.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-folders/folders.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/files-folders/folders.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-circle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-circle.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-circle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-circle.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-diamond.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-diamond.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-diamond.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-diamond.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-triangle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-triangle.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-triangle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-alert-triangle.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-question-mark.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-question-mark.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-question-mark.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/interface-feedback/interface-question-mark.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/lights/lightbulb-4.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/lights/lightbulb-4.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/lights/lightbulb-4.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/lights/lightbulb-4.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/locations/compass-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/locations/compass-3.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/locations/compass-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/locations/compass-3.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/locations/location-pin-question-mark-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/locations/location-pin-question-mark-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/locations/location-pin-question-mark-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/locations/location-pin-question-mark-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/locks/lock-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/locks/lock-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/locks/lock-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/locks/lock-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/locks/lock-unlock-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/locks/lock-unlock-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/locks/lock-unlock-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/locks/lock-unlock-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/key-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/key-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/key-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/key-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/locked.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/locked.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/locked.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/locked.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/logout-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/logout-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/logout-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/login/logout-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/messages-chat/chat-bubbles-circle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/messages-chat/chat-bubbles-circle.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/messages-chat/chat-bubbles-circle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/messages-chat/chat-bubbles-circle.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/places/places-home-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/places/places-home-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/places/places-home-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/places/places-home-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/places/places-home-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/places/places-home-2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/places/places-home-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/places/places-home-2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/programming/programming-jigsaw.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/programming/programming-jigsaw.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/programming/programming-jigsaw.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/programming/programming-jigsaw.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-circle-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-circle-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-circle-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-circle-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-circle-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-circle-2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-circle-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/add-circle-2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/remove-circle-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/remove-circle-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/remove-circle-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/remove-circle-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/subtract-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/subtract-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/subtract-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/remove-add/subtract-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/resize-move/expand-diagonal-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/resize-move/expand-diagonal-3.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/resize-move/expand-diagonal-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/resize-move/expand-diagonal-3.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/resize-move/shrink-diagonal-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/resize-move/shrink-diagonal-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/resize-move/shrink-diagonal-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/resize-move/shrink-diagonal-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/school-science/graduation-hat.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/school-science/graduation-hat.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/school-science/graduation-hat.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/school-science/graduation-hat.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/moon-rocket.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/moon-rocket.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/moon-rocket.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/moon-rocket.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/ring-planet.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/ring-planet.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/ring-planet.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/ring-planet.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/space-rocket.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/space-rocket.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/space-rocket.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/space/space-rocket.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/check-circle-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/check-circle-2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/check-circle-2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/check-circle-2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/close.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/close.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/close.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/close.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/validate.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/validate.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/validate.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/status/validate.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/time/alarm.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/time/alarm.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/time/alarm.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/time/alarm.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/users-actions/user.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/users-actions/user.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/users-actions/user.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/users-actions/user.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/users/user-shield-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/users/user-shield-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/users/user-shield-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/users/user-shield-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-clip-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-clip-3.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-clip-3.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-clip-3.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-control-play.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-control-play.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-control-play.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-control-play.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-subtitle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-subtitle.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-subtitle.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/videos/video-subtitle.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-badge-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-badge-1.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-badge-1.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-badge-1.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-badge-5.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-badge-5.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-badge-5.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-badge-5.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-trophy-5.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-trophy-5.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-trophy-5.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/rewards-trophy-5.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/vote-heart.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/vote-heart.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/vote-heart.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/vote-heart.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/vote-star.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/vote-star.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/vote-star.js
+++ b/packages/@coorpacademy-nova-icons/src/components/nova-solid/vote-rewards/vote-star.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/arrow-nav.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/arrow-nav.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/arrow-nav.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/arrow-nav.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/backward-10s.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/backward-10s.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/backward-10s.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/backward-10s.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/backward.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/backward.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/backward.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/backward.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/forward-10s.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/forward-10s.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/forward-10s.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/forward-10s.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/forward.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/forward.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/forward.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/forward.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/heartrounded.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/heartrounded.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/heartrounded.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/heartrounded.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/pause.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/pause.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/pause.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/pause.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/playrounded.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/playrounded.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/playrounded.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/playrounded.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/settings2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/settings2.js
@@ -6,7 +6,7 @@ const SvgComponent = _props => {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: role ?? 'img',
+          role: role || 'img',
           'aria-label': ariaLabel,
           alt
         }

--- a/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/settings2.js
+++ b/packages/@coorpacademy-nova-icons/src/components/podcast/podcast/settings2.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 const SvgComponent = _props => {
-  const {'aria-label': ariaLabel, alt, ...rest} = _props;
+  const {'aria-label': ariaLabel, role, alt, ...rest} = _props;
   const props = {
     ...rest,
     ...(ariaLabel || alt
       ? {
-          role: 'img',
+          role: role ?? 'img',
           'aria-label': ariaLabel,
           alt
         }


### PR DESCRIPTION
purpose of the PR: 
the problem is that all generated svg would have img role by default in case we set aria-label or alt, but in some cases, we would prefer to have an other role (status as example).
so this PR offers this possibility.