### PR TITLE
create expandible errors table component

### DIFF
--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -88,7 +88,8 @@
   "bulk_import": {
     "errors_number": "bulk import errors number is {{bulkImportErrorsNumber}}",
     "valid_scorm": "scorm file is valid",
-    "invalid_scorm": "scorm file is not valid"
+    "invalid_scorm": "scorm file is not valid",
+    "show_errors": "show errors"
   },
   "close_button_ariaLabel": "Close review slide",
   "post_comment_aria_label": "Post your comment",

--- a/packages/@coorpacademy-components/src/atom/button-link-icon-only/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon-only/style.css
@@ -114,3 +114,7 @@
   composes: bulkArrowDown;
   transform: rotate(180deg);
 }
+
+.bulkBulletButton{
+  background-color: white;
+}

--- a/packages/@coorpacademy-components/src/molecule/expandible-errors-table/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/expandible-errors-table/index.tsx
@@ -1,0 +1,155 @@
+/* eslint-disable css-modules/no-unused-class */
+import React, {useState} from 'react';
+import classnames from 'classnames';
+import {get, isString, some} from 'lodash/fp';
+import ButtonLinkIconOnly from '../../atom/button-link-icon-only';
+import StatusItem from '../../atom/status-item';
+import ErrorsTable from '../errors-table';
+import {WebContextValues} from '../../atom/provider/web-context';
+import Provider, {GetTranslateFromContext} from '../../atom/provider';
+import style from './style.css';
+import {ExpandState, Props, propTypes} from './types';
+
+const ExpandableErrorsTable = (props: Props, legacyContext: WebContextValues) => {
+  const {columns, rows = [], ariaDescribedby, nested = false} = props;
+  const translate = GetTranslateFromContext(legacyContext);
+
+  /**
+   * State variable to keep track of all the expanded rows
+   * By default, nothing expanded. Hence initialized with empty array.
+   */
+  const [expandedRows, setExpandedRows] = useState<number[]>([]);
+
+  /**
+   * State variable to keep track which row is currently expanded.
+   */
+  const [expandState, setExpandState] = useState<ExpandState>({});
+
+  /**
+   * This function gets called when show/hide link is clicked.
+   */
+  const handleExpandRow = (index: number) => () => {
+    const isRowExpanded = expandedRows.includes(index);
+
+    /**
+     * If the row is expanded, we are here to hide it. Hence remove
+     * it from the state variable. Otherwise add to it.
+     */
+    const newExpandedRows = isRowExpanded
+      ? expandedRows.filter(id => id !== index)
+      : expandedRows.concat(index);
+
+    setExpandedRows(newExpandedRows);
+
+    /**
+     * Create a new object to update the expanded state of all rows
+     * Use the newExpandedRows array to set the state of all rows that are currently expanded
+     */
+    const expandedState: ExpandState = {};
+    newExpandedRows.forEach(id => {
+      expandedState[id] = true;
+    });
+
+    setExpandState(expandedState);
+  };
+
+  const isTableExpandible = some(row => some({icon: 'invalid'}, row.fields), rows);
+  const renderIcon = (icon: 'valid' | 'invalid') => {
+    switch (icon) {
+      case 'valid':
+      case 'invalid':
+        return <StatusItem {...{icon}} />;
+    }
+  };
+
+  const headerRow = columns.map((column, cIndex) => {
+    const {title} = column;
+    return (
+      <th
+        className={style[`header-${cIndex + 1}`]}
+        key={`${title}-${cIndex + 1}`}
+        role="columnheader"
+      >
+        {title}
+      </th>
+    );
+  });
+
+  const headerView = [
+    <th
+      className={isTableExpandible ? style[`header-0-expandible`] : style[`header-0`]}
+      key="header"
+    />
+  ].concat(headerRow);
+
+  const bodyView = rows.map((row, index) => {
+    const {fields} = row;
+
+    const bodyRow = fields.map((field: string | {icon: 'valid' | 'invalid'}, fIndex: number) => {
+      return (
+        <td className={style.col} key={`${field}-${fIndex}`}>
+          {isString(field) ? field : renderIcon(get('icon', field))}
+        </td>
+      );
+    });
+
+    bodyRow.unshift(
+      <td
+        className={classnames(
+          isTableExpandible ? style[`col-0-expandible`] : style[`col-0`],
+          style.col
+        )}
+        key="header"
+      >
+        {some((field: string | {icon: string}) => get('icon', field) === 'invalid')(fields) ? (
+          <div className={style.upDownIcon}>
+            <ButtonLinkIconOnly
+              onClick={handleExpandRow(index)}
+              data-name="arrowUp-button"
+              icon="down"
+              className={expandState[index] ? 'bulkArrowUp' : 'bulkArrowDown'}
+              aria-label={translate('bulk_import.show_errors')}
+            />
+          </div>
+        ) : null}
+      </td>
+    );
+
+    const errorRow =
+      get('errors-table', row) && expandedRows.includes(index) ? (
+        <tr key={`line-${index}-error`}>
+          <td className={style.errorRow} colSpan={fields.length + 1}>
+            <ErrorsTable
+              rows={get('errors-table.rows', row)}
+              columns={get('errors-table.columns', row)}
+            />
+          </td>
+        </tr>
+      ) : null;
+
+    return errorRow
+      ? [<tr key={`line-${index}`}>{bodyRow}</tr>, errorRow]
+      : [<tr key={`line-${index}`}>{bodyRow}</tr>];
+  });
+
+  return (
+    <table
+      {...(ariaDescribedby ? {'aria-describedby': ariaDescribedby} : {})}
+      className={style.table}
+    >
+      <thead className={nested ? style[`thead-nested`] : style.thead}>
+        <tr>{headerView}</tr>
+      </thead>
+      <tbody>{bodyView}</tbody>
+    </table>
+  );
+};
+
+ExpandableErrorsTable.contextTypes = {
+  skin: Provider.childContextTypes.skin,
+  translate: Provider.childContextTypes.translate
+};
+
+ExpandableErrorsTable.propTypes = propTypes;
+
+export default ExpandableErrorsTable;

