### PR TITLE
Create a Boosted revision player :orange_book:

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/config/review.js
+++ b/packages/@coorpacademy-progression-engine/src/config/review.js
@@ -1,23 +1,30 @@
 // @flow
+import {assign} from 'lodash/fp';
 import type {Config} from '../types';
 
+const CURRENT_BASE_CONFIGURATION = {
+  version: '1',
+  lives: 0,
+  livesDisabled: true,
+  maxTypos: 2,
+  slidesToComplete: 5,
+  shuffleChoices: true,
+  answerBoundaryLimit: 5,
+  starsPerAskingClue: 0,
+  starsPerCorrectAnswer: 8,
+  starsPerResourceViewed: 0,
+  remainingLifeRequests: 0
+};
+
 const configurations: Array<Config> = [
-  {
-    version: '1',
-    lives: 0,
-    livesDisabled: true,
-    maxTypos: 2,
-    slidesToComplete: 5,
-    shuffleChoices: true,
-    answerBoundaryLimit: 5,
-    starsPerAskingClue: 0,
-    starsPerCorrectAnswer: 8,
-    starsPerResourceViewed: 0,
-    remainingLifeRequests: 0
-  }
+  CURRENT_BASE_CONFIGURATION,
+  assign(CURRENT_BASE_CONFIGURATION, {
+    version: '2',
+    starsPerCorrectAnswer: 12
+  })
 ];
 
 export default {
   configurations,
-  defaultConfiguration: configurations[0]
+  defaultConfiguration: CURRENT_BASE_CONFIGURATION
 };


### PR DESCRIPTION
## Detailed purpose of the PR

Add a new revision engine, v2 with "tripled" stars 🌟. (compared to learner, revision default being already doubled)
Similar to #2651 

:card_index: https://trello.com/c/LaU5jVlu/385-tripler-gain-%C3%A9toiles-sur-mode-r%C3%A9vision