### PR TITLE
New learner engine with doubled stars

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/config/learner.js
+++ b/packages/@coorpacademy-progression-engine/src/config/learner.js
@@ -1,62 +1,43 @@
 // @flow
+import {assign} from 'lodash/fp';
 import type {Config} from '../types';
 
+const CURRENT_BASE_VERSION = {
+  version: '2',
+  lives: 4,
+  livesDisabled: false,
+  maxTypos: 2,
+  slidesToComplete: 4,
+  shuffleChoices: true,
+  answerBoundaryLimit: 5,
+  starsPerAskingClue: -1,
+  starsPerCorrectAnswer: 4,
+  starsPerResourceViewed: 4,
+  remainingLifeRequests: 1
+};
+
 const configurations: Array<Config> = [
-  {
+  // V1: original engine with 3 live
+  assign(CURRENT_BASE_VERSION, {
     version: '1',
-    lives: 3,
-    livesDisabled: false,
-    maxTypos: 2,
-    slidesToComplete: 4,
-    shuffleChoices: true,
-    answerBoundaryLimit: 5,
-    starsPerAskingClue: -1,
-    starsPerCorrectAnswer: 4,
-    starsPerResourceViewed: 4,
-    remainingLifeRequests: 1
-  },
-  {
-    version: '2',
-    lives: 4,
-    livesDisabled: false,
-    maxTypos: 2,
-    slidesToComplete: 4,
-    shuffleChoices: true,
-    answerBoundaryLimit: 5,
-    starsPerAskingClue: -1,
-    starsPerCorrectAnswer: 4,
-    starsPerResourceViewed: 4,
-    remainingLifeRequests: 1
-  },
-  {
+    lives: 3
+  }),
+  // V2: current classic engine with 4 live 🚀
+  CURRENT_BASE_VERSION,
+  // V3: Extra life (4+1) saint valentin engine
+  assign(CURRENT_BASE_VERSION, {
     version: '3',
-    lives: 5,
-    livesDisabled: false,
-    maxTypos: 2,
-    slidesToComplete: 4,
-    shuffleChoices: true,
-    answerBoundaryLimit: 5,
-    starsPerAskingClue: -1,
-    starsPerCorrectAnswer: 4,
-    starsPerResourceViewed: 4,
-    remainingLifeRequests: 1
-  },
-  {
+    lives: 5
+  }),
+  // V4: Extra life (4+1) and double stars
+  assign(CURRENT_BASE_VERSION, {
     version: '4',
     lives: 5,
-    livesDisabled: false,
-    maxTypos: 2,
-    slidesToComplete: 4,
-    shuffleChoices: true,
-    answerBoundaryLimit: 5,
-    starsPerAskingClue: -1,
-    starsPerCorrectAnswer: 8,
-    starsPerResourceViewed: 4,
-    remainingLifeRequests: 1
-  }
+    starsPerCorrectAnswer: 8
+  })
 ];
 
 export default {
   configurations,
-  defaultConfiguration: configurations[1]
+  defaultConfiguration: CURRENT_BASE_VERSION
 };

--- a/packages/@coorpacademy-progression-engine/src/config/learner.js
+++ b/packages/@coorpacademy-progression-engine/src/config/learner.js
@@ -34,6 +34,11 @@ const configurations: Array<Config> = [
     version: '4',
     lives: 5,
     starsPerCorrectAnswer: 8
+  }),
+  // V5: Double stars engine
+  assign(CURRENT_BASE_VERSION, {
+    version: '5',
+    starsPerCorrectAnswer: 8
   })
 ];
 


### PR DESCRIPTION
## Detailed purpose of the PR

Add a new engine, `v5` with double stars :star2:.
Document, refactor, and simplify learner engines declaration, to make logic more explicit.

:card_index: https://trello.com/c/L5DTIhQa/367-u-enseigne-doubler-les-%C3%A9toiles-sur-la-plateforme-pdt-un-jour

:bulb: Note: maybe a ref for engine version should be introduced. And/or an effect concept (+1 live, *2 stars) to apply to a given engine version.