--- a/packages/@coorpacademy-components/src/molecule/expandible-errors-table/style.css
+++ b/packages/@coorpacademy-components/src/molecule/expandible-errors-table/style.css
@@ -1,0 +1,87 @@
+@value colors: "../../variables/colors.css";
+@value xtraLightGrey from colors;
+@value cm_grey_400 from colors;
+@value cm_grey_700 from colors;
+@value cm_negative_red_200 from colors;
+@value light from colors;
+
+.table {
+  border: 1px solid light;
+  font-family: 'Gilroy';
+  font-style: normal;
+  border-spacing: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.table .thead {
+  background-color: xtraLightGrey;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 24px;
+  color: cm_grey_400;
+  height: 56px;
+  overflow: hidden;
+  text-align: left; 
+}
+
+.table .thead-nested {
+  background-color: xtraLightGrey;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 24px;
+  color: cm_grey_400;
+  height: 40px;
+  overflow: hidden;
+  text-align: left; 
+}
+
+.table .header-0 {
+  width: 24px;
+}
+.table .header-0-expandible {
+  width: 57px;
+}
+.table .header-1 {
+  width: 182px;
+}
+
+.table .col {
+  text-align: left; 
+  padding-top: 8px;
+  padding-bottom: 8px;
+  position: relative;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+  color: cm_grey_700;
+  border-top: 1px solid light;
+}
+
+
+.table .col-0 {
+  text-align: center;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 16px;
+  width: 24px;
+  color: cm_grey_400;
+}
+.table .col-0-expandible {
+  text-align: center;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 16px;
+  width: 57px;
+  color: cm_grey_400;
+}
+
+.table .upDownIcon{
+  padding-left: 16px;
+}
+
+.table .errorRow{
+padding: 10px;
+border-top: 1px solid light;
+}

--- a/packages/@coorpacademy-components/src/molecule/expandible-errors-table/test/expandible-errors-table.js
+++ b/packages/@coorpacademy-components/src/molecule/expandible-errors-table/test/expandible-errors-table.js
@@ -1,0 +1,38 @@
+import test from 'ava';
+import browserEnv from 'browser-env';
+import React from 'react';
+import {mount, configure} from 'enzyme';
+import {identity} from 'lodash/fp';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import ExpandableErrorsTable from '..';
+import defaultFixture from './fixtures/default';
+
+browserEnv();
+configure({adapter: new Adapter()});
+const translate = identity;
+
+test('should launch onClick', t => {
+  const wrapper = mount(<ExpandableErrorsTable {...defaultFixture.props} />, {
+    context: {translate}
+  });
+  const clickEvent = {preventDefault: () => t.pass(), stopPropagation: () => t.pass()};
+  const button = wrapper.find('[data-name="arrowUp-button"]').first();
+  t.true(button.exists());
+
+  t.true(wrapper.find('.bulkArrowDown').at(0).exists());
+  t.false(wrapper.find('.bulkArrowUp').at(0).exists());
+  t.false(wrapper.find('table').at(1).exists());
+
+  button.simulate('click', clickEvent);
+
+  t.false(wrapper.find('.bulkArrowDown').at(0).exists());
+  t.true(wrapper.find('.bulkArrowUp').at(0).exists());
+  t.true(wrapper.find('table').at(1).exists());
+
+  button.simulate('click', clickEvent);
+
+  t.true(wrapper.find('.bulkArrowDown').at(0).exists());
+  t.false(wrapper.find('.bulkArrowUp').at(0).exists());
+  t.false(wrapper.find('table').at(1).exists());
+
+});

--- a/packages/@coorpacademy-components/src/molecule/expandible-errors-table/test/fixtures/all-valid.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-errors-table/test/fixtures/all-valid.ts
@@ -1,0 +1,36 @@
+import {Props} from '../../types';
+
+type Fixture = {props: Props};
+const fixture: Fixture = {
+  props: {
+    columns: [{title: 'File name'}, {title: 'Status'}],
+    rows: [
+      {
+        fields: [
+          'Scorm1.zip',
+          {
+            icon: 'valid'
+          }
+        ]
+      },
+      {
+        fields: [
+          'Scorm2.zip',
+          {
+            icon: 'valid'
+          }
+        ]
+      },
+      {
+        fields: [
+          'Scorm3.zip',
+          {
+            icon: 'valid'
+          }
+        ]
+      }
+    ],
+    ariaDescribedby: 'description-id'
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/molecule/expandible-errors-table/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-errors-table/test/fixtures/default.ts
@@ -1,0 +1,38 @@
+import {Props} from '../../types';
+import tableOfErrors from '../../../errors-table/test/fixtures/default';
+
+type Fixture = {props: Props};
+const fixture: Fixture = {
+  props: {
+    columns: [{title: 'File name'}, {title: 'Status'}],
+    rows: [
+      {
+        fields: [
+          'Scorm1.zip',
+          {
+            icon: 'valid'
+          }
+        ]
+      },
+      {
+        fields: [
+          'Scorm2.zip',
+          {
+            icon: 'invalid'
+          }
+        ],
+        'errors-table': tableOfErrors.props
+      },
+      {
+        fields: [
+          'Scorm3.zip',
+          {
+            icon: 'valid'
+          }
+        ]
+      }
+    ],
+    ariaDescribedby: 'description-id'
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/molecule/expandible-errors-table/test/fixtures/empty.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-errors-table/test/fixtures/empty.ts
@@ -1,0 +1,9 @@
+import {Props} from '../../types';
+
+type Fixture = {props: Props};
+const fixture: Fixture = {
+  props: {
+    columns: [{title: 'File name'}, {title: 'Status'}]
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/molecule/expandible-errors-table/test/fixtures/nested-style.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-errors-table/test/fixtures/nested-style.ts
@@ -1,0 +1,39 @@
+import {Props} from '../../types';
+import tableOfErrors from '../../../errors-table/test/fixtures/default';
+
+type Fixture = {props: Props};
+const fixture: Fixture = {
+  props: {
+    nested: true,
+    columns: [{title: 'File name'}, {title: 'Status'}],
+    rows: [
+      {
+        fields: [
+          'Scorm1.zip',
+          {
+            icon: 'valid'
+          }
+        ]
+      },
+      {
+        fields: [
+          'Scorm2.zip',
+          {
+            icon: 'invalid'
+          }
+        ],
+        'errors-table': tableOfErrors.props
+      },
+      {
+        fields: [
+          'Scorm3.zip',
+          {
+            icon: 'valid'
+          }
+        ]
+      }
+    ],
+    ariaDescribedby: 'description-id'
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/molecule/expandible-errors-table/types.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-errors-table/types.ts
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import {Props as ErrorsTableProps} from '../errors-table/types';
+
+const columnProptypes = PropTypes.shape({
+  title: PropTypes.string.isRequired
+});
+
+const rowProptypes = PropTypes.shape({
+  fields: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.shape({icon: PropTypes.string})])
+  )
+});
+
+export const propTypes = {
+  columns: PropTypes.arrayOf(columnProptypes).isRequired,
+  rows: PropTypes.arrayOf(rowProptypes),
+  ariaDescribedby: PropTypes.string,
+  nested: PropTypes.bool
+};
+
+export type Column = {title: string};
+export type Row = {
+  fields: (string | {icon: 'valid' | 'invalid'})[];
+  'errors-table'?: ErrorsTableProps;
+};
+export type Columns = [Column, Column];
+export type Rows = Row[];
+
+export type Props = {
+  columns: Columns;
+  rows?: Rows;
+  ariaDescribedby?: string;
+  nested?: boolean;
+};
+
+export type ExpandState = {[key: number]: boolean};

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/index.js
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/index.js
@@ -11,6 +11,7 @@ import OrganismSearchAndChipsResults from '../search-and-chips-results';
 import CourseSelection from '../course-selection';
 import CourseSections from '../../molecule/course-sections';
 import RewardsForm from '../rewards-form';
+import ExpandibleErrorsTable from '../../molecule/expandible-errors-table';
 import style from './style.css';
 
 const buildHeader = (wizardHeader, steps) => {
@@ -52,6 +53,8 @@ const buildForm = content => {
       return <CourseSections {...content} />;
     case 'rewards':
       return <RewardsForm {...content} />;
+    case 'expandible-errors-table':
+      return <ExpandibleErrorsTable {...content} />;
   }
 };
 
@@ -185,6 +188,10 @@ WizardContents.propTypes = {
     PropTypes.shape({
       ...RewardsForm.propTypes,
       type: PropTypes.oneOf(['rewards'])
+    }),
+    PropTypes.shape({
+      ...ExpandibleErrorsTable.propTypes,
+      type: PropTypes.oneOf(['expandible-errors-table'])
     })
   ]),
   previousStep: PropTypes.shape({

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
@@ -23,6 +23,7 @@ import CmPopin from '../../../molecule/cm-popin';
 import ButtonLinkIconOnly from '../../../atom/button-link-icon-only';
 import EmptyStateDashboard from '../../../molecule/empty-state-dashboard';
 import UploadingFileProgress from '../../../molecule/uploading-file-progress';
+import ExpandibleErrorsTable from '../../../molecule/expandible-errors-table';
 import style from './style.css';
 
 const getStyle = isSelected => (isSelected ? style.selectedElement : style.unselectedElement);
@@ -170,6 +171,7 @@ const buildContentView = content => {
     case 'home':
       return <BrandDashboard {...content} />;
     case 'wizard':
+    case 'expandible-errors-table':
       return <WizardContents {...content} />;
     case 'empty-state-dashboard':
       return <EmptyStateDashboard {...content} />;
@@ -311,6 +313,15 @@ BrandUpdate.propTypes = {
       ...UploadingFileProgress.propTypes,
       key: PropTypes.string,
       type: PropTypes.oneOf(['uploading-file-progress'])
+    }),
+    PropTypes.shape({
+      ...WizardContents.propTypes,
+      content: PropTypes.shape({
+        ...ExpandibleErrorsTable.propTypes,
+        ...WizardContents.propTypes.content.propTypes
+      }),
+      key: PropTypes.string,
+      type: PropTypes.oneOf(['expandible-errors-table'])
     })
   ]),
   documentation: PropTypes.shape({

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/bulk-inspect.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/bulk-inspect.js
@@ -1,0 +1,114 @@
+import ExpandibleErrorsTable from '../../../../../molecule/expandible-errors-table/test/fixtures/default';
+import headerAndMenu from './default';
+
+const {header} = headerAndMenu.props;
+const items = [
+  {
+    title: 'My Dashboard',
+    key: 'dashboard',
+    href: '#brand/samsung/dashboard',
+    open: undefined,
+    selected: false,
+    type: 'simpleTab'
+  },
+  {
+    title: 'Administration',
+    key: 'administration',
+    href: '#brand/samsung/administration',
+    open: false,
+    selected: false,
+    type: 'collapsibleTab'
+  },
+  {
+    title: 'Editorialization',
+    key: 'editorialization',
+    href: '#brand/samsung/editorialization',
+    type: 'collapsibleTab',
+    open: false,
+    selected: false
+  },
+  {
+    title: 'Content Creation',
+    key: 'contentCreation',
+    href: '#brand/samsung/content-creation',
+    isOpen: true,
+    selected: true,
+    type: 'collapsibleTab',
+    tabs: [
+      {title: 'Go to Cockpit', href: '#/cockpit', selected: false, type: 'iconLink'},
+      {title: 'Bulk Import', href: '#/external-content', selected: true}
+    ]
+  },
+  {
+    title: 'Animation',
+    key: 'animation',
+    href: '#brand/samsung/content-creation',
+    selected: false,
+    isOpen: true,
+    type: 'collapsibleTab'
+  },
+  {
+    title: 'Analytics',
+    key: 'analytics',
+    href: '#brand/samsung/analytics',
+    open: false,
+    selected: false,
+    type: 'collapsibleTab',
+    tabs: [
+      {title: 'SSO', href: '#/sso', selected: false, type: 'iconLink'},
+      {title: 'Look and Feel', href: '#/look-and-feel', selected: false},
+      {title: 'Settings', href: '#/settings', selected: false},
+      {title: 'Any', href: '#/any', selected: false},
+      {title: 'Many', href: '#/many', selected: false}
+    ]
+  }
+];
+
+const contentSteps = [
+  {
+    title: 'Import',
+    done: true
+  },
+  {
+    title: 'Inspect',
+    done: false,
+    current: true
+  }
+];
+const wizardHeader = {
+  title: 'Massive Import',
+  onClick: function onClick() {
+    return console.log('Close');
+  }
+};
+
+const notifications = [
+  {
+    type: 'warning',
+    message:
+      '1 file out of 3 failed, you can still save the rest of the content. The files in error will be ignored. You will be able to correct them via a subsequent re-upload',
+    firstCTALabel: 'Download report',
+    firstCTA: function firstCTA() {
+      return console.log('first cta');
+    }
+  }
+];
+
+export default {
+  props: {
+    header,
+    items,
+    content: {
+      content: {
+        type: 'expandible-errors-table',
+        ...ExpandibleErrorsTable.props
+      },
+      steps: contentSteps,
+      wizardHeader,
+      key: 'expandible-errors-table',
+      type: 'expandible-errors-table'
+    },
+    notifications,
+    contentFixHeight: true
+  }
+};


### PR DESCRIPTION
[ticket](https://trello.com/c/YbO0HtBE/1188-composant-inspect-post-progress-100)
expandible errors table is a component that would be used to build the other bulk tables. and is build using errors table already created.
Purpose of the PR:
- create expandible errors table.
- expandible errors table should be RGAA compliant
- add expandible errors table to brandUpdate 
- create bulk inspect fixtures
- expandible errors table test coverage 100%

![Pasted Graphic 32](https://user-images.githubusercontent.com/111736786/220517318-236d3979-d6ef-4909-a760-2b25195fe3b8.png)

![Pasted Graphic 33](https://user-images.githubusercontent.com/111736786/220517346-95a7af0e-c61a-419a-8692-9bb7820fd510.png)

![Pasted Graphic 34](https://user-images.githubusercontent.com/111736786/220517365-1b869e1d-5684-4fa0-8af4-8311af1ff3e0.png)

brandUpdate Template bulk inspect: 
![image](https://user-images.githubusercontent.com/111736786/222289348-a25f231b-0c42-416a-9dd1-3378f31e626e.png)

