### PR TITLE
using flexGrow to allow both centering and scrolling

### DIFF
--- a/packages/@coorpacademy-components/src/organism/review-slide/index.native.tsx
+++ b/packages/@coorpacademy-components/src/organism/review-slide/index.native.tsx
@@ -159,6 +159,7 @@ const createQuestionStyle = (theme: Theme): StyleSheetType =>
       width: '100%'
     },
     choicesScrollContent: {
+      flexGrow: 1,
       justifyContent: 'space-around',
       padding: 10
     }
@@ -202,15 +203,7 @@ const Question = (props: QuestionProps) => {
       </View>
       <ScrollView
         style={style.choicesScrollView}
-        contentContainerStyle={[
-          style.choicesScrollContent,
-          isKeyboardVisible
-            ? {
-                flex: 1
-              }
-            : null
-        ]}
-        centerContent
+        contentContainerStyle={style.choicesScrollContent}
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
       >
@@ -219,7 +212,6 @@ const Question = (props: QuestionProps) => {
         ) : null}
         <View
           style={{
-            flex: isKeyboardVisible ? 1 : 0,
             marginTop: hasVideoOrImage ? 30 : 0
           }}
         >


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Issue:**

new layout [to fix scrolling](https://github.com/CoorpAcademy/components) disabled the centering on android....

- `flex: 1` allows centering and cause issue with scrolling
- removing `flex: 1` allows scrolling but breaks android centering
- `centerContent` works for [iOS only](https://reactnative.dev/docs/scrollview#centercontent-ios)

**Fix:**

using `flexGrow:1` allows [centering + scrolling everywhere](https://stackoverflow.com/a/43227730/959219) .....