### PR TITLE
fixing atom.range.handle

### DIFF
--- a/packages/@coorpacademy-components/src/atom/range/handle.js
+++ b/packages/@coorpacademy-components/src/atom/range/handle.js
@@ -34,10 +34,12 @@ const Handle = (props, legacyContext) => {
   const {onPanStart = noop, onPanEnd = noop, onPan = noop, HammerForTesting} = props;
 
   const handle = useRef();
-  const hammer = useMemo(
-    () => HammerForTesting || new Hammer(handle.current),
-    [handle, HammerForTesting]
-  );
+
+  const hammer = useMemo(() => {
+    return HammerForTesting || (handle.current && new Hammer(handle.current));
+    // (we need to mount Hammer when handle.current is rendered and ready)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [handle.current, HammerForTesting]);
 
   useEffect(() => {
     if (!hammer) return;


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

issue:
- `useMemo` is triggered before the first render, meaning `ref` is not created

```
Uncaught TypeError: Cannot read properties of undefined (reading 'addEventListener')
    at eval (hammer.js:237:14)
```

- solution: calling `useMemo` once again when the render is done and the `ref` is updated