### PR TITLE
create Actionnable expandible table 

### DIFF
--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -89,7 +89,8 @@
   "bulk_import": {
     "errors_number": "bulk import errors number is {{bulkImportErrorsNumber}}",
     "valid_scorm": "scorm file is valid",
-    "invalid_scorm": "scorm file is not valid"
+    "invalid_scorm": "scorm file is not valid",
+    "show_errors": "show errors"
   },
   "close_button_ariaLabel": "Close review slide",
   "post_comment_aria_label": "Post your comment",

--- a/packages/@coorpacademy-components/src/atom/button-link-icon-only/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon-only/style.css
@@ -111,6 +111,21 @@
 }
 
 .bulkArrowUp {
-  composes: bulkArrowDown;
+  composes: button;
+  width: 24px;
+  height: 24px;
+  background-color: white;
+  border: 1px solid cm_grey_200;
+  border-radius: 5px;
+  padding: 10px;
+  opacity: 0.5;
   transform: rotate(180deg);
+}
+.bulkArrowUp .icon {
+  width: 8px;
+  height: 8px;
+}
+
+.bulkBulletButton{
+  background-color: white;
 }

--- a/packages/@coorpacademy-components/src/atom/button-link/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.tsx
@@ -1,14 +1,15 @@
 import React, {useCallback} from 'react';
-import PropTypes from 'prop-types';
-import {getOr, keys, noop} from 'lodash/fp';
+import {noop} from 'lodash/fp';
 import classnames from 'classnames';
 import Link from '../link';
 import {ICONS} from '../../util/button-icons';
+import propTypes, {ButtonLinkProps, IconType} from './types';
+// eslint-disable-next-line css-modules/no-unused-class
 import style from './style.css';
 
