### PR TITLE
[review] handle local on post answer

### DIFF
--- a/packages/@coorpacademy-review-services/src/index.ts
+++ b/packages/@coorpacademy-review-services/src/index.ts
@@ -45,7 +45,7 @@ export const getServices = (locale: string | void): Services => ({
   fetchSkills: fetchSkills(locale),
   fetchSlide: fetchSlide(locale),
   fetchSlidesToReviewBySkillRef,
-  postAnswer,
+  postAnswer: postAnswer(locale),
   postProgression
 });
 

--- a/packages/@coorpacademy-review-services/src/post-answer.ts
+++ b/packages/@coorpacademy-review-services/src/post-answer.ts
@@ -3,26 +3,30 @@ import decode from 'jwt-decode';
 
 import {JWT, ProgressionFromAPI} from './types/services-types';
 import {toJSON} from './tools/fetch-responses';
+import {buildURL} from './tools';
 
-export const postAnswer = async (
-  progression: ProgressionFromAPI,
-  token: string,
-  answer: string[]
-): Promise<ProgressionFromAPI> => {
-  const progressionId = progression._id;
-  const slideRef = progression.state.nextContent.ref;
-  const {host}: JWT = decode(token);
-  const response = await crossFetch(`${host}/api/v2/progressions/${progressionId}/answers`, {
-    method: 'post',
-    headers: {authorization: token, 'content-type': 'application/json'},
-    body: JSON.stringify({
-      content: {
-        ref: slideRef,
-        type: 'slide'
-      },
-      answer
-    })
-  });
+export const postAnswer =
+  (locale: string | void) =>
+  async (
+    progression: ProgressionFromAPI,
+    token: string,
+    answer: string[]
+  ): Promise<ProgressionFromAPI> => {
+    const progressionId = progression._id;
+    const slideRef = progression.state.nextContent.ref;
+    const {host}: JWT = decode(token);
+    const url = buildURL(`${host}/api/v2/progressions/${progressionId}/answers`, locale);
+    const response = await crossFetch(url, {
+      method: 'post',
+      headers: {authorization: token, 'content-type': 'application/json'},
+      body: JSON.stringify({
+        content: {
+          ref: slideRef,
+          type: 'slide'
+        },
+        answer
+      })
+    });
 
-  return toJSON<ProgressionFromAPI>(response);
-};
+    return toJSON<ProgressionFromAPI>(response);
+  };

--- a/packages/@coorpacademy-review-services/src/test/post-answer.test.ts
+++ b/packages/@coorpacademy-review-services/src/test/post-answer.test.ts
@@ -69,7 +69,7 @@ const result: ProgressionFromAPI = {
 test.before(() => {
   const moocApi = nock('http://localhost:3000');
   moocApi
-    .post('/api/v2/progressions/123456123456/answers', {
+    .post('/api/v2/progressions/123456123456/answers?lang=fr', {
       content: {
         ref: 'sli_NkvrWPFF2',
         type: 'slide'
@@ -85,13 +85,13 @@ test.after(() => {
 
 test('should post the answers successfully', async t => {
   const token = process.env.API_TEST_TOKEN || '';
-  const progression = await postAnswer(initProgression, token, answer);
+  const progression = await postAnswer('fr')(initProgression, token, answer);
   t.deepEqual(result, progression);
 });
 
 test('should reject bad token', async t => {
   const badToken = 'token is not a jwt';
-  const error = await t.throwsAsync(() => postAnswer(initProgression, badToken, answer));
+  const error = await t.throwsAsync(() => postAnswer()(initProgression, badToken, answer));
 
   t.is(
     error?.message,


### PR DESCRIPTION
https://trello.com/c/z3fF8KDu/3020-or-bug-validation-de-la-r%C3%A9ponse-li%C3%A9-%C3%A0-langue-token

**Detailed purpose of the PR**

Currently, correction from mobile are made on the language set on JWT token rather than on locale selected on the mobile.