### PR TITLE
[app-review] resetting stack on creating a new progression

### DIFF
--- a/packages/@coorpacademy-app-review/src/views/slides/index.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/index.ts
@@ -468,26 +468,28 @@ export const mapStateToSlidesProps = (
       steps: buildStepItems(state),
       hiddenSteps: showCongrats
     },
-    stack: {
-      slides: buildStackSlides(state, dispatch, options),
-      validateButton: {
-        label: translate('Validate'),
-        disabled: !get(['ui', 'slide', currentSlideRef, 'validateButton'], state),
-        onClick: (): void => {
-          dispatch(postAnswer);
+    stack: state.data.progression
+      ? {
+          slides: buildStackSlides(state, dispatch, options),
+          validateButton: {
+            label: translate('Validate'),
+            disabled: !get(['ui', 'slide', currentSlideRef, 'validateButton'], state),
+            onClick: (): void => {
+              dispatch(postAnswer);
+            }
+          },
+          correctionPopinProps:
+            correction &&
+            getCorrectionPopinProps(dispatch)(
+              isCorrect,
+              correction.correctAnswer,
+              klf,
+              translate,
+              endReview
+            ),
+          endReview: endReview && state.ui.showCongrats
         }
-      },
-      correctionPopinProps:
-        correction &&
-        getCorrectionPopinProps(dispatch)(
-          isCorrect,
-          correction.correctAnswer,
-          klf,
-          translate,
-          endReview
-        ),
-      endReview: endReview && state.ui.showCongrats
-    },
+      : null,
     backgroundImage,
     congrats: buildCongratsProps(state, dispatch, options),
     quitPopin: showQuitPopin

--- a/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/index.test.ts
@@ -298,7 +298,7 @@ test('should create props when first slide is on the state', t => {
     correctionPopinProps: undefined,
     endReview: false
   });
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -310,8 +310,8 @@ test('should create props when first slide is on the state', t => {
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
-  t.is(props.stack.validateButton.disabled, true);
-  t.deepEqual(omit('model.onChange', props.stack.slides['0'].answerUI), {
+  t.is(props.stack?.validateButton.disabled, true);
+  t.deepEqual(omit('model.onChange', props.stack?.slides['0'].answerUI), {
     help: 'Type your answer.',
     model: {
       placeholder: 'Type here',
@@ -320,7 +320,7 @@ test('should create props when first slide is on the state', t => {
     },
     media: undefined
   });
-  t.deepEqual(omit(['0'], props.stack.slides), {
+  t.deepEqual(omit(['0'], props.stack?.slides), {
     '1': {
       position: 1,
       loading: true
@@ -413,7 +413,7 @@ test('should create props when slide is on the state and user has selected answe
     correctionPopinProps: undefined,
     endReview: false
   });
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -425,8 +425,8 @@ test('should create props when slide is on the state and user has selected answe
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
-  t.is(props.stack.validateButton.disabled, false);
-  t.deepEqual(omit('model.onChange', props.stack.slides['0'].answerUI), {
+  t.is(props.stack?.validateButton.disabled, false);
+  t.deepEqual(omit('model.onChange', props.stack?.slides['0'].answerUI), {
     help: 'Type your answer.',
     model: {
       placeholder: 'Type here',
@@ -435,7 +435,7 @@ test('should create props when slide is on the state and user has selected answe
     },
     media: undefined
   });
-  t.deepEqual(omit(['0'], props.stack.slides), {
+  t.deepEqual(omit(['0'], props.stack?.slides), {
     '1': {
       position: 1,
       loading: true
@@ -535,7 +535,7 @@ test('should verify props when first slide was answered correctly and next slide
     correctionPopinProps: undefined,
     endReview: false
   });
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -547,7 +547,7 @@ test('should verify props when first slide was answered correctly and next slide
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
-  t.deepEqual(omit('model.onChange', props.stack.slides['0'].answerUI), {
+  t.deepEqual(omit('model.onChange', props.stack?.slides['0'].answerUI), {
     help: 'Type your answer.',
     model: {
       placeholder: 'Type here',
@@ -556,8 +556,8 @@ test('should verify props when first slide was answered correctly and next slide
     },
     media: undefined
   });
-  t.is(props.stack.validateButton.disabled, true);
-  t.deepEqual(omit(['0'], props.stack.slides), {
+  t.is(props.stack?.validateButton.disabled, true);
+  t.deepEqual(omit(['0'], props.stack?.slides), {
     '1': {
       position: 1,
       loading: true
@@ -737,8 +737,8 @@ test('should verify props when first slide was answered, next slide is fetched &
       }
     ]
   });
-  t.is(props.stack.endReview, false);
-  t.deepEqual(omit('next.onClick', props.stack.correctionPopinProps), {
+  t.is(props.stack?.endReview, false);
+  t.deepEqual(omit('next.onClick', props.stack?.correctionPopinProps), {
     resultLabel: '__Correct Answer',
     information: {
       label: '__KLF',
@@ -752,7 +752,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     },
     type: 'right'
   });
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: true,
     showCorrectionPopin: true,
@@ -764,7 +764,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
-  t.deepEqual(omit('model.onChange', props.stack.slides['0'].answerUI), {
+  t.deepEqual(omit('model.onChange', props.stack?.slides['0'].answerUI), {
     help: 'Type your answer.',
     model: {
       placeholder: 'Type here',
@@ -773,7 +773,7 @@ test('should verify props when first slide was answered, next slide is fetched &
     },
     media: undefined
   });
-  t.deepEqual(omit('answerUI', props.stack.slides['1']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['1']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -784,8 +784,8 @@ test('should verify props when first slide was answered, next slide is fetched &
       '__Content Parent Title{"contentTitle":"Developing the review app","contentType":"course"}',
     questionText: 'Quels sont les 4 piliers de l’apprentissage ?'
   });
-  t.is(props.stack.validateButton.disabled, true);
-  t.deepEqual(omit(['0', '1'], props.stack.slides), {
+  t.is(props.stack?.validateButton.disabled, true);
+  t.deepEqual(omit(['0', '1'], props.stack?.slides), {
     '2': {
       position: 2,
       loading: true
@@ -879,8 +879,8 @@ test('should verify props when first slide was answered incorrectly, next slide 
       }
     ]
   });
-  t.is(props.stack.endReview, false);
-  t.deepEqual(omit('next.onClick', props.stack.correctionPopinProps), {
+  t.is(props.stack?.endReview, false);
+  t.deepEqual(omit('next.onClick', props.stack?.correctionPopinProps), {
     resultLabel: '__Wrong Answer',
     information: {
       label: '__Correct Answer',
@@ -897,7 +897,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     },
     type: 'wrong'
   });
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: true,
     showCorrectionPopin: true,
@@ -909,7 +909,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     questionText:
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
-  t.deepEqual(omit('model.onChange', props.stack.slides['0'].answerUI), {
+  t.deepEqual(omit('model.onChange', props.stack?.slides['0'].answerUI), {
     help: 'Type your answer.',
     model: {
       placeholder: 'Type here',
@@ -918,7 +918,7 @@ test('should verify props when first slide was answered incorrectly, next slide 
     },
     media: undefined
   });
-  t.deepEqual(omit('answerUI', props.stack.slides['1']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['1']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -929,8 +929,8 @@ test('should verify props when first slide was answered incorrectly, next slide 
       '__Content Parent Title{"contentTitle":"Developing the review app","contentType":"course"}',
     questionText: 'Quels sont les 4 piliers de l’apprentissage ?'
   });
-  t.is(props.stack.validateButton.disabled, true);
-  t.deepEqual(omit(['0', '1'], props.stack.slides), {
+  t.is(props.stack?.validateButton.disabled, true);
+  t.deepEqual(omit(['0', '1'], props.stack?.slides), {
     '2': {
       position: 2,
       loading: true
@@ -1030,27 +1030,27 @@ test('should verify props when currentSlideRef has changed to nextContent of pro
   });
 
   const propsToCheck = ['loading', 'animateCorrectionPopin', 'animationType', 'position'];
-  t.deepEqual(pick(propsToCheck, props.stack.slides[0]), {
+  t.deepEqual(pick(propsToCheck, props.stack?.slides[0]), {
     loading: false,
     animateCorrectionPopin: false,
     animationType: 'unstack',
     position: 0
   });
-  t.deepEqual(pick(propsToCheck, props.stack.slides[1]), {
+  t.deepEqual(pick(propsToCheck, props.stack?.slides[1]), {
     loading: false,
     animateCorrectionPopin: false,
     animationType: undefined,
     position: 0
   });
-  t.deepEqual(pick(propsToCheck, props.stack.slides[2]), {
+  t.deepEqual(pick(propsToCheck, props.stack?.slides[2]), {
     loading: true,
     position: 1
   });
-  t.deepEqual(pick(propsToCheck, props.stack.slides[3]), {
+  t.deepEqual(pick(propsToCheck, props.stack?.slides[3]), {
     loading: true,
     position: 2
   });
-  t.deepEqual(pick(propsToCheck, props.stack.slides[4]), {
+  t.deepEqual(pick(propsToCheck, props.stack?.slides[4]), {
     loading: true,
     position: 3
   });
@@ -1170,7 +1170,7 @@ test('should verify props when progression is in success, showing last correctio
     ]
   });
 
-  t.deepEqual(omit(['next.onClick'], props.stack.correctionPopinProps), {
+  t.deepEqual(omit(['next.onClick'], props.stack?.correctionPopinProps), {
     information: {
       label: '__KLF',
       message:
@@ -1265,7 +1265,7 @@ test('should verify props showing congrats', t => {
 
   const props = mapStateToSlidesProps(state, identity, connectedOptions);
   const congrats = props.congrats as ReviewCongratsProps;
-  t.true(props.stack.endReview);
+  t.true(props.stack?.endReview);
   t.is(congrats.title, '__Congratulations!');
   t.is(
     congrats.animationLottie.animationSrc,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.free-text.on-change.test.ts
@@ -147,7 +147,7 @@ test('should dispatch EDIT_BASIC action via the property onChange of a Free Text
   const {dispatch, getState} = createTestStore(t, initialState, {}, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -160,8 +160,8 @@ test('should dispatch EDIT_BASIC action via the property onChange of a Free Text
       'Which term is used to describe the act of asking what the usual salary is for the position you are applying for?'
   });
 
-  const slideProps = props.stack.slides['0'].answerUI?.model;
+  const slideProps = props.stack?.slides['0'].answerUI?.model;
   slideProps?.onChange && (await slideProps.onChange('My Answer'));
-  await props.stack.validateButton.onClick();
+  await props.stack?.validateButton.onClick();
   await sleep(10);
 });

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.next-slide.on-click.test.ts
@@ -89,7 +89,7 @@ test('correction popin actions after click', async t => {
 
   const {dispatch, getState} = createTestStore(t, state, {}, expectedActions);
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
-  const correctionPopin = props.stack.correctionPopinProps as ReviewCorrectionPopinProps;
+  const correctionPopin = props.stack?.correctionPopinProps as ReviewCorrectionPopinProps;
   await correctionPopin.next.onClick();
 
   const updatedState = getState();
@@ -229,7 +229,7 @@ test('correction popin actions after click when progression is finished', async 
   const {dispatch, getState} = createTestStore(t, state, {}, expectedActions);
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
   t.is(props.congrats, undefined);
-  const correctionPopin = props.stack.correctionPopinProps as ReviewCorrectionPopinProps;
+  const correctionPopin = props.stack?.correctionPopinProps as ReviewCorrectionPopinProps;
   await correctionPopin.next.onClick();
 
   await checkStatePositionsAndSuccessExitNode(t, getState);

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-drag.on-click.test.ts
@@ -82,7 +82,7 @@ test('should dispatch EDIT_QCM_DRAG action via the property onClick of a QCM Dra
   const {dispatch, getState} = createTestStore(t, initialState, {}, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -94,7 +94,7 @@ test('should dispatch EDIT_QCM_DRAG action via the property onClick of a QCM Dra
     questionText: "Remettez dans l'ordre les quatre étapes du burn out."
   });
 
-  const SlideProps = props.stack.slides['0'].answerUI?.model as QcmDrag;
+  const SlideProps = props.stack?.slides['0'].answerUI?.model as QcmDrag;
   const onClick = get(['0', 'onClick'], SlideProps.answers);
   onClick();
 });

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm-graphic.on-click.test.ts
@@ -81,7 +81,7 @@ test('should dispatch EDIT_QCM_GRAPHIC action via the property onClick of a QCM 
   const {dispatch, getState} = createTestStore(t, initialState, {}, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -93,7 +93,7 @@ test('should dispatch EDIT_QCM_GRAPHIC action via the property onClick of a QCM 
     questionText: 'Quels sont les 4 piliers de l’apprentissage ?'
   });
 
-  const SlideProps = props.stack.slides['0'].answerUI?.model as QcmGraphic;
+  const SlideProps = props.stack?.slides['0'].answerUI?.model as QcmGraphic;
   const onClick = get(['1', 'onClick'], SlideProps.answers);
   onClick();
 });

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.qcm.on-click.test.ts
@@ -83,7 +83,7 @@ test('should dispatch EDIT_QCM action via the property onClick of a QCM slide', 
   const {dispatch, getState} = createTestStore(t, initialState, {}, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -95,7 +95,7 @@ test('should dispatch EDIT_QCM action via the property onClick of a QCM slide', 
     questionText: "Après la vente d'un NFT, son créateur peut-il toucher de l'argent ?"
   });
 
-  const SlideProps = props.stack.slides['0'].answerUI?.model as Qcm;
+  const SlideProps = props.stack?.slides['0'].answerUI?.model as Qcm;
   const onClick = get(['1', 'onClick'], SlideProps.answers);
   onClick();
 });

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-change.test.ts
@@ -81,7 +81,7 @@ test('should dispatch EDIT_SLIDER action via the property onChange of a Slider s
   const {dispatch, getState} = createTestStore(t, initialState, {}, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     disabledContent: false,
@@ -94,7 +94,7 @@ test('should dispatch EDIT_SLIDER action via the property onChange of a Slider s
       'En combien d’années la communauté de communes du Thouarsais est-elle passée de zéro à un tiers d’énergies renouvelables ?'
   });
 
-  const SlideProps = props.stack.slides['0'].answerUI?.model as QuestionRange;
+  const SlideProps = props.stack?.slides['0'].answerUI?.model as QuestionRange;
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const onChange = get('onChange', SlideProps)!;
   onChange(0.29339261968085106);

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.slider.on-slider-change.test.ts
@@ -81,8 +81,8 @@ test('should dispatch EDIT_SLIDER action via the property onSliderChange of a Sl
   const {dispatch, getState} = createTestStore(t, initialState, {}, expectedActions);
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
 
-  const slideProps = props.stack.slides['0'].answerUI?.model as QuestionRange;
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  const slideProps = props.stack?.slides['0'].answerUI?.model as QuestionRange;
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,

--- a/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/slide.template.on-change.test.ts
@@ -79,7 +79,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
   const {dispatch, getState} = createTestStore(t, initialState, {}, expectedActions);
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -91,7 +91,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
     questionText: 'Complétez la phrase ci-dessous.'
   });
 
-  const slideProps = props.stack.slides['0'].answerUI?.model as Template;
+  const slideProps = props.stack?.slides['0'].answerUI?.model as Template;
   const onChangeText = get(['1', 'onChange'], slideProps.answers);
   onChangeText('test');
   const onChangeSelect = get(['0', 'onChange'], slideProps.answers);
@@ -112,7 +112,7 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
   );
 
   const props = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
-  t.deepEqual(omit('answerUI', props.stack.slides['0']), {
+  t.deepEqual(omit('answerUI', props.stack?.slides['0']), {
     animationType: undefined,
     animateCorrectionPopin: false,
     showCorrectionPopin: false,
@@ -124,14 +124,14 @@ test('should dispatch EDIT_TEMPLATE action via the property onChange of a Templa
     questionText: 'Complétez la phrase ci-dessous.'
   });
 
-  const slideProps = props.stack.slides['0'].answerUI?.model as Template;
+  const slideProps = props.stack?.slides['0'].answerUI?.model as Template;
   const textAnswerProps = slideProps.answers[1] as TextTemplate;
   t.is(textAnswerProps.value, 'Test');
   const onChangeText = get(['1', 'onChange'], slideProps.answers);
   onChangeText('');
 
   const newProps = mapStateToSlidesProps(getState(), dispatch, connectedOptions);
-  const slidePropsAfterOnChange = newProps.stack.slides['0'].answerUI?.model as Template;
+  const slidePropsAfterOnChange = newProps.stack?.slides['0'].answerUI?.model as Template;
   const textAnswerPropsAfterOnChange = slidePropsAfterOnChange.answers[1] as TextTemplate;
   t.is(textAnswerPropsAfterOnChange.value, '');
 });

--- a/packages/@coorpacademy-components/src/template/app-review/player/index.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/index.js
@@ -29,7 +29,6 @@ const PlayerReview = ({header, stack, congrats, quitPopin}) => {
         <ReviewHeader {...header} />
       </div>
       {isNil(stack) ? null : <StackedSlides {...stack} />}
-
       {isNil(congrats) ? null : (
         <div className={style.congrats} data-testid="congrats-container">
           <ReviewCongrats {...congrats} />

--- a/packages/@coorpacademy-components/src/template/app-review/player/index.js
+++ b/packages/@coorpacademy-components/src/template/app-review/player/index.js
@@ -28,7 +28,8 @@ const PlayerReview = ({header, stack, congrats, quitPopin}) => {
       >
         <ReviewHeader {...header} />
       </div>
-      <StackedSlides {...stack} />
+      {isNil(stack) ? null : <StackedSlides {...stack} />}
+
       {isNil(congrats) ? null : (
         <div className={style.congrats} data-testid="congrats-container">
           <ReviewCongrats {...congrats} />

--- a/packages/@coorpacademy-components/src/template/app-review/player/prop-types.ts
+++ b/packages/@coorpacademy-components/src/template/app-review/player/prop-types.ts
@@ -22,7 +22,7 @@ export default propTypes;
 
 export type ReviewPlayerProps = {
   header: HeaderProps;
-  stack: ReviewStackProps;
+  stack: ReviewStackProps | null;
   backgroundImage?: ImageSourcePropType;
   congrats?: ReviewCongratsProps;
   quitPopin?: CMPopinProps;

--- a/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/resetting-stack.ts
+++ b/packages/@coorpacademy-components/src/template/app-review/player/test/fixtures/resetting-stack.ts
@@ -1,0 +1,15 @@
+import headerProps from '../../../../../organism/review-header/test/fixtures/no-answered-question';
+import {ReviewPlayerProps} from '../../prop-types';
+
+type Fixture = {
+  props: ReviewPlayerProps;
+};
+
+const fixture: Fixture = {
+  props: {
+    header: headerProps.props,
+    stack: null
+  }
+};
+
+export default fixture;


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- `stack` must be reset when creating a new progression, to unmount the current `<StackedSlides>` and mount new ones with a reset React state.

<img width="900" alt="Screenshot 2023-02-20 at 14 31 51" src="https://user-images.githubusercontent.com/79636283/220122952-d03f55e0-ca6e-455f-b13a-3bc8ff4e0959.png">

![Kapture 2023-02-20 at 14 37 42](https://user-images.githubusercontent.com/79636283/220123454-8bdfa888-8f85-415c-9138-4d04ac3b92b3.gif)

![Kapture 2023-02-20 at 14 34 16](https://user-images.githubusercontent.com/79636283/220122879-002f0fbc-b96a-47d0-8461-e36db6ef2124.gif)

