### PR TITLE
[review] fix select in player mobile

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/answer/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/answer/index.native.tsx
@@ -15,8 +15,8 @@ const convertType = (modelType: AnswerProps['model']['type']): QuestionType => {
 };
 
 const convertToChoices = (answers: AnswerProps['model']['answers'] = []): Choice[] =>
-  answers.map((answer, index) => ({
-    _id: `${index}`,
+  answers.map(answer => ({
+    _id: `${answer.name}`,
     label: answer.title,
     value: answer.title,
     onPress: answer.onClick || answer.onChange,

--- a/packages/@coorpacademy-components/src/molecule/answer/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/answer/index.native.tsx
@@ -15,8 +15,8 @@ const convertType = (modelType: AnswerProps['model']['type']): QuestionType => {
 };
 
 const convertToChoices = (answers: AnswerProps['model']['answers'] = []): Choice[] =>
-  answers.map(answer => ({
-    _id: `${answer.name}`,
+  answers.map((answer, index) => ({
+    _id: `${index}`,
     label: answer.title,
     value: answer.title,
     onPress: answer.onClick || answer.onChange,

--- a/packages/@coorpacademy-components/src/molecule/questions/mobile/switch/test/on-item-input-change.test.tsx
+++ b/packages/@coorpacademy-components/src/molecule/questions/mobile/switch/test/on-item-input-change.test.tsx
@@ -19,7 +19,7 @@ test('template question › should handle onItemInputChange', t => {
   const mockedMobileContext = {
     ...mockMobileContext(),
     store: {
-      focusedSelectId: 'foo',
+      focusedSelectId: 'question-part-inp1',
       handleBlur: noop,
       handleFocus: () => noop
     }
@@ -37,7 +37,7 @@ test('template question › should handle onItemInputChange', t => {
   );
 
   const {getByTestId} = render(component);
-  const text = getByTestId('question-part-2-text');
+  const text = getByTestId(`question-part-inp1-text`);
 
   fireEvent(text, 'onChange', TEST_VALUE);
 

--- a/packages/@coorpacademy-components/src/molecule/questions/mobile/switch/test/on-item-input-change.test.tsx
+++ b/packages/@coorpacademy-components/src/molecule/questions/mobile/switch/test/on-item-input-change.test.tsx
@@ -37,7 +37,7 @@ test('template question › should handle onItemInputChange', t => {
   );
 
   const {getByTestId} = render(component);
-  const text = getByTestId(`question-part-inp1-text`);
+  const text = getByTestId('question-part-inp1-text');
 
   fireEvent(text, 'onChange', TEST_VALUE);
 

--- a/packages/@coorpacademy-components/src/molecule/questions/mobile/template/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/questions/mobile/template/index.native.tsx
@@ -1,6 +1,8 @@
 import React, {useEffect, useState} from 'react';
 import {TextStyle, View, ViewStyle} from 'react-native';
 
+import trim from 'lodash/fp/trim';
+
 import Html from '../../../../atom/html/index.native';
 import Select from '../../../../atom/select-modal/index.native';
 import Space from '../../../../atom/space/index.native';
@@ -152,7 +154,7 @@ const Item = (props: ItemProps) => {
 
   return (
     <Html key={id} fontSize={theme.fontSize.regular} testID={id} style={styles.htmlText}>
-      {part.value || ''}
+      {part.value === ' ' ? part.value : trim(part.value || '')}
     </Html>
   );
 };

--- a/packages/@coorpacademy-components/src/molecule/questions/mobile/template/index.native.tsx
+++ b/packages/@coorpacademy-components/src/molecule/questions/mobile/template/index.native.tsx
@@ -1,8 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {TextStyle, View, ViewStyle} from 'react-native';
 
-import trim from 'lodash/fp/trim';
-
 import Html from '../../../../atom/html/index.native';
 import Select from '../../../../atom/select-modal/index.native';
 import Space from '../../../../atom/space/index.native';
@@ -68,7 +66,6 @@ type TemplatePart = {
 type ItemProps = {
   part: TemplatePart;
   choices: Array<TemplateTextChoice | TemplateListOfChoices>;
-  index: number;
   isDisabled?: boolean;
   onInputChange: (item: TemplateTextChoice | TemplateListOfChoices, value: string) => void;
   focusedSelectId: FocusedSelectId;
@@ -80,7 +77,6 @@ type ItemProps = {
 const Item = (props: ItemProps) => {
   const {
     part,
-    index,
     isDisabled = false,
     focusedSelectId,
     choices,
@@ -94,7 +90,7 @@ const Item = (props: ItemProps) => {
   const {theme, translations} = templateContext;
 
   const inputNames = choices.map(choice => choice.name);
-  const id = `question-part-${index + 1}`;
+  const id = `question-part-${part.value}`;
   const isFocused = focusedSelectId === id;
 
   if (part.type === 'answerField' && inputNames.includes(part.value)) {
@@ -156,7 +152,7 @@ const Item = (props: ItemProps) => {
 
   return (
     <Html key={id} fontSize={theme.fontSize.regular} testID={id} style={styles.htmlText}>
-      {trim(part.value || '')}
+      {part.value || ''}
     </Html>
   );
 };
@@ -200,12 +196,11 @@ const QuestionTemplate = (props: Props) => {
 
   return (
     <View style={styleSheet.container} testID="question-template">
-      {parts.map((part, id) => (
-        <View key={`question-part-${id}`} style={{flexDirection: 'row'}}>
+      {parts.map(part => (
+        <View key={`question-part-${part.value}`} style={{flexDirection: 'row'}}>
           <Item
             part={part}
             choices={choices}
-            index={id}
             focusedSelectId={focusedSelectId}
             isDisabled={isDisabled}
             handleBlur={handleBlur}


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR modifies components `Answer` and `QuestionTemplate` to fix the bug related to the use of several select in mobile revision player.

**Result and observation**
* In the review player, the options proposed by a select matched with the options of a previous select. The error was caused by the use of the index that identified a select in the template. 
In the revision player, several selects, used on different slides, could have the same index. 
I propose to identify a select in a different way by replacing the index with the name of the select.

![Kapture 2023-02-21 at 16 20 07](https://user-images.githubusercontent.com/79636283/220394450-57f5ad4b-9db2-4cbc-bb81-4166024487e1.gif)


*******

* Each element composing the template is an element of the `parts` array : 
<img width="634" alt="Screenshot 2023-02-23 at 11 37 29" src="https://user-images.githubusercontent.com/79636283/220884563-c43310ec-c541-495f-8d7f-29e768e59e19.png">
If the value is a whitespace, then the `trim` function should not be used. So I added a condition to use the `trim` function in the `QuestionTemplate` component to avoid having an `undefined` value when spacing is desired. 


BEFORE
<img width="200" alt="Screenshot 2023-02-21 at 17 06 56" src="https://user-images.githubusercontent.com/79636283/220635145-f25798ad-5fc5-4302-a1a4-41d97223ca38.png">

AFTER
<img width="200" alt="Screenshot 2023-02-22 at 14 35 57" src="https://user-images.githubusercontent.com/79636283/220635336-ef00bc23-7172-435a-97bb-1a854d9612fa.png">


*******
internal store : 
https://user-images.githubusercontent.com/79636283/221187604-9f36fdee-30a5-4fb0-9614-67cd7a594643.mp4


https://user-images.githubusercontent.com/79636283/221222410-d2f1b33f-dca8-4be1-9758-90c7e0333610.mp4



**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing