### PR TITLE
[RGAA] add role group to settings menu

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -92,6 +92,7 @@ class MoocHeader extends React.Component {
     }),
     'settings-aria-label': PropTypes.string,
     'active-page-aria-label': PropTypes.string,
+    'group-settings-aria-label': PropTypes.string,
     settings: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string,
@@ -283,7 +284,8 @@ class MoocHeader extends React.Component {
       search,
       'search-reset-aria-label': searchResetAriaLabel,
       'settings-aria-label': settingsAriaLabel,
-      'active-page-aria-label': activePageAriaLabel
+      'active-page-aria-label': activePageAriaLabel,
+      'group-settings-aria-label': groupAriaLbale
     } = this.props;
     const {isFocus, isSettingsOpen, isMenuOpen, isToolTipOpen} = this.state;
     const {translate, skin} = this.context;
@@ -621,7 +623,12 @@ class MoocHeader extends React.Component {
             aria-label={settingsAriaLabel}
           />
           <div className={isSettingsOpen ? style.settingsWrapper : style.settingsWrapperHidden}>
-            <div data-name="settings" className={style.settingsGroup}>
+            <div
+              data-name="settings"
+              className={style.settingsGroup}
+              role="group"
+              aria-label={groupAriaLbale}
+            >
               {settingsElements}
             </div>
           </div>

--- a/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
@@ -112,6 +112,7 @@ export default {
     'settings-aria-label': 'account settings',
     'close-settings-aria-label': 'close account settings',
     'active-page-aria-label': 'Active page',
+    'group-settings-aria-label': 'Manage settings',
     settings: [
       {
         title: 'Language',


### PR DESCRIPTION
add role to settings menu 
[ticket](https://trello.com/c/c9JWzEOf/98-115-dans-chaque-formulaire-les-champs-de-m%C3%AAme-nature-sont-ils-regroup%C3%A9s-si-n%C3%A9cessaire)

![image](https://user-images.githubusercontent.com/58167920/225962589-c3341e62-b1f6-421a-b9c1-7b738e178522.png)

**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
