### PR TITLE
Fixes input that should use display: none; instead of opacity

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/style.css
@@ -165,6 +165,7 @@
 .innerHTML {
   composes: innerHTML from '../../../atom/label/style.css'
 }
+
 .hiddenCheckbox {
-  opacity: 0;
+  display: none;
 }


### PR DESCRIPTION
**Detailed purpose of the PR**

Fixes input that should use display: none; instead of opacity

**Result and observation**
Before:
![Screenshot 2023-03-22 at 16 56 24](https://user-images.githubusercontent.com/33550261/226964077-bf3f00c9-9654-4c33-9463-f4c1750c13a2.png)

After:
![Screenshot 2023-03-22 at 16 56 16](https://user-images.githubusercontent.com/33550261/226964098-6fcadbd5-e337-4270-b5ac-e053eef231b0.png)



**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
