### PR TITLE
modifiy image upload component props image type

### DIFF
--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
@@ -32,7 +32,9 @@ class DragAndDrop extends React.Component {
     onReset: PropTypes.func,
     error: PropTypes.string,
     buttonAriaLabel: PropTypes.string,
-    errorButtonLabel: PropTypes.string
+    errorButtonLabel: PropTypes.string,
+    pdfButtonLabel: PropTypes.string,
+    pdfButtonAriaLabel: PropTypes.string
   };
 
   constructor(props) {
@@ -73,7 +75,9 @@ class DragAndDrop extends React.Component {
       error = '',
       buttonAriaLabel = '',
       errorButtonLabel = '',
-      disabled = false
+      disabled = false,
+      pdfButtonLabel,
+      pdfButtonAriaLabel
     } = this.props;
     const {dragging} = this.state;
 
@@ -89,6 +93,23 @@ class DragAndDrop extends React.Component {
       previewView = (
         <div className={style.preview}>
           <video controls src={previewContent.src} type="video/*" />
+        </div>
+      );
+    } else if (previewContent && previewContent.type === 'pdf') {
+      previewView = (
+        <div className={style.previewPdf}>
+          <p className={style.previewLabelPdf}>{previewLabel}</p>
+          <Button
+            type="secondary"
+            link={{href: previewContent.src, target: '_blank', download: false}}
+            label={pdfButtonLabel}
+            aria-label={pdfButtonAriaLabel}
+            data-name="default-button-pdf"
+            icon={{
+              position: 'left',
+              type: 'pdf'
+            }}
+          />
         </div>
       );
     } else if (loading) {

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
@@ -78,12 +78,31 @@
   background-color: white;
 }
 
-.preview img, video {
+.preview img,
+video {
   max-width: 100%;
   max-height: 100%;
   margin: auto;
 }
 
+.previewPdf {
+  composes: preview;
+  min-height: 150px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+}
+
+.previewLabelPdf {
+  text-align: center;
+  font-family: "Gilroy";
+  color: cm_grey_300;
+  padding: 0px 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 90%;
+  white-space: nowrap;
+}
 .infosContainer {
   width: 100%;
   height: 100%;
@@ -152,7 +171,7 @@
   align-items: center;
   justify-content: space-between;
   margin-top: 16px;
-  padding: 4px 8px;
+  padding: 8px 14px 8px 1px;
   font-size: 12px;
   font-weight: 400;
   position: relative;
@@ -164,9 +183,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   flex-wrap: nowrap;
-  position: absolute;
-  left: 0;
-  right: 15px;
 }
 
 .closeIcon {

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/with-pdf.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/with-pdf.js
@@ -1,0 +1,15 @@
+export default {
+  props: {
+    title: 'Drag & Drop With PDF',
+    description: 'Drag and drop component with a pdf',
+    uploadLabel: 'Upload Image(s)',
+    previewLabel: 'File Preview',
+    previewContent: {
+      type: 'pdf',
+      src: 'https://static.coorpacademy.com/content/digital/raw/meta_inc-1677774948417._logo-1-1677774948417.pdf',
+      label: 'meta image'
+    },
+    pdfButtonLabel: 'Open PDF',
+    pdfButtonAriaLabel: 'Open PDF'
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/image-upload/index.js
+++ b/packages/@coorpacademy-components/src/atom/image-upload/index.js
@@ -1,6 +1,6 @@
 import React, {useCallback} from 'react';
 import PropTypes from 'prop-types';
-import {join, map, pipe, isNil} from 'lodash/fp';
+import {isNil} from 'lodash/fp';
 import DragAndDrop from '../drag-and-drop';
 import {ImagePropType} from '../../util/proptypes';
 import Link from '../button-link';
@@ -18,14 +18,16 @@ const ImageUpload = ({
   onChange,
   onReset = null,
   name,
-  // See ImagePropType for accepted values
   labelLink,
   labelButtonLink,
   hrefLink,
+  // See ImagePropType for accepted values
   imageTypes = ['*'],
   error = '',
   buttonAriaLabel,
-  errorButtonLabel
+  errorButtonLabel,
+  pdfButtonLabel,
+  pdfButtonAriaLabel
 }) => {
   const handleReset = useCallback(
     e => {
@@ -35,11 +37,6 @@ const ImageUpload = ({
     },
     [onReset]
   );
-
-  const acceptedImages = pipe(
-    map(t => `image/${t}`),
-    join(',')
-  )(imageTypes);
 
   const linkCustomStyle = {
     width: '40px',
@@ -61,12 +58,14 @@ const ImageUpload = ({
         disabled={disabled}
         buttonAriaLabel={buttonAriaLabel}
         errorButtonLabel={errorButtonLabel}
+        pdfButtonLabel={pdfButtonLabel}
+        pdfButtonAriaLabel={pdfButtonAriaLabel}
       >
         {(onDragStart, onDragStop) => (
           <input
             type="file"
             name={name}
-            accept={acceptedImages}
+            accept={imageTypes}
             disabled={loading || disabled}
             className={style.input}
             onChange={onChange}

--- a/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/desktop-reset-description-multiple.js
+++ b/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/desktop-reset-description-multiple.js
@@ -5,6 +5,6 @@ const {props} = DesktopReset;
 export default {
   props: {
     ...props,
-    imageTypes: ['png', 'jpg', 'svg+xml']
+    imageTypes: ['image/png', 'image/jpeg', 'image/svg+xml']
   }
 };

--- a/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/desktop-reset-description-only-png.js
+++ b/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/desktop-reset-description-only-png.js
@@ -9,6 +9,6 @@ export default {
       type: 'image',
       src: 'https://static.coorpacademy.com/content/up/raw/batman.png'
     },
-    imageTypes: ['png']
+    imageTypes: ['image/png']
   }
 };

--- a/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/pdf.js
+++ b/packages/@coorpacademy-components/src/atom/image-upload/test/fixtures/pdf.js
@@ -1,0 +1,14 @@
+export default {
+  props: {
+    title: 'Desktop (*)',
+    uploadLabel: 'Upload',
+    previewLabel: 'file_00001_009_6342672899999999999',
+    onChange: () => true,
+    previewContent: {
+      type: 'pdf',
+      src: 'https://static.coorpacademy.com/content/digital/raw/meta_inc-1677774948417._logo-1-1677774948417.pdf'
+    },
+    pdfButtonLabel: 'Open PDF',
+    pdfButtonAriaLabel: 'Open PDF'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/drag-and-drop-wrapper/style.css
+++ b/packages/@coorpacademy-components/src/molecule/drag-and-drop-wrapper/style.css
@@ -10,5 +10,5 @@
 .dragAndDrop {
   margin-right: 16px;
   width: 202px;
-  height: 183px;
+  min-height: 183px;
 }

--- a/packages/@coorpacademy-components/src/organism/list-item/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/index.js
@@ -8,8 +8,15 @@ import style from './style.css';
 
 const ListItem = props => {
   let isPublished = false;
-  const {bulletPointMenuButton, buttonLink, tags, title, order, 'aria-label': ariaLabel} = props;
-
+  const {
+    bulletPointMenuButton,
+    buttonLink,
+    tags,
+    title,
+    order,
+    'aria-label': ariaLabel,
+    contentType
+  } = props;
   const tagsView = map.convert({cap: false})((tag, index) => {
     isPublished = tag.type === 'published';
     return (
@@ -20,7 +27,7 @@ const ListItem = props => {
   })(tags);
   return (
     <div className={style.wrapper}>
-      {isPublished ? (
+      {isPublished && contentType === 'certification' ? (
         <div className={style.orderWrapper}>
           <div className={style.order} aria-label={ariaLabel}>
             {order + 1}
@@ -78,7 +85,8 @@ ListItem.propTypes = {
   ),
   title: PropTypes.string.isRequired,
   order: PropTypes.number,
-  'aria-label': PropTypes.string
+  'aria-label': PropTypes.string,
+  contentType: PropTypes.string
 };
 
 export default ListItem;

--- a/packages/@coorpacademy-components/src/organism/list-items/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/index.js
@@ -5,10 +5,10 @@ import Title from '../../atom/title';
 import ButtonLink from '../../atom/button-link';
 import style from './style.css';
 
-const ListItems = ({title, buttonLink, items, 'aria-label': ariaLabel}) => {
+const ListItems = ({title, buttonLink, items, 'aria-label': ariaLabel, contentType}) => {
   const itemsView = items.map((item, index) => (
     <li key={item.id} className={style.item} data-name={`content-${index}`}>
-      <ListItem {...item} order={index} />
+      <ListItem {...item} order={index} contentType={contentType} />
     </li>
   ));
 
@@ -33,7 +33,8 @@ ListItems.propTypes = {
   'aria-label': PropTypes.string,
   buttonLink: PropTypes.shape(ButtonLink.propTypes),
   items: PropTypes.arrayOf(PropTypes.shape(ListItem.propTypes)),
-  title: PropTypes.string
+  title: PropTypes.string,
+  contentType: PropTypes.string
 };
 
 export default ListItems;

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/published-certification.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/published-certification.js
@@ -1,0 +1,27 @@
+import publishedItem from '../../../list-item/test/fixtures/published';
+import revisedItem from '../../../list-item/test/fixtures/revised';
+
+const propsRevised = revisedItem.props;
+
+const ids = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'];
+const listePublishedItems = ids.map(id => {
+  return {
+    ...publishedItem.props,
+    id
+  };
+});
+
+export default {
+  props: {
+    title: `${listePublishedItems.length + 1} certifications`,
+    'aria-label': 'aria list',
+    buttonLink: {
+      type: 'primary',
+      label: 'Create certification',
+      'aria-label': 'aria button',
+      'data-name': 'default-button',
+      onClick: () => console.log('click')
+    },
+    items: [...listePublishedItems, propsRevised]
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/rewards-form/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/rewards-form/test/fixtures/default.js
@@ -1,6 +1,6 @@
 import inputText from '../../../../atom/input-text-with-title/test/fixtures/error';
 import CheckboxWithTitle from '../../../../atom/checkbox-with-title/test/fixtures/checked';
-import singleDragAndDrop from '../../../../molecule/drag-and-drop-wrapper/test/fixtures/disabled';
+import PDFDragAndDrop from '../../../../atom/image-upload/test/fixtures/pdf';
 import doubleDragAndDrop from '../../../../molecule/drag-and-drop-wrapper/test/fixtures/two-drag-and-drops';
 
 export default {
@@ -12,11 +12,11 @@ export default {
       },
       {
         child: {
-          ...singleDragAndDrop.props,
+          list: [{...PDFDragAndDrop.props}],
           childType: 'drag-and-drop-wrapper',
           title: 'Create badge'
         },
-        checkboxWithTitle: {title: 'Create badge'}
+        checkboxWithTitle: {title: 'Create badge', checked: true}
       },
       {
         child: {...doubleDragAndDrop.props, childType: 'drag-and-drop-wrapper'},

--- a/packages/@coorpacademy-components/src/organism/rewards-form/test/fixtures/one-reward.js
+++ b/packages/@coorpacademy-components/src/organism/rewards-form/test/fixtures/one-reward.js
@@ -1,7 +1,14 @@
-import singleDragAndDrop from '../../../../molecule/drag-and-drop-wrapper/test/fixtures/default';
+import PDFDragAndDrop from '../../../../atom/image-upload/test/fixtures/pdf';
 
 export default {
   props: {
-    items: [{child: {...singleDragAndDrop.props, childType: 'drag-and-drop-wrapper'}}]
+    items: [
+      {
+        child: {
+          list: [{...PDFDragAndDrop.props}],
+          childType: 'drag-and-drop-wrapper'
+        }
+      }
+    ]
   }
 };

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
@@ -300,7 +300,8 @@ BrandUpdate.propTypes = {
     PropTypes.shape({
       ...ListItems.propTypes,
       key: PropTypes.string,
-      type: PropTypes.oneOf(['list-content'])
+      type: PropTypes.oneOf(['list-content']),
+      contentType: PropTypes.string
     }),
     PropTypes.shape({
       ...EmptyStateDashboard.propTypes,

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/list-items-certification-published.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/list-items-certification-published.js
@@ -1,0 +1,75 @@
+import {defaultsDeep, cloneDeep} from 'lodash/fp';
+import listItemsCertification from '../../../../../organism/list-items/test/fixtures/published-certification';
+import Default from './default';
+
+const props = cloneDeep(Default.props);
+const listItemsCertificationProps = listItemsCertification.props;
+
+props.items[0].selected = false;
+props.items[2].selected = true;
+props.items[2].tabs = [
+  {
+    title: 'Look & feel',
+    href: '/brands/7steps/admin/look-and-feel',
+    name: 'brand_tab_admin_look_and_feel',
+    selected: false,
+    type: 'simpleTab'
+  },
+  {
+    title: 'Content',
+    href: '/brands/7steps/admin/content',
+    name: 'brand_tab_admin_user',
+    selected: false,
+    type: 'simpleTab'
+  },
+  {
+    title: 'Dashboard',
+    href: '/brands/7steps/admin/user/dashboard',
+    name: 'brand_tab_admin_user',
+    selected: false,
+    type: 'simpleTab'
+  },
+  {
+    title: 'Certification',
+    href: '/brands/7steps/admin/custom-playlist/published',
+    name: 'brand_tab_admin_custom_playlist',
+    selected: true,
+    type: 'simpleTab',
+    subTabs: [
+      {
+        title: 'Published',
+        href: '/brands/7steps/admin/custom-playlist/published',
+        name: 'published',
+        permissions: ['published'],
+        selected: true,
+        type: 'simpleTab'
+      },
+      {
+        title: 'Drafts',
+        href: '/brands/7steps/admin/custom-playlist/drafts',
+        name: 'drafts',
+        permissions: ['drafts'],
+        selected: false,
+        type: 'simpleTab'
+      },
+      {
+        title: 'Archived',
+        href: '/brands/7steps/admin/custom-playlist/archived',
+        name: 'archived',
+        permissions: ['archived'],
+        selected: false,
+        type: 'simpleTab'
+      }
+    ]
+  }
+];
+
+export default {
+  props: defaultsDeep(props, {
+    content: {
+      ...listItemsCertificationProps,
+      type: 'list-content',
+      contentType: 'certification'
+    }
+  })
+};

--- a/packages/@coorpacademy-components/src/util/button-icons.js
+++ b/packages/@coorpacademy-components/src/util/button-icons.js
@@ -15,7 +15,8 @@ import {
   NovaLineLoginKey1 as KlfIcon,
   NovaSolidFilesFoldersFolders as FoldersIcon,
   NovaSolidFilesBasicFileUpload2 as UploadIcon,
-  NovaCompositionNavigationArrowDown as ArrowDown
+  NovaCompositionNavigationArrowDown as ArrowDown,
+  NovaLineFilesOfficeFileOfficePdf as PDF
 } from '@coorpacademy/nova-icons';
 
 export const ICONS = {
@@ -35,5 +36,6 @@ export const ICONS = {
   see: EyeIcon,
   folders: FoldersIcon,
   upload: UploadIcon,
-  down: ArrowDown
+  down: ArrowDown,
+  pdf: PDF
 };

--- a/packages/@coorpacademy-components/src/util/proptypes.js
+++ b/packages/@coorpacademy-components/src/util/proptypes.js
@@ -15,9 +15,10 @@ export const PathPropType = stringMatching(PATH_REGEXP);
 export const SrcPropType = PropTypes.oneOfType([UrlPropType, PathPropType]);
 
 export const ImagePropType = (propValue, key, componentName) => {
-  if (includes(propValue[key], ['jpg', 'png', 'svg+xml'])) return;
+  if (includes(propValue[key], ['image/jpeg', 'image/png', 'image/svg+xml', 'application/pdf']))
+    return;
   return new Error(
-    `Invalid prop value: ${propValue[key]}, at component: ${componentName}. Expected a valid image type: jpg, png or svg+xml.`
+    `Invalid prop value: ${propValue[key]}, at component: ${componentName}. Expected a valid image type: image/jpeg, image/png, image/svg+xml or application/pdf.`
   );
 };
 

--- a/packages/@coorpacademy-components/src/util/test/proptypes.js
+++ b/packages/@coorpacademy-components/src/util/test/proptypes.js
@@ -79,21 +79,22 @@ test('SrcPropType should pass when valid source is passed', validMacro, SrcPropT
 test('SrcPropType should throw error when incorrect source is passed', failMacro, SrcPropType, [0]);
 
 test('ImagePropType should pass when correct image type is passed', validMacro, ImagePropType, [
-  'svg+xml',
-  'jpg',
-  'png'
+  'image/svg+xml',
+  'image/jpeg',
+  'image/png',
+  'application/pdf'
 ]);
 
 test(
   'ImagePropType should throw error when incorrect image type is passed: misspelled',
   failMacro,
   ImagePropType,
-  ['sgv+xml']
+  ['image/sgv+xml']
 );
 
 test(
   'ImagePropType should throw error when incorrect image type is passed: not included',
   failMacro,
   ImagePropType,
-  ['pdf', 'another']
+  ['image/pdf', 'another']
 );


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->
https://trello.com/c/RU4nABtM/1207-pouvoir-mettre-le-ressource-pdf-dans-le-certificat

link with this PR backoffice:
https://github.com/CoorpAcademy/app-backoffice/pull/1025

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

- modify drag and drop component to receive pdf type
- modify upload image to receive directly MIME type

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->
voir storybook: 
fixtures wizardContent > certification rewards

<img width="924" alt="image" src="https://user-images.githubusercontent.com/23300140/222776717-7a8e00fd-4dd7-4072-a1fe-aba053ee8b84.png">


- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
