### PR TITLE
fix button-link regression

### DIFF
--- a/packages/@coorpacademy-components/src/atom/button-link/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.tsx
@@ -46,7 +46,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
   } = props;
   const contentView = getButtonContent(icon, label);
   const styleButton = classnames(
-    style[`${className}`],
+    className,
     style.button,
     type === 'primary' && style.primary,
     type === 'secondary' && style.secondary,

--- a/packages/@coorpacademy-components/src/atom/button-link/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-link/style.css
@@ -94,12 +94,3 @@
   border-radius: 0px;
   height: auto;
 }
-
-/* bulk inspect button style */
-.bulkInspectButton {
-  font-family: 'Gilroy';
-  font-style: normal;
-  font-weight: 600;
-  font-size: 14px;
-  color: cm_primary_blue;
-}

--- a/packages/@coorpacademy-components/src/atom/button-link/types.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/types.ts
@@ -43,7 +43,7 @@ export type ButtonLinkProps = {
   };
   disabled?: boolean;
   className?: string;
-  customStyle?: Record<string, never>;
+  customStyle?: Record<string, unknown>;
   useTitle?: boolean;
 };
 

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/dashboard-pending.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/dashboard-pending.ts
@@ -4,7 +4,13 @@ import {defaultProps as failBulkProgressBarProps} from '../../../bulk-progress-b
 import {defaultProps as inProgessBulkProgressBarProps} from '../../../bulk-progress-bar/test/fixtures/in-progress';
 
 const buttonLinkProps: LastField = {
-  className: 'bulkInspectButton',
+  customStyle: {
+    color: '#0061FF',
+    'font-family': 'Gilroy',
+    'font-style': 'normal',
+    'font-weight': 600,
+    'font-size': '14px'
+  },
   label: 'Inspect',
   'data-name': 'default-button',
   'aria-label': 'aria button',

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/dashboard-pending.ts
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/test/fixtures/dashboard-pending.ts
@@ -6,10 +6,10 @@ import {defaultProps as inProgessBulkProgressBarProps} from '../../../bulk-progr
 const buttonLinkProps: LastField = {
   customStyle: {
     color: '#0061FF',
-    'font-family': 'Gilroy',
-    'font-style': 'normal',
-    'font-weight': 600,
-    'font-size': '14px'
+    fontFamily: 'Gilroy',
+    fontStyle: 'normal',
+    fontWeight: 600,
+    fontSize: '14px'
   },
   label: 'Inspect',
   'data-name': 'default-button',


### PR DESCRIPTION
problem:
className prop was not used the right way.
fix : 

- reset className prop
- use customStyle to customize link style instead of using className 

result:
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/111736786/226965400-63559832-da04-472a-a0d7-205d4ee8f1f1.png">

<img width="1134" alt="image" src="https://user-images.githubusercontent.com/111736786/226965270-ab317aa4-8584-4c85-925e-4f0d8bf74c00.png">
