### PR TITLE
[RGAA] update primary color primaryColor of inputSwitch and update height

### DIFF
--- a/packages/@coorpacademy-components/src/atom/input-switch/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-switch/index.js
@@ -78,7 +78,7 @@ const InputSwitch = props => {
         </div>
       </div>
       <div className={!details ? style.alignedTextContainer : null}>
-        {titlePosition === 'right' ? {titleView} : null}
+        {titlePosition === 'right' ? titleView : null}
         {details ? <div className={style.detailsTxt}>{details}</div> : null}
       </div>
       {descriptionView}

--- a/packages/@coorpacademy-components/src/atom/input-switch/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-switch/style.css
@@ -2,7 +2,7 @@
 @value orange from colors;
 @value medium from colors;
 @value white from colors;
-@value positive from colors;
+@value cm_primary_blue from colors;
 @value light from colors;
 @value dark from colors;
 @value cm_grey_200 from colors;
@@ -79,7 +79,7 @@
 }
 
 .checkbox:checked ~ label {
-  background: positive;
+  background: cm_primary_blue;
 }
 
 .default input:checked ~ label::after {

--- a/packages/@coorpacademy-components/src/atom/input-switch/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-switch/style.css
@@ -2,7 +2,6 @@
 @value orange from colors;
 @value medium from colors;
 @value white from colors;
-@value cm_primary_blue from colors;
 @value light from colors;
 @value dark from colors;
 @value cm_grey_200 from colors;
@@ -31,7 +30,7 @@
 }
 
 .default label {
-  height: 30px;
+  height: 24px;
   position: relative;
   flex-grow: 0;
   display: block;
@@ -44,11 +43,11 @@
 
 .default label::after {
   position: absolute;
-  left: 1px;
-  top: 1px;
+  left: 2px;
+  top: 2px;
   display: block;
-  width: 28px;
-  height: 28px;
+  width: 20px;
+  height: 20px;
   border-radius: 100px;
   background: white;
   box-shadow: 0 3px 3px rgba(0, 0, 0, 0.05);
@@ -58,11 +57,11 @@
 
 .modified label::after {
   position: absolute;
-  left: 1px;
-  top: 1px;
+  left: 2px;
+  top: 2px;
   display: block;
-  width: 28px;
-  height: 28px;
+  width: 20px;
+  height: 20px;
   border-radius: 100px;
   background: orange;
   box-shadow: 0 3px 3px rgba(0, 0, 0, 0.05);
@@ -83,7 +82,7 @@
 }
 
 .default input:checked ~ label::after {
-  left: 23px;
+  left: 30px;
 }
 
 .checkbox:disabled ~ label {

--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -535,7 +535,7 @@ class MoocHeader extends React.Component {
             selectProps.title = '';
             selectProps.theme = 'header';
             selectProps.onChange = options.onChange;
-
+            selectProps.className = style.languageSelect;
             settingView = (
               <div data-name={`setting-${settingName}`} className={style.setting} key={settingName}>
                 <span className={style.label}>{title}</span>

--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -557,10 +557,10 @@ class MoocHeader extends React.Component {
                 key={settingName}
                 aria-label={ariaLabel || title}
               >
+                <InputSwitch {...switchProps} aria-labelledby={`title-id-${settingName}`} />
                 <span id={`title-id-${settingName}`} className={style.label}>
                   {title}
                 </span>
-                <InputSwitch {...switchProps} aria-labelledby={`title-id-${settingName}`} />
               </div>
             );
             break;

--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -461,7 +461,7 @@
   height: 40px;
   display: flex;
   align-items: center;
-  /* justify-content: space-between; */
+  gap: 12px;
 }
 
 .languageSelect {
@@ -470,7 +470,6 @@
 
 .setting:nth-child(1) {
   flex-direction: column;
-  gap: 6px;
   height: 60px;
   align-items: baseline;
 }

--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -461,7 +461,18 @@
   height: 40px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  /* justify-content: space-between; */
+}
+
+.languageSelect {
+  width: 98%;
+}
+
+.setting:nth-child(1) {
+  flex-direction: column;
+  gap: 6px;
+  height: 60px;
+  align-items: baseline;
 }
 
 .setting .label {

--- a/packages/@coorpacademy-components/src/organism/user-preferences/index.js
+++ b/packages/@coorpacademy-components/src/organism/user-preferences/index.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/fp/isEmpty';
 import map from 'lodash/fp/map';
-import {GetTranslateFromContext} from '../../atom/provider';
+import Provider, {GetTranslateFromContext} from '../../atom/provider';
 import ToolTip from '../../atom/tooltip';
 import InputSwitch from '../../atom/input-switch';
 import style from './style.css';
 
-const Settings = props => {
-  const translate = GetTranslateFromContext();
+const Settings = (props, legacyContext) => {
+  const translate = GetTranslateFromContext(legacyContext);
   const {label, description, moreInfoAriaLabel, ...settings} = props;
   return (
     <div className={style.settings}>
@@ -36,6 +36,10 @@ Settings.propTypes = {
   ...InputSwitch.propTypes,
   label: PropTypes.string.isRequired,
   description: PropTypes.string
+};
+
+Settings.contextTypes = {
+  translate: Provider.childContextTypes.translate
 };
 
 const UserPreferences = props => {


### PR DESCRIPTION
Part of this trello card : [11.4 - Dans chaque formulaire, chaque étiquette de champ et son champ associé sont-ils accolés (hors cas particuliers) ?](https://trello.com/c/ncuCQrP1/16-114-dans-chaque-formulaire-chaque-%C3%A9tiquette-de-champ-et-son-champ-associ%C3%A9-sont-ils-accol%C3%A9s-hors-cas-particuliers)

**Detailed purpose of the PR**
- Update the background of the input switch to the blue of CM
- Change the height of the switch

**Result and observation**
Environnement : Canary mooc local

#### MoocHeader - settings + Input Switch on Catalog page (Molecule/Filters)
##### Before
![Capture d’écran 2023-02-17 à 11 15 03](https://user-images.githubusercontent.com/113359769/219616655-bb3d3a7a-0f7f-4c06-bf12-d85cde7caf13.png)

##### After
![Capture d’écran 2023-02-17 à 11 13 45](https://user-images.githubusercontent.com/113359769/219616337-8538cc68-70be-4e57-9f05-f0af772171d2.png)

#### Users Preferences
##### Before
![Capture d’écran 2023-02-17 à 11 30 29](https://user-images.githubusercontent.com/113359769/219619807-a3d37f06-fc92-468b-b034-815636b5668f.png)

##### After
![Capture d’écran 2023-02-17 à 11 29 42](https://user-images.githubusercontent.com/113359769/219619717-a1bee172-56ed-4848-8fea-31ac0ed5781b.png)

**Testing Strategy**
- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