-const getButtonContent = (icon, label) => {
-  const {type, position} = icon;
-  const Icon = getOr(null, type, ICONS);
+const getButtonContent = (icon?: IconType, label?: string) => {
+  const {type, position} = icon || {type: '', position: ''};
+  const Icon = type && ICONS[type];
 
   if (!Icon) {
     return (
@@ -27,12 +28,12 @@ const getButtonContent = (icon, label) => {
   );
 };
 
-const ButtonLink = props => {
+const ButtonLink = (props: ButtonLinkProps) => {
   const {
     type,
     label,
     disabled,
-    icon = {},
+    icon,
     'data-name': dataName,
     'data-testid': dataTestId = 'button-link',
     'aria-label': ariaLabel,
@@ -45,7 +46,7 @@ const ButtonLink = props => {
   } = props;
   const contentView = getButtonContent(icon, label);
   const styleButton = classnames(
-    className,
+    style[`${className}`],
     style.button,
     type === 'primary' && style.primary,
     type === 'secondary' && style.secondary,
@@ -98,27 +99,6 @@ const ButtonLink = props => {
   );
 };
 
-ButtonLink.propTypes = {
-  type: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'text', 'dangerous']),
-  label: PropTypes.string,
-  'aria-label': PropTypes.string,
-  'data-name': PropTypes.string,
-  'data-testid': PropTypes.string,
-  icon: PropTypes.shape({
-    position: PropTypes.oneOf(['right', 'left']),
-    type: PropTypes.oneOf(keys(ICONS))
-  }),
-  onClick: PropTypes.func,
-  onKeyDown: PropTypes.func,
-  link: PropTypes.shape({
-    href: PropTypes.string,
-    download: PropTypes.bool,
-    target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top'])
-  }),
-  disabled: PropTypes.bool,
-  className: PropTypes.string,
-  customStyle: PropTypes.shape({}),
-  useTitle: PropTypes.bool
-};
+ButtonLink.propTypes = propTypes;
 
 export default ButtonLink;

--- a/packages/@coorpacademy-components/src/atom/button-link/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-link/style.css
@@ -94,3 +94,12 @@
   border-radius: 0px;
   height: auto;
 }
+
+/* bulk inspect button style */
+.bulkInspectButton {
+  font-family: 'Gilroy';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 14px;
+  color: cm_primary_blue;
+}

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-dangerous-no-icon.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-dangerous-no-icon.ts
@@ -1,4 +1,6 @@
-export default {
+import {Fixture} from '../../types';
+
+export const fixture: Fixture = {
   props: {
     type: 'dangerous',
     label: 'Delete',
@@ -7,3 +9,4 @@ export default {
     onClick: () => console.log('click')
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-primary-icon-left.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-primary-icon-left.ts
@@ -1,13 +1,16 @@
-export default {
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
   props: {
-    type: 'tertiary',
-    label: 'Button',
+    type: 'primary',
+    label: 'See my platform',
     'aria-label': 'aria button',
     'data-name': 'default-button',
     icon: {
       position: 'left',
-      type: 'see'
+      type: 'chevron-left'
     },
     onClick: () => console.log('click')
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-primary-no-icon.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-primary-no-icon.ts
@@ -1,4 +1,6 @@
-export default {
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
   props: {
     type: 'primary',
     label: 'See my platform',
@@ -6,3 +8,4 @@ export default {
     onClick: () => console.log('click')
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-secondary-no-icon-disabled.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-secondary-no-icon-disabled.ts
@@ -1,4 +1,6 @@
-export default {
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
   props: {
     type: 'secondary',
     label: 'See my platform',
@@ -8,3 +10,4 @@ export default {
     disabled: true
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-tertiary-icon-left.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-tertiary-icon-left.ts
@@ -1,13 +1,16 @@
-export default {
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
   props: {
-    type: 'primary',
-    label: 'See my platform',
+    type: 'tertiary',
+    label: 'Button',
     'aria-label': 'aria button',
     'data-name': 'default-button',
     icon: {
       position: 'left',
-      type: 'chevron-left'
+      type: 'see'
     },
     onClick: () => console.log('click')
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-primary-disabled-icon-right.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-primary-disabled-icon-right.ts
@@ -1,4 +1,6 @@
-export default {
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
   props: {
     type: 'primary',
     disabled: true,
@@ -14,3 +16,4 @@ export default {
     }
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-secondary-icon-right.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-secondary-icon-right.ts
@@ -1,4 +1,6 @@
-export default {
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
   props: {
     type: 'secondary',
     label: 'Global Analytics',
@@ -17,3 +19,4 @@ export default {
     }
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-tertiary-no-icon-no-aria-label.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-tertiary-no-icon-no-aria-label.ts
@@ -1,4 +1,6 @@
-export default {
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
   props: {
     type: 'tertiary',
     label: 'Go to google',
@@ -13,3 +15,4 @@ export default {
     }
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-tertiary-no-icon.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-tertiary-no-icon.ts
@@ -1,4 +1,6 @@
-export default {
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
   props: {
     type: 'tertiary',
     label: 'Go to google',
@@ -15,3 +17,4 @@ export default {
     useTitle: false
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-text-icon-right-target-blank.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-text-icon-right-target-blank.ts
@@ -1,4 +1,6 @@
-export default {
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
   props: {
     type: 'text',
     label: 'Button',
@@ -14,3 +16,4 @@ export default {
     }
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-text-no-icon-download.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/link-text-no-icon-download.ts
@@ -1,4 +1,6 @@
-export default {
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
   props: {
     type: 'text',
     label: 'Download',
@@ -10,3 +12,4 @@ export default {
     }
   }
 };
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/types.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/types.ts
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+import {keys} from 'lodash/fp';
+import {ICONS} from '../../util/button-icons';
+
+const propTypes = {
+  type: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'text', 'dangerous']),
+  label: PropTypes.string,
+  'aria-label': PropTypes.string,
+  'data-name': PropTypes.string,
+  'data-testid': PropTypes.string,
+  icon: PropTypes.shape({
+    position: PropTypes.oneOf(['right', 'left']),
+    type: PropTypes.oneOf(keys(ICONS))
+  }),
+  onClick: PropTypes.func,
+  link: PropTypes.shape({
+    href: PropTypes.string,
+    download: PropTypes.bool,
+    target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top'])
+  }),
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+  customStyle: PropTypes.shape({})
+};
+
+export type IconType = {
+  position: 'right' | 'left';
+  type: keyof typeof ICONS;
+};
+export type ButtonLinkProps = {
+  type?: 'primary' | 'secondary' | 'tertiary' | 'text' | 'dangerous';
+  label?: string;
+  'aria-label'?: string;
+  'data-name'?: string;
+  'data-testid'?: string;
+  icon?: IconType;
+  onClick?: () => void;
+  onKeyDown?: () => void;
+  link?: {
+    href?: string;
+    download?: boolean;
+    target?: '_self' | '_blank' | '_parent' | '_top';
+  };
+  disabled?: boolean;
+  className?: string;
+  customStyle?: Record<string, never>;
+  useTitle?: boolean;
+};
+
+export type Fixture = {props: ButtonLinkProps};
+
+export default propTypes;

--- a/packages/@coorpacademy-components/src/atom/button-menu/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-menu/index.tsx
@@ -1,10 +1,10 @@
 import React, {useMemo, useCallback} from 'react';
-import PropTypes from 'prop-types';
 import map from 'lodash/fp/map';
 import classnames from 'classnames';
 import style from './style.css';
+import propTypes, {ButtonMenuProps, ButtonProps, buttonPropTypes} from './types';
 
-const Button = props => {
+const Button = (props: ButtonProps) => {
   const {'data-name': dataName, disabled, label, onClick, type = 'default'} = props;
   const styleButton = classnames(
     style.button,
@@ -30,21 +30,16 @@ const Button = props => {
   );
 };
 
-Button.propTypes = {
-  'data-name': PropTypes.string,
-  disabled: PropTypes.bool,
-  label: PropTypes.string.isRequired,
-  onClick: PropTypes.func.isRequired,
-  type: PropTypes.oneOf(['default', 'dangerous'])
-};
+Button.propTypes = buttonPropTypes;
 
-const ButtonMenu = props => {
+const ButtonMenu = (props: ButtonMenuProps) => {
   const {buttons, 'data-name': dataName} = props;
   const buildButton = useCallback((button, index) => {
     return <Button {...button} key={button.label + index} />;
   }, []);
 
   const buttonList = useMemo(
+    // @ts-expect-error (to avoid using map as any)
     () => map.convert({cap: false})(buildButton, buttons),
     [buttons, buildButton]
   );
@@ -52,9 +47,6 @@ const ButtonMenu = props => {
   return <div data-name={dataName}>{buttonList}</div>;
 };
 
-ButtonMenu.propTypes = {
-  buttons: PropTypes.arrayOf(PropTypes.shape(Button.propTypes)).isRequired,
-  'data-name': PropTypes.string
-};
+ButtonMenu.propTypes = propTypes;
 
 export default ButtonMenu;

--- a/packages/@coorpacademy-components/src/atom/button-menu/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/atom/button-menu/test/fixtures/default.ts
@@ -1,21 +1,25 @@
-export const actionButtonProps = {
+import {ButtonProps, ButtonMenuPropsFixture} from '../../types';
+
+export const actionButtonProps: ButtonProps = {
   'data-name': 'menu-publish-button',
   label: 'Publish',
   onClick: () => console.log('Publish'),
   type: 'default'
 };
 
-export const deleteButtonProps = {
+export const deleteButtonProps: ButtonProps = {
   'data-name': 'menu-delete-button',
   label: 'Delete',
   onClick: () => console.log('Delete'),
   type: 'dangerous'
 };
 
-export default {
+const defaultFixture: ButtonMenuPropsFixture = {
   props: {
     buttons: [actionButtonProps, deleteButtonProps],
     'aria-label': 'aria button',
     'data-name': 'default-menu'
   }
 };
+
+export default defaultFixture;

--- a/packages/@coorpacademy-components/src/atom/button-menu/test/fixtures/multiple-buttons.ts
+++ b/packages/@coorpacademy-components/src/atom/button-menu/test/fixtures/multiple-buttons.ts
@@ -1,16 +1,19 @@
+import {ButtonProps, ButtonMenuPropsFixture} from '../../types';
 import {actionButtonProps, deleteButtonProps} from './default';
 
-export const disabledButtonProps = {
+export const disabledButtonProps: ButtonProps = {
   'data-name': 'menu-disabled-button',
   label: 'Disabled',
   onClick: () => console.log('Disabled'),
   disabled: true
 };
 
-export default {
+const defaultFixture: ButtonMenuPropsFixture = {
   props: {
     buttons: [actionButtonProps, disabledButtonProps, deleteButtonProps],
     'aria-label': 'aria button 2',
     'data-name': 'default-menu-2'
   }
 };
+
+export default defaultFixture;

--- a/packages/@coorpacademy-components/src/atom/button-menu/types.ts
+++ b/packages/@coorpacademy-components/src/atom/button-menu/types.ts
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+
+export const buttonPropTypes = {
+  'data-name': PropTypes.string,
+  disabled: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  type: PropTypes.oneOf(['default', 'dangerous'])
+};
+
+const propTypes = {
+  buttons: PropTypes.arrayOf(PropTypes.shape(buttonPropTypes)).isRequired,
+  'data-name': PropTypes.string
+};
+
+export default propTypes;
+
+export type ButtonProps = {
+  'data-name'?: string;
+  disabled?: boolean;
+  label: string;
+  onClick: () => void;
+  type?: 'default' | 'dangerous';
+};
+
+export type ButtonMenuProps = {
+  buttons: ButtonProps[];
+  'data-name'?: string;
+  'aria-label'?: string;
+};
+
+export type ButtonMenuPropsFixture = {props: ButtonMenuProps};

--- a/packages/@coorpacademy-components/src/atom/link/index.js
+++ b/packages/@coorpacademy-components/src/atom/link/index.js
@@ -91,6 +91,7 @@ Link.propTypes = {
   href: PropTypes.string,
   'data-name': PropTypes.string,
   'aria-label': PropTypes.string,
+  title: PropTypes.string,
   target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
   skinHover: PropTypes.bool,
   hoverColor: PropTypes.string,

--- a/packages/@coorpacademy-components/src/atom/status-item/style.css
+++ b/packages/@coorpacademy-components/src/atom/status-item/style.css
@@ -74,6 +74,7 @@
 .valid {
   opacity: 1;
   width: 24px;
+  min-width: 24px;
   height: 24px;
   background-color: cm_green_secondary_100;
 }
@@ -88,6 +89,7 @@
 .invalid {
   opacity: 1;
   width: 24px;
+  min-width: 24px;
   height: 24px;
   background-color: cm_negative_50;
 }
@@ -102,6 +104,7 @@
 .errorsNumber {
   opacity: 1;
   width: 24px;
+  min-width: 24px;
   height: 24px;
   background-color: cm_pink_50;
   color: cm_negative_100;

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/index.tsx
@@ -1,11 +1,20 @@
 import React, {useCallback} from 'react';
-import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import ButtonLinkIconOnly from '../../atom/button-link-icon-only';
 import ButtonMenu from '../../atom/button-menu';
+import propTypes, {BulletPointMenuButtonProps} from './types';
 import style from './style.css';
 
-const BulletPointMenuButton = props => {
-  const {disabled = false, buttonAriaLabel, menuAriaLabel, onClick, buttons} = props;
+const BulletPointMenuButton = (props: BulletPointMenuButtonProps) => {
+  const {
+    disabled = false,
+    buttonAriaLabel,
+    menuAriaLabel,
+    onClick,
+    buttons,
+    menuButtonClassName,
+    isBulkMenu
+  } = props;
   const handleOnClick = useCallback(() => onClick(), [onClick]);
 
   const menuProps = {
@@ -14,7 +23,11 @@ const BulletPointMenuButton = props => {
   };
 
   const menu = (
-    <div className={style.bulletPointMenu} data-name="menu-wrapper" aria-label={menuAriaLabel}>
+    <div
+      className={classnames(style.bulletPointMenu, isBulkMenu && style.bulkBulletPointMenu)}
+      data-name="menu-wrapper"
+      aria-label={menuAriaLabel}
+    >
       <ButtonMenu {...menuProps} />
     </div>
   );
@@ -24,7 +37,8 @@ const BulletPointMenuButton = props => {
     'data-name': 'bullet-point-button',
     icon: 'bullet-point',
     onClick: handleOnClick,
-    disabled
+    disabled,
+    className: menuButtonClassName
   };
 
   return (
@@ -35,12 +49,6 @@ const BulletPointMenuButton = props => {
   );
 };
 
-BulletPointMenuButton.propTypes = {
-  disabled: PropTypes.bool,
-  buttonAriaLabel: PropTypes.string,
-  menuAriaLabel: PropTypes.string,
-  buttons: ButtonMenu.propTypes.buttons,
-  onClick: PropTypes.func
-};
+BulletPointMenuButton.propTypes = propTypes;
 
 export default BulletPointMenuButton;

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/style.css
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/style.css
@@ -53,3 +53,23 @@ button:focus + .bulletPointMenu {
 */
 .bulletPointWrapper > button:focus { pointer-events: none; }
 .bulletPointWrapper > button:not(:focus) { pointer-events: auto; }
+
+/* 
+  bulk theme
+*/
+.bulkBulletPointMenu{
+  min-width: 80px;
+  /* positioning */
+  position: absolute;
+  align-self: flex-end;
+  bottom: 54px;
+  right: 0px;
+  /* elevation shadow */
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 12px 28px 0px, rgba(0, 0, 0, 0.1) 0px 2px 4px 0px, rgba(255, 255, 255, 0.05) 0px 0px 0px 1px inset;
+  z-index: 1;
+  /* round corners */
+  border-radius: 7px;
+  overflow: hidden;
+  background-color: cm_grey_100;
+  width: 142px;
+}

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/test/fixtures/default.ts
@@ -2,14 +2,16 @@ import {
   actionButtonProps,
   deleteButtonProps
 } from '../../../../atom/button-menu/test/fixtures/default';
+import {BulletPointMenuButtonPropsFixture} from '../../types';
 
-export default {
+const defaultFixture: BulletPointMenuButtonPropsFixture = {
   props: {
     buttonAriaLabel: 'aria button',
     menuAriaLabel: 'aria menu',
     buttons: [actionButtonProps, deleteButtonProps],
     onClick: () =>
-      console.log('click on bullet point button - test in a bigger component to see the menu'),
-    componentKey: 'bullet-key'
+      console.log('click on bullet point button - test in a bigger component to see the menu')
   }
 };
+
+export default defaultFixture;

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/test/fixtures/multiple-buttons.ts
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/test/fixtures/multiple-buttons.ts
@@ -4,12 +4,15 @@ import {
   deleteButtonProps
 } from '../../../../atom/button-menu/test/fixtures/default';
 import {disabledButtonProps} from '../../../../atom/button-menu/test/fixtures/multiple-buttons';
+import {BulletPointMenuButtonPropsFixture} from '../../types';
 import Default from './default';
 
 const {props} = Default;
 
-export default {
+const defaultFixture: BulletPointMenuButtonPropsFixture = {
   props: defaultsDeep(props, {
     buttons: [actionButtonProps, disabledButtonProps, deleteButtonProps]
   })
 };
+
+export default defaultFixture;

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/types.ts
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/types.ts
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import ButtonMenu from '../../atom/button-menu';
+import {ButtonProps} from '../../atom/button-menu/types';
+
+const propTypes = {
+  disabled: PropTypes.bool,
+  buttonAriaLabel: PropTypes.string,
+  menuAriaLabel: PropTypes.string,
+  buttons: ButtonMenu.propTypes.buttons,
+  onClick: PropTypes.func,
+  menuButtonClassName: PropTypes.string,
+  isBulkMenu: PropTypes.bool
+};
+
+export default propTypes;
+
+export type BulletPointMenuButtonProps = {
+  disabled?: boolean;
+  buttonAriaLabel?: string;
+  menuAriaLabel?: string;
+  buttons: ButtonProps[];
+  onClick: () => void;
+  menuButtonClassName?: string;
+  isBulkMenu?: boolean;
+};
+
+export type BulletPointMenuButtonPropsFixture = {props: BulletPointMenuButtonProps};

--- a/packages/@coorpacademy-components/src/molecule/empty-state-dashboard/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/empty-state-dashboard/index.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import ButtonLink from '../../atom/button-link';
 import style from './style.css';
-import {Props, propTypes} from './types';
+import {EmptyStateDashboardProps as Props, propTypes} from './types';
 
 const EmptyStateDashboard = ({mainText, subText, imageUrl, buttonLink}: Props) => (
   <div className={style.container}>
     <div>
-      <img className={style.img} src={imageUrl} aria-hidden="true" />
+      {imageUrl && typeof imageUrl === 'string' ? (
+        <img className={style.img} src={imageUrl} aria-hidden="true" />
+      ) : null}
     </div>
     <p className={style.mainText}>{mainText}</p>
     <p className={style.subText}>{subText}</p>

--- a/packages/@coorpacademy-components/src/molecule/empty-state-dashboard/types.ts
+++ b/packages/@coorpacademy-components/src/molecule/empty-state-dashboard/types.ts
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import {ButtonLinkProps} from '../../atom/button-link/types';
 import Picture from '../../atom/picture';
 
 export const propTypes = {
@@ -16,6 +17,13 @@ export const propTypes = {
     }),
     onClick: PropTypes.func
   })
+};
+
+export type EmptyStateDashboardProps = {
+  mainText: string;
+  subText: string;
+  imageUrl: PropTypes.InferProps<typeof Picture.propTypes.src>;
+  buttonLink: ButtonLinkProps;
 };
 
 export type Props = PropTypes.InferProps<typeof propTypes>;

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/index.tsx
@@ -1,0 +1,220 @@
+import React, {useState} from 'react';
+import classnames from 'classnames';
+import {get, isString, size, includes} from 'lodash/fp';
+import ButtonLinkIconOnly from '../../atom/button-link-icon-only';
+import StatusItem from '../../atom/status-item';
+import BulkProgressBar from '../bulk-progress-bar';
+import {WebContextValues} from '../../atom/provider/web-context';
+import Provider, {GetTranslateFromContext} from '../../atom/provider';
+import BulletPointMenuButton from '../bullet-point-menu-button';
+import ButtonLink from '../../atom/button-link';
+import ErrorsTable from '../errors-table';
+import style from './style.css';
+import {ExpandState, Field, LastField, NestedRow, Props, propTypes} from './types';
+
+const buildField = (field: Field) => {
+  if (isString(field)) return field;
+  const {componentType} = field;
+  switch (componentType) {
+    case 'status':
+      return <StatusItem {...field} />;
+    case 'progress-bar':
+      return <BulkProgressBar {...field} />;
+  }
+};
+
+const buildLastField = (lastField: LastField) => {
+  const {componentType} = lastField;
+  switch (componentType) {
+    case 'menu':
+      return <BulletPointMenuButton {...lastField} />;
+    case 'button-link':
+      return <ButtonLink {...lastField} />;
+  }
+};
+
+const buildNestedRow = (row: NestedRow) => {
+  const {componentType} = row;
+  switch (componentType) {
+    case 'errors-table':
+      return <ErrorsTable {...row} />;
+    case 'expandible-errors-table':
+      return <ActionableExpandableErrorsTable {...row} />;
+  }
+};
+
+const ActionableExpandableErrorsTable = (props: Props, legacyContext: WebContextValues) => {
+  const {
+    columns,
+    rows = [],
+    lastField,
+    stickyFirstColumn = false,
+    stickyLastColumn = false,
+    ariaDescribedby,
+    columnWidth = `${100 / size(columns)}%`,
+    isNestedTable = false
+  } = props;
+  const translate = GetTranslateFromContext(legacyContext);
+
+  /**
+   * State variable to keep track of all the expanded rows
+   * By default, nothing expanded. Hence initialized with empty array.
+   */
+  const [expandedRows, setExpandedRows] = useState<number[]>([]);
+
+  /**
+   * State variable to keep track which row is currently expanded.
+   */
+  const [expandState, setExpandState] = useState<ExpandState>({});
+
+  /**
+   * This function gets called when show/hide link is clicked.
+   */
+  const handleExpandRow = (index: number) => () => {
+    const isRowExpanded = includes(index, expandedRows);
+
+    /**
+     * If the row is expanded, we are here to hide it. Hence remove
+     * it from the state variable. Otherwise add to it.
+     */
+    const newExpandedRows = isRowExpanded
+      ? expandedRows.filter(id => id !== index)
+      : expandedRows.concat(index);
+
+    setExpandedRows(newExpandedRows);
+
+    /**
+     * Create a new object to update the expanded state of all rows
+     * Use the newExpandedRows array to set the state of all rows that are currently expanded
+     */
+    const expandedState: ExpandState = {};
+    newExpandedRows.forEach(id => {
+      expandedState[id] = true;
+    });
+
+    setExpandState(expandedState);
+  };
+
+  const headerRow = columns.map((column, cIndex) => {
+    const {title} = column;
+    return (
+      <th
+        className={
+          cIndex === 0
+            ? classnames(
+                stickyFirstColumn ? style.headerFirstSticky : style.headerFirst,
+                style.header
+              )
+            : style.header
+        }
+        key={`${title}-${cIndex}`}
+        role="columnheader"
+      >
+        {title}
+      </th>
+    );
+  });
+
+  headerRow.push(
+    <th
+      className={stickyLastColumn ? style.headerLastSticky : style.headerLast}
+      key="action-header"
+    />
+  );
+  const headerView = [...headerRow];
+
+  const bodyView = rows.map((row, index) => {
+    const {fields, isRowExpandible = false} = row;
+    const bodyRow = fields.map((field, fIndex) => {
+      const cellContent =
+        fIndex === 0 ? (
+          <div className={style.columFirstWrapper}>
+            <div className={style.expandButtonWrapper}>
+              {isRowExpandible ? (
+                <ButtonLinkIconOnly
+                  onClick={handleExpandRow(index)}
+                  data-name={`arrowUp-button-${index}`}
+                  icon="down"
+                  className={expandState[index] ? 'bulkArrowUp' : 'bulkArrowDown'}
+                  aria-label={translate('bulk_import.show_errors')}
+                />
+              ) : null}
+            </div>
+            {buildField(field)}
+          </div>
+        ) : (
+          buildField(field)
+        );
+      return (
+        <td
+          className={
+            fIndex === 0
+              ? classnames(
+                  stickyFirstColumn ? style.columnFirstSticky : style.columnFirst,
+                  style.col
+                )
+              : style.col
+          }
+          style={{width: columnWidth}}
+          key={`${field}-${fIndex}`}
+        >
+          {cellContent}
+        </td>
+      );
+    });
+
+    bodyRow.push(
+      <td
+        className={stickyLastColumn ? style.columnLastSticky : style.columnLast}
+        key="actionHeader"
+      >
+        {lastField ? (
+          <div
+            className={classnames({
+              [style.inspectButton]: get('className', lastField) === 'bulkInspectButton'
+            })}
+          >
+            {buildLastField(lastField)}
+          </div>
+        ) : null}
+      </td>
+    );
+    const nestedRow = get('nestedRow', row);
+    const nestedRowCellule =
+      nestedRow && expandedRows.includes(index) ? (
+        <tr key={`line-${index}-error`}>
+          <td className={style.nestedRowCellule} colSpan={fields.length + 2}>
+            {buildNestedRow(nestedRow)}
+          </td>
+        </tr>
+      ) : null;
+
+    return nestedRowCellule
+      ? [<tr key={`line-${index}`}>{bodyRow}</tr>, nestedRowCellule]
+      : [<tr key={`line-${index}`}>{bodyRow}</tr>];
+  });
+
+  return (
+    <div className={style.wrapper}>
+      <table
+        {...(ariaDescribedby ? {'aria-describedby': ariaDescribedby} : {})}
+        className={style.table}
+        data-name="expandible-actionable-table"
+      >
+        <thead className={isNestedTable ? style.theadNested : style.thead}>
+          <tr>{headerView}</tr>
+        </thead>
+        <tbody>{bodyView}</tbody>
+      </table>
+    </div>
+  );
+};
+
+ActionableExpandableErrorsTable.contextTypes = {
+  skin: Provider.childContextTypes.skin,
+  translate: Provider.childContextTypes.translate
+};
+
+ActionableExpandableErrorsTable.propTypes = propTypes;
+
+export default ActionableExpandableErrorsTable;

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/style.css
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/style.css
@@ -1,0 +1,134 @@
+@value colors: "../../variables/colors.css";
+@value xtraLightGrey from colors;
+@value cm_grey_400 from colors;
+@value cm_grey_700 from colors;
+@value cm_negative_red_200 from colors;
+@value light from colors;
+
+.wrapper {
+  width: 100%;
+}
+
+.table {
+  table-layout: fixed;  
+  border: 1px solid light;
+  font-family: 'Gilroy';
+  font-style: normal;
+  border-spacing: 0;
+  border-radius: 8px;
+  max-width: 1089px;
+  min-width: 1089px;
+}
+
+.thead {
+  background-color: xtraLightGrey;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 24px;
+  color: cm_grey_400;
+  height: 56px;
+  text-align: left; 
+}
+
+.theadNested {
+  background-color: xtraLightGrey;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 24px;
+  color: cm_grey_400;
+  height: 40px;
+  text-align: left; 
+}
+
+.header {
+  width: 276px;
+  padding-left: 56px;
+  box-sizing: border-box;
+  background-color: xtraLightGrey;
+}
+
+.headerFirstSticky {
+  position: sticky;
+  left: 0;
+  background-color: xtraLightGrey;
+}
+
+.headerFirst {
+  background-color: xtraLightGrey;
+}
+
+.headerLastSticky {
+  position: sticky;
+  right: 0;
+  background-color: xtraLightGrey;
+}
+
+.headerLast {
+  background-color: xtraLightGrey;
+}
+
+.col {
+  text-align: left; 
+  padding-top: 8px;
+  padding-bottom: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+  color: cm_grey_700;
+  border-top: 1px solid light;
+  padding-left: 56px;
+  max-width: 364px;
+}
+
+.columnFirst {
+  padding-left: 16px;
+  background-color: white;
+}
+
+.columnFirst .columFirstWrapper,
+.columnFirstSticky .columFirstWrapper {
+  display: flex;
+  justify-content: start;
+  gap: 16px;
+}
+
+.columnFirst .columFirstWrapper .expandButtonWrapper,
+.columnFirstSticky .columFirstWrapper .expandButtonWrapper {
+  min-width: 24px;
+}
+
+.columnFirstSticky {
+  position: sticky;
+  left: 0;
+  padding-left: 16px;
+  background-color: white;
+}
+
+.columnLast {
+  text-align: left; 
+  padding-top: 8px;
+  padding-bottom: 8px;
+  font-weight: 600; 
+  font-size: 14px;
+  line-height: 20px;
+  color: cm_grey_700;
+  border-top: 1px solid light;
+  display: flex;
+  justify-content: end;
+}
+
+.columnLastSticky {
+  composes: columnLast;
+  position: sticky;
+  right: 0;
+ }
+
+.inspectButton{
+  padding-right: 20px;
+  background-color: white;
+}
+
+.nestedRowCellule{
+padding: 10px;
+border-top: 1px solid light;  
+}

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/expandible-actionable-table.js
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/expandible-actionable-table.js
@@ -1,0 +1,41 @@
+import test from 'ava';
+import browserEnv from 'browser-env';
+import React from 'react';
+import {mount, configure} from 'enzyme';
+import {identity} from 'lodash/fp';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import ActionableExpandableErrorsTable from '..';
+import defaultFixture from './fixtures/dashboard-saved';
+
+browserEnv();
+configure({adapter: new Adapter()});
+const translate = identity;
+
+test('should launch onClick and toggle dropDown icon style and nested table', t => {
+  const wrapper = mount(<ActionableExpandableErrorsTable {...defaultFixture.props} />, {
+    context: {translate}
+  });
+  const clickEvent = {preventDefault: () => t.pass(), stopPropagation: () => t.pass()};
+
+  t.true(wrapper.find('[data-name="arrowUp-button-0"].bulkArrowDown').exists());
+  t.false(wrapper.find('[data-name="arrowUp-button-0"].bulkArrowUp').exists());
+  t.false(wrapper.find('table').at(1).exists());
+
+  wrapper.find('[data-name="arrowUp-button-0"].bulkArrowDown').simulate('click', clickEvent);
+  t.false(wrapper.find('[data-name="arrowUp-button-0"].bulkArrowDown').exists());
+  t.true(wrapper.find('[data-name="arrowUp-button-0"].bulkArrowUp').exists());
+  t.true(wrapper.find('table').at(1).exists());
+
+  wrapper.find('[data-name="arrowUp-button-0"].bulkArrowUp').simulate('click', clickEvent);
+  t.true(wrapper.find('[data-name="arrowUp-button-0"].bulkArrowDown').exists());
+  t.false(wrapper.find('[data-name="arrowUp-button-0"].bulkArrowUp').exists());
+  t.false(wrapper.find('table').at(1).exists());
+
+  wrapper.find('[data-name="arrowUp-button-1"].bulkArrowDown').simulate('click', clickEvent);
+  t.true(wrapper.find('table').at(1).exists());
+  t.true(wrapper.find('[data-name="arrowUp-button-1"].bulkArrowDown').exists());
+
+  wrapper.find('[data-name="arrowUp-button-1"].bulkArrowDown').simulate('click', clickEvent);
+  t.false(wrapper.find('[data-name="arrowUp-button-1"].bulkArrowDown').exists());
+  t.true(wrapper.find('[data-name="arrowUp-button-1"].bulkArrowUp').at(1).exists());
+});

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/dashboard-pending.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/dashboard-pending.ts
@@ -1,0 +1,76 @@
+import {LastField, Props} from '../../types';
+import {defaultProps as successBulkProgressBarProps} from '../../../bulk-progress-bar/test/fixtures/success';
+import {defaultProps as failBulkProgressBarProps} from '../../../bulk-progress-bar/test/fixtures/fail';
+import {defaultProps as inProgessBulkProgressBarProps} from '../../../bulk-progress-bar/test/fixtures/in-progress';
+
+const buttonLinkProps: LastField = {
+  className: 'bulkInspectButton',
+  label: 'Inspect',
+  'data-name': 'default-button',
+  'aria-label': 'aria button',
+  link: {
+    href: 'https://setup.coorpacademy.com/assets/templates/import-users-template.xlsx',
+    download: true
+  },
+  componentType: 'button-link'
+};
+type Fixture = {props: Props};
+const fixture: Fixture = {
+  props: {
+    columns: [{title: 'File name'}, {title: 'Download Status'}],
+    rows: [
+      {
+        fields: [
+          'BulkScorm1.zip',
+          {
+            ...successBulkProgressBarProps,
+            componentType: 'progress-bar'
+          }
+        ]
+      },
+      {
+        fields: [
+          'BulkScorm2.zip',
+          {
+            ...inProgessBulkProgressBarProps,
+            progress: 90,
+            componentType: 'progress-bar'
+          }
+        ]
+      },
+      {
+        fields: [
+          'BulkScorm3.zip',
+          {
+            ...inProgessBulkProgressBarProps,
+            progress: 70,
+            componentType: 'progress-bar'
+          }
+        ]
+      },
+      {
+        fields: [
+          'BulkScorm4.zip',
+          {
+            ...inProgessBulkProgressBarProps,
+            progress: 23,
+            componentType: 'progress-bar'
+          }
+        ]
+      },
+      {
+        fields: [
+          'BulkScorm5.zip',
+          {
+            ...failBulkProgressBarProps,
+            componentType: 'progress-bar'
+          }
+        ]
+      }
+    ],
+    columnWidth: '220px',
+    lastField: {...buttonLinkProps},
+    ariaDescribedby: 'description-id'
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/dashboard-saved.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/dashboard-saved.ts
@@ -1,0 +1,92 @@
+import {Props} from '../../types';
+import validTableOfErrors from './inspect-all-valid';
+import validAndInvalidTableOfErrors from './inspect-valid-invalid';
+
+type Fixture = {props: Props};
+const fixture: Fixture = {
+  props: {
+    columns: [
+      {
+        title: 'File name'
+      },
+      {
+        title: 'Author'
+      },
+      {
+        title: 'Creation Date'
+      },
+      {
+        title: 'Total files'
+      },
+      {
+        title: 'Total Errors'
+      }
+    ],
+    rows: [
+      {
+        fields: [
+          'Import1.zip',
+          'Coorpacademy',
+          '22/10/2022',
+          '3',
+          {
+            icon: 'errors-number',
+            value: '0',
+            componentType: 'status'
+          }
+        ],
+        nestedRow: {
+          ...validTableOfErrors.props,
+          componentType: 'expandible-errors-table',
+          isNestedTable: true
+        },
+        isRowExpandible: true
+      },
+      {
+        fields: [
+          'Import2.zip',
+          'Coorpacademy',
+          '22/10/2022',
+          '3',
+          {
+            icon: 'errors-number',
+            value: '1',
+            componentType: 'status'
+          }
+        ],
+        nestedRow: {
+          ...validAndInvalidTableOfErrors.props,
+          componentType: 'expandible-errors-table',
+          isNestedTable: true
+        },
+        isRowExpandible: true
+      }
+    ],
+    stickyFirstColumn: true,
+    stickyLastColumn: true,
+    ariaDescribedby: 'description-id',
+    lastField: {
+      buttonAriaLabel: 'aria button',
+      menuAriaLabel: 'aria menu',
+      buttons: [
+        {
+          'data-name': 'CP-publish-button',
+          label: 'Download Report',
+          type: 'default',
+          onClick: () => console.log('click Download Report')
+        },
+        {
+          'data-name': 'CP-delete-button',
+          label: 'Redownload files',
+          type: 'default',
+          onClick: () => console.log('click on Redownload files')
+        }
+      ],
+      onClick: () => console.log('click on menu'),
+      menuButtonClassName: 'bulkBulletButton',
+      isBulkMenu: true,
+      componentType: 'menu'
+    }
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/empty.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/empty.ts
@@ -1,0 +1,25 @@
+import {Props} from '../../types';
+
+type Fixture = {props: Props};
+const fixture: Fixture = {
+  props: {
+    columns: [
+      {
+        title: 'File name'
+      },
+      {
+        title: 'Author'
+      },
+      {
+        title: 'Creation Date'
+      },
+      {
+        title: 'Total files'
+      },
+      {
+        title: 'Total Errors'
+      }
+    ]
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/inspect-all-valid.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/inspect-all-valid.ts
@@ -1,0 +1,40 @@
+import {Props} from '../../types';
+
+type Fixture = {props: Props};
+const fixture: Fixture = {
+  props: {
+    columns: [{title: 'File name'}, {title: 'Status'}],
+    rows: [
+      {
+        fields: [
+          'Scorm1.zip',
+          {
+            icon: 'valid',
+            componentType: 'status'
+          }
+        ]
+      },
+      {
+        fields: [
+          'Scorm2.zip',
+          {
+            icon: 'valid',
+            componentType: 'status'
+          }
+        ]
+      },
+      {
+        fields: [
+          'Scorm3.zip',
+          {
+            icon: 'valid',
+            componentType: 'status'
+          }
+        ]
+      }
+    ],
+    columnWidth: '20%',
+    ariaDescribedby: 'description-id'
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/inspect-valid-invalid.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/inspect-valid-invalid.ts
@@ -1,0 +1,46 @@
+import {Props} from '../../types';
+import tableOfErrors from '../../../errors-table/test/fixtures/default';
+
+type Fixture = {props: Props};
+const fixture: Fixture = {
+  props: {
+    columns: [{title: 'File name'}, {title: 'Status'}],
+    rows: [
+      {
+        fields: [
+          'Scorm1.zip',
+          {
+            icon: 'valid',
+            componentType: 'status'
+          }
+        ]
+      },
+      {
+        fields: [
+          'Scorm2.zip',
+          {
+            icon: 'invalid',
+            componentType: 'status'
+          }
+        ],
+        nestedRow: {
+          ...tableOfErrors.props,
+          componentType: 'errors-table'
+        },
+        isRowExpandible: true
+      },
+      {
+        fields: [
+          'Scorm3.zip',
+          {
+            icon: 'valid',
+            componentType: 'status'
+          }
+        ]
+      }
+    ],
+    columnWidth: '20%',
+    ariaDescribedby: 'description-id'
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/types.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/types.ts
@@ -1,0 +1,101 @@
+import PropTypes from 'prop-types';
+import StatusItem from '../../atom/status-item';
+import ButtonLink from '../../atom/button-link';
+import BulletPointMenuButton from '../bullet-point-menu-button';
+import {BulletPointMenuButtonProps} from '../bullet-point-menu-button/types';
+import {ButtonLinkProps} from '../../atom/button-link/types';
+import {StatusItemProps} from '../../atom/status-item/types';
+import {Props as ErrorsTableProps} from '../errors-table/types';
+import {Props as BulkProgressBarProps} from '../bulk-progress-bar/types';
+
+const columnProptypes = PropTypes.shape({
+  title: PropTypes.string.isRequired
+});
+
+const rowProptypes = PropTypes.shape({
+  fields: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        ...StatusItem.propTypes,
+        type: PropTypes.oneOf(['status'])
+      })
+    ])
+  ),
+  isRowExpandible: PropTypes.bool,
+  lastField: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      ...BulletPointMenuButton.propTypes,
+      type: PropTypes.oneOf(['menu'])
+    })
+  ])
+});
+
+export const propTypes = {
+  columns: PropTypes.arrayOf(columnProptypes),
+  rows: PropTypes.arrayOf(rowProptypes),
+  stickyFirstColumn: PropTypes.bool,
+  stickyLastColumn: PropTypes.bool,
+  columnWidth: PropTypes.string,
+  ariaDescribedby: PropTypes.string,
+  lastField: PropTypes.oneOfType([
+    PropTypes.shape({
+      ...ButtonLink.propTypes,
+      componentType: PropTypes.oneOf(['button-link'])
+    }),
+    PropTypes.shape({
+      ...BulletPointMenuButton.propTypes,
+      componentType: PropTypes.oneOf(['menu'])
+    })
+  ]),
+  isNestedTable: PropTypes.bool
+};
+
+export type Field =
+  | string
+  | (StatusItemProps & {
+      componentType: 'status';
+    })
+  | (BulkProgressBarProps & {
+      componentType: 'progress-bar';
+    });
+
+export type LastField =
+  | (ButtonLinkProps & {
+      componentType: 'button-link';
+    })
+  | (BulletPointMenuButtonProps & {
+      componentType: 'menu';
+    });
+
+export type NestedRow =
+  | (ErrorsTableProps & {
+      componentType: 'errors-table';
+    })
+  | (Props & {
+      componentType: 'expandible-errors-table';
+    });
+
+export type Column = {title: string};
+export type Row = {
+  fields: Field[];
+
+  nestedRow?: NestedRow;
+  isRowExpandible?: boolean;
+};
+export type Columns = Column[];
+export type Rows = Row[];
+
+export type Props = {
+  columns: Columns;
+  rows?: Rows;
+  stickyFirstColumn?: boolean;
+  stickyLastColumn?: boolean;
+  columnWidth?: `${number}${'px' | '%'}`;
+  ariaDescribedby?: string;
+  lastField?: LastField;
+  isNestedTable?: boolean;
+};
+
+export type ExpandState = {[key: number]: boolean};

--- a/packages/@coorpacademy-components/src/molecule/uploading-file-progress/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/uploading-file-progress/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ButtonLink from '../../atom/button-link';
 import Loader from '../../atom/loader';
 import style from './style.css';
-import {Props, propTypes} from './types';
+import {UploadingFileProgressProps as Props, propTypes} from './types';
 
 const UploadingFileProgress = ({
   mainText,

--- a/packages/@coorpacademy-components/src/molecule/uploading-file-progress/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/molecule/uploading-file-progress/test/fixtures/default.ts
@@ -1,4 +1,4 @@
-import {Props} from '../../types';
+import {UploadingFileProgressProps as Props} from '../../types';
 
 type Fixture = {props: Props};
 const fixture: Fixture = {
@@ -10,15 +10,15 @@ const fixture: Fixture = {
     leftButtonLink: {
       type: 'secondary',
       label: 'Create New Import',
-      ariaLabel: 'Create New Import',
-      dataName: 'default-button',
+      'aria-label': 'Create New Import',
+      'data-name': 'default-button',
       onClick: () => console.log('click')
     },
     rightButtonLink: {
       type: 'primary',
       label: 'Go to Dashboard',
-      ariaLabel: 'Go to Dashboard',
-      dataName: 'default-button',
+      'aria-label': 'Go to Dashboard',
+      'data-name': 'default-button',
       onClick: () => console.log('click')
     }
   }

--- a/packages/@coorpacademy-components/src/molecule/uploading-file-progress/types.ts
+++ b/packages/@coorpacademy-components/src/molecule/uploading-file-progress/types.ts
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import {ButtonLinkProps} from '../../atom/button-link/types';
 import Picture from '../../atom/picture';
 
 export const propTypes = {
@@ -30,4 +31,11 @@ export const propTypes = {
   })
 };
 
-export type Props = PropTypes.InferProps<typeof propTypes>;
+export type UploadingFileProgressProps = {
+  mainText?: string;
+  subText?: string;
+  imageUrl?: PropTypes.InferProps<typeof Picture.propTypes.src>;
+  progressionValue?: number;
+  leftButtonLink?: ButtonLinkProps;
+  rightButtonLink?: ButtonLinkProps;
+};

--- a/packages/@coorpacademy-components/src/organism/list-items/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/index.js
@@ -3,14 +3,34 @@ import PropTypes from 'prop-types';
 import ListItem from '../list-item';
 import Title from '../../atom/title';
 import ButtonLink from '../../atom/button-link';
+import ExpandibleActionableTable from '../../molecule/expandible-actionable-table';
 import style from './style.css';
 
-const ListItems = ({title, buttonLink, items, 'aria-label': ariaLabel, contentType}) => {
+const buildListItemsView = (content, ariaLabel) => {
+  const {items, itemType} = content;
   const itemsView = items.map((item, index) => (
     <li key={item.id} className={style.item} data-name={`content-${index}`}>
-      <ListItem {...item} order={index} contentType={contentType} />
+      <ListItem {...item} order={index} contentType={itemType} />
     </li>
   ));
+  return (
+    <ul className={style.list} aria-label={ariaLabel} data-name={'content-list'}>
+      {itemsView}
+    </ul>
+  );
+};
+const buildContentView = (content, ariaLabel) => {
+  const {type} = content;
+  switch (type) {
+    case 'list':
+      return buildListItemsView(content, ariaLabel);
+    case 'expandible-actionable-table':
+      return <ExpandibleActionableTable {...content} />;
+  }
+};
+
+const ListItems = ({title, buttonLink, content, 'aria-label': ariaLabel}) => {
+  const contentView = buildContentView(content, ariaLabel);
 
   return (
     <div>
@@ -22,9 +42,7 @@ const ListItems = ({title, buttonLink, items, 'aria-label': ariaLabel, contentTy
           <ButtonLink {...buttonLink} />
         </div>
       </div>
-      <ul className={style.list} aria-label={ariaLabel} data-name={'content-list'}>
-        {itemsView}
-      </ul>
+      {contentView}
     </div>
   );
 };
@@ -33,8 +51,18 @@ ListItems.propTypes = {
   'aria-label': PropTypes.string,
   buttonLink: PropTypes.shape(ButtonLink.propTypes),
   items: PropTypes.arrayOf(PropTypes.shape(ListItem.propTypes)),
-  title: PropTypes.string,
-  contentType: PropTypes.string
+  content: PropTypes.oneOfType([
+    PropTypes.shape({
+      items: PropTypes.arrayOf(PropTypes.shape(ListItem.propTypes)),
+      type: PropTypes.oneOf(['list']),
+      itemType: PropTypes.string
+    }),
+    PropTypes.shape({
+      ...ExpandibleActionableTable.propTypes,
+      type: PropTypes.oneOf(['expandible-actionable-table'])
+    })
+  ]),
+  title: PropTypes.string
 };
 
 export default ListItems;

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/archived.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/archived.js
@@ -19,6 +19,6 @@ export default {
       'data-name': 'default-button',
       onClick: () => console.log('click')
     },
-    items: listeItems
+    content: {items: listeItems, type: 'list'}
   }
 };

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/bulk-imports-saved.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/bulk-imports-saved.js
@@ -1,0 +1,17 @@
+import ExpandibleActionableTable from '../../../../molecule/expandible-actionable-table/test/fixtures/dashboard-saved';
+
+const {props: ExpandibleActionableTableProps} = ExpandibleActionableTable;
+
+export default {
+  props: {
+    title: `${ExpandibleActionableTableProps.rows.length} massive imports`,
+    buttonLink: {
+      type: 'primary',
+      label: 'Import files',
+      'aria-label': 'aria button',
+      'data-name': 'default-button',
+      onClick: () => console.log('click')
+    },
+    content: {...ExpandibleActionableTableProps, type: 'expandible-actionable-table'}
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/draft.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/draft.js
@@ -19,6 +19,6 @@ export default {
       'data-name': 'default-button',
       onClick: () => console.log('click')
     },
-    items: listeItems
+    content: {items: listeItems, type: 'list'}
   }
 };

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/published-certification.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/published-certification.js
@@ -22,6 +22,6 @@ export default {
       'data-name': 'default-button',
       onClick: () => console.log('click')
     },
-    items: [...listePublishedItems, propsRevised]
+    content: {items: [...listePublishedItems, propsRevised], type: 'list'}
   }
 };

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/published.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/published.js
@@ -22,6 +22,6 @@ export default {
       'data-name': 'default-button',
       onClick: () => console.log('click')
     },
-    items: [...listePublishedItems, propsRevised]
+    content: {items: [...listePublishedItems, propsRevised], type: 'list'}
   }
 };

--- a/packages/@coorpacademy-components/src/organism/wizard-contents/index.js
+++ b/packages/@coorpacademy-components/src/organism/wizard-contents/index.js
@@ -11,6 +11,7 @@ import OrganismSearchAndChipsResults from '../search-and-chips-results';
 import CourseSelection from '../course-selection';
 import CourseSections from '../../molecule/course-sections';
 import RewardsForm from '../rewards-form';
+import ExpandibleActionableErrorsTable from '../../molecule/expandible-actionable-table';
 import style from './style.css';
 
 const buildHeader = (wizardHeader, steps) => {
@@ -52,6 +53,8 @@ const buildForm = content => {
       return <CourseSections {...content} />;
     case 'rewards':
       return <RewardsForm {...content} />;
+    case 'expandible-table':
+      return <ExpandibleActionableErrorsTable {...content} />;
   }
 };
 
@@ -185,6 +188,10 @@ WizardContents.propTypes = {
     PropTypes.shape({
       ...RewardsForm.propTypes,
       type: PropTypes.oneOf(['rewards'])
+    }),
+    PropTypes.shape({
+      ...ExpandibleActionableErrorsTable.propTypes,
+      type: PropTypes.oneOf(['expandible-table'])
     })
   ]),
   previousStep: PropTypes.shape({

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
@@ -23,6 +23,7 @@ import CmPopin from '../../../molecule/cm-popin';
 import ButtonLinkIconOnly from '../../../atom/button-link-icon-only';
 import EmptyStateDashboard from '../../../molecule/empty-state-dashboard';
 import UploadingFileProgress from '../../../molecule/uploading-file-progress';
+import ExpandibleActionableTable from '../../../molecule/expandible-actionable-table';
 import style from './style.css';
 
 const getStyle = isSelected => (isSelected ? style.selectedElement : style.unselectedElement);
@@ -166,15 +167,19 @@ const buildContentView = content => {
     case 'analytics-dashboards':
       return <BrandAnalytics {...content} />;
     case 'list-content':
+    case 'expandible-actionable-table':
       return <ListItems {...content} />;
     case 'home':
       return <BrandDashboard {...content} />;
     case 'wizard':
+    case 'expandible-table':
       return <WizardContents {...content} />;
     case 'empty-state-dashboard':
       return <EmptyStateDashboard {...content} />;
     case 'uploading-file-progress':
       return <UploadingFileProgress {...content} />;
+    case 'table-pending':
+      return <ExpandibleActionableTable {...content} />;
   }
 };
 
@@ -300,8 +305,7 @@ BrandUpdate.propTypes = {
     PropTypes.shape({
       ...ListItems.propTypes,
       key: PropTypes.string,
-      type: PropTypes.oneOf(['list-content']),
-      contentType: PropTypes.string
+      type: PropTypes.oneOf(['list-content', 'expandible-actionable-table'])
     }),
     PropTypes.shape({
       ...EmptyStateDashboard.propTypes,
@@ -312,6 +316,20 @@ BrandUpdate.propTypes = {
       ...UploadingFileProgress.propTypes,
       key: PropTypes.string,
       type: PropTypes.oneOf(['uploading-file-progress'])
+    }),
+    PropTypes.shape({
+      ...ExpandibleActionableTable.propTypes,
+      key: PropTypes.string,
+      type: PropTypes.oneOf(['table-pending'])
+    }),
+    PropTypes.shape({
+      ...WizardContents.propTypes,
+      content: PropTypes.shape({
+        ...ExpandibleActionableTable.propTypes,
+        ...WizardContents.propTypes.content.propTypes
+      }),
+      key: PropTypes.string,
+      type: PropTypes.oneOf(['expandible-table'])
     })
   ]),
   documentation: PropTypes.shape({

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/bulk-dashboard-imports-pending.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/bulk-dashboard-imports-pending.js
@@ -1,0 +1,99 @@
+import {defaultsDeep, cloneDeep} from 'lodash/fp';
+import bulkPending from '../../../../../molecule/expandible-actionable-table/test/fixtures/dashboard-pending';
+
+import Default from './default';
+
+const props = cloneDeep(Default.props);
+
+props.items = [
+  {
+    title: 'My Dashboard',
+    key: 'dashboard',
+    href: '#brand/samsung/dashboard',
+    open: undefined,
+    selected: false,
+    type: 'simpleTab'
+  },
+  {
+    title: 'Administration',
+    key: 'administration',
+    href: '#brand/samsung/administration',
+    open: false,
+    selected: false,
+    type: 'collapsibleTab'
+  },
+  {
+    title: 'Editorialization',
+    key: 'editorialization',
+    href: '#brand/samsung/editorialization',
+    type: 'collapsibleTab',
+    open: false,
+    selected: false
+  },
+  {
+    title: 'Content Creation',
+    key: 'contentCreation',
+    href: '#brand/samsung/content-creation',
+    isOpen: true,
+    selected: true,
+    type: 'collapsibleTab',
+    tabs: [
+      {title: 'Go to Cockpit', href: '#/cockpit', selected: false, type: 'iconLink'},
+      {
+        title: 'Bulk Import',
+        href: '#/external-content',
+        selected: true,
+        subTabs: [
+          {
+            title: 'Saved',
+            href: '#/external-content/saved',
+            name: 'saved-imports',
+            permissions: ['list-saved-imports'],
+            selected: false,
+            type: 'simpleTab'
+          },
+          {
+            title: 'Pending',
+            href: '#/external-content/pending',
+            name: 'pending-imports',
+            permissions: ['list-pending-imports'],
+            selected: true,
+            type: 'simpleTab'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    title: 'Animation',
+    key: 'animation',
+    href: '#brand/samsung/content-creation',
+    selected: false,
+    isOpen: true,
+    type: 'collapsibleTab'
+  },
+  {
+    title: 'Analytics',
+    key: 'analytics',
+    href: '#brand/samsung/analytics',
+    open: false,
+    selected: false,
+    type: 'collapsibleTab',
+    tabs: [
+      {title: 'SSO', href: '#/sso', selected: false, type: 'iconLink'},
+      {title: 'Look and Feel', href: '#/look-and-feel', selected: false},
+      {title: 'Settings', href: '#/settings', selected: false},
+      {title: 'Any', href: '#/any', selected: false},
+      {title: 'Many', href: '#/many', selected: false}
+    ]
+  }
+];
+
+export default {
+  props: defaultsDeep(props, {
+    content: {
+      ...bulkPending.props,
+      type: 'table-pending'
+    }
+  })
+};

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/bulk-dashboard-imports-saved.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/bulk-dashboard-imports-saved.js
@@ -1,0 +1,98 @@
+import {defaultsDeep, cloneDeep} from 'lodash/fp';
+import ExpandibleActionableTable from '../../../../../organism/list-items/test/fixtures/bulk-imports-saved';
+import Default from './default';
+
+const props = cloneDeep(Default.props);
+const listItemsProps = ExpandibleActionableTable.props;
+props.items = [
+  {
+    title: 'My Dashboard',
+    key: 'dashboard',
+    href: '#brand/samsung/dashboard',
+    open: undefined,
+    selected: false,
+    type: 'simpleTab'
+  },
+  {
+    title: 'Administration',
+    key: 'administration',
+    href: '#brand/samsung/administration',
+    open: false,
+    selected: false,
+    type: 'collapsibleTab'
+  },
+  {
+    title: 'Editorialization',
+    key: 'editorialization',
+    href: '#brand/samsung/editorialization',
+    type: 'collapsibleTab',
+    open: false,
+    selected: false
+  },
+  {
+    title: 'Content Creation',
+    key: 'contentCreation',
+    href: '#brand/samsung/content-creation',
+    isOpen: true,
+    selected: true,
+    type: 'collapsibleTab',
+    tabs: [
+      {title: 'Go to Cockpit', href: '#/cockpit', selected: false, type: 'iconLink'},
+      {
+        title: 'Bulk Import',
+        href: '#/external-content',
+        selected: true,
+        subTabs: [
+          {
+            title: 'Saved',
+            href: '#/external-content/saved',
+            name: 'saved-imports',
+            permissions: ['list-saved-imports'],
+            selected: true,
+            type: 'simpleTab'
+          },
+          {
+            title: 'Pending',
+            href: '#/external-content/pending',
+            name: 'pending-imports',
+            permissions: ['list-pending-imports'],
+            selected: false,
+            type: 'simpleTab'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    title: 'Animation',
+    key: 'animation',
+    href: '#brand/samsung/content-creation',
+    selected: false,
+    isOpen: true,
+    type: 'collapsibleTab'
+  },
+  {
+    title: 'Analytics',
+    key: 'analytics',
+    href: '#brand/samsung/analytics',
+    open: false,
+    selected: false,
+    type: 'collapsibleTab',
+    tabs: [
+      {title: 'SSO', href: '#/sso', selected: false, type: 'iconLink'},
+      {title: 'Look and Feel', href: '#/look-and-feel', selected: false},
+      {title: 'Settings', href: '#/settings', selected: false},
+      {title: 'Any', href: '#/any', selected: false},
+      {title: 'Many', href: '#/many', selected: false}
+    ]
+  }
+];
+
+export default {
+  props: defaultsDeep(props, {
+    content: {
+      ...listItemsProps,
+      type: 'expandible-actionable-table'
+    }
+  })
+};

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/bulk-inspect.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/bulk-inspect.js
@@ -1,0 +1,114 @@
+import BulkInspect from '../../../../../molecule/expandible-actionable-table/test/fixtures/inspect-valid-invalid';
+import headerAndMenu from './default';
+
+const {header} = headerAndMenu.props;
+const items = [
+  {
+    title: 'My Dashboard',
+    key: 'dashboard',
+    href: '#brand/samsung/dashboard',
+    open: undefined,
+    selected: false,
+    type: 'simpleTab'
+  },
+  {
+    title: 'Administration',
+    key: 'administration',
+    href: '#brand/samsung/administration',
+    open: false,
+    selected: false,
+    type: 'collapsibleTab'
+  },
+  {
+    title: 'Editorialization',
+    key: 'editorialization',
+    href: '#brand/samsung/editorialization',
+    type: 'collapsibleTab',
+    open: false,
+    selected: false
+  },
+  {
+    title: 'Content Creation',
+    key: 'contentCreation',
+    href: '#brand/samsung/content-creation',
+    isOpen: true,
+    selected: true,
+    type: 'collapsibleTab',
+    tabs: [
+      {title: 'Go to Cockpit', href: '#/cockpit', selected: false, type: 'iconLink'},
+      {title: 'Bulk Import', href: '#/external-content', selected: true}
+    ]
+  },
+  {
+    title: 'Animation',
+    key: 'animation',
+    href: '#brand/samsung/content-creation',
+    selected: false,
+    isOpen: true,
+    type: 'collapsibleTab'
+  },
+  {
+    title: 'Analytics',
+    key: 'analytics',
+    href: '#brand/samsung/analytics',
+    open: false,
+    selected: false,
+    type: 'collapsibleTab',
+    tabs: [
+      {title: 'SSO', href: '#/sso', selected: false, type: 'iconLink'},
+      {title: 'Look and Feel', href: '#/look-and-feel', selected: false},
+      {title: 'Settings', href: '#/settings', selected: false},
+      {title: 'Any', href: '#/any', selected: false},
+      {title: 'Many', href: '#/many', selected: false}
+    ]
+  }
+];
+
+const contentSteps = [
+  {
+    title: 'Import',
+    done: true
+  },
+  {
+    title: 'Inspect',
+    done: false,
+    current: true
+  }
+];
+const wizardHeader = {
+  title: 'Massive Import',
+  onClick: function onClick() {
+    return console.log('Close');
+  }
+};
+
+const notifications = [
+  {
+    type: 'warning',
+    message:
+      '1 file out of 3 failed, you can still save the rest of the content. The files in error will be ignored. You will be able to correct them via a subsequent re-upload',
+    firstCTALabel: 'Download report',
+    firstCTA: function firstCTA() {
+      return console.log('first cta');
+    }
+  }
+];
+
+export default {
+  props: {
+    header,
+    items,
+    content: {
+      content: {
+        type: 'expandible-table',
+        ...BulkInspect.props
+      },
+      steps: contentSteps,
+      wizardHeader,
+      key: 'expandible-table',
+      type: 'expandible-table'
+    },
+    notifications,
+    contentFixHeight: true
+  }
+};

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/list-items-certification-published.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/list-items-certification-published.js
@@ -69,7 +69,7 @@ export default {
     content: {
       ...listItemsCertificationProps,
       type: 'list-content',
-      contentType: 'certification'
+      itemType: 'certification'
     }
   })
 };


### PR DESCRIPTION
[ticket](https://trello.com/c/YbO0HtBE/1188-composant-inspect-post-progress-100) 
Actionnable errors table is a component that would be used on bulk tables. and is built using errors table already created.
(in the future, a nice to have is to integrate errors table support in the expandible actionable table)

Purpose of the PR:

- create expandible actionnable errors table.
- update wizardContents to support expandible actionnable errors table
- update listItems to support expandible  actionnable errors table
- add expandible actionnable errors table to brandUpdate
- create bulk inspect fixtures
- create bulk dashboard saved fixtures
- create bulk dashboard pending fixtures
- expandible  actionnable errors table  test coverage 100%
- update some components from js to ts 

How to review : 
big part of changes is just converting some components from js to ts (with very small changes) :

- button-link 
- button-menu
- bullet-point-menu-button

the other changes concern bulk tables.

this PR  and the  [previous one](https://github.com/CoorpAcademy/components/pull/2665)  comparison: 

- this PR has only one table component (expandible actionnable errors table) that manages bulk tables (dashboard saved - dashboard pending - inspect ... except errors table). and it takes all the previous one's reviews
- the other one has two table components that manage bulk tables (expandible actionnable errors table && expandible) errors table. and it needed an other component table (bulk pending) to be created 

**inspect - table  :**
![Pasted Graphic 32](https://user-images.githubusercontent.com/111736786/220517318-236d3979-d6ef-4909-a760-2b25195fe3b8.png)

![Pasted Graphic 33](https://user-images.githubusercontent.com/111736786/220517346-95a7af0e-c61a-419a-8692-9bb7820fd510.png)

![Pasted Graphic 34](https://user-images.githubusercontent.com/111736786/220517365-1b869e1d-5684-4fa0-8af4-8311af1ff3e0.png)

brandUpdate Template bulk inspect: 
![image](https://user-images.githubusercontent.com/111736786/222289348-a25f231b-0c42-416a-9dd1-3378f31e626e.png)

**dashboard / saved :** 
![image](https://user-images.githubusercontent.com/111736786/221755361-d9d47b2f-9b38-4d6d-bbb7-94f3f704ccf8.png)
![image](https://user-images.githubusercontent.com/111736786/221755398-633fa84a-8ad0-400b-9f04-0d95aa141fae.png)
![image](https://user-images.githubusercontent.com/111736786/221755430-3bd2c50c-1b90-4cc6-9098-fefe022d826b.png)
![image](https://user-images.githubusercontent.com/111736786/221755457-218214bd-326a-4cd6-88ed-4f4a83e08275.png)

**Action menu:**
![image](https://user-images.githubusercontent.com/111736786/221755520-0876cbaa-03cb-494a-bb79-d24f6cdd4068.png)

**sticky columns when scrolling horizontally:**
![image](https://user-images.githubusercontent.com/111736786/221755614-877d15db-cad6-4707-82ee-ad6e06a8a04c.png)
![image](https://user-images.githubusercontent.com/111736786/221755673-7b4bacd8-f034-4b7d-baeb-24d468c43310.png)

![image](https://user-images.githubusercontent.com/111736786/222627322-7ddcb8a8-385a-4c9d-9347-e4c6f17c7f0c.png)

**dashboard / pending**
![image](https://user-images.githubusercontent.com/111736786/223605380-2a24063a-ca16-46c1-9f70-976147528c29.png)
![image](https://user-images.githubusercontent.com/111736786/223605489-fa8b8187-1a8f-437b-999e-8714a98f2028.png)
