### PR TITLE
fix Last update Icon position + short desc last update position

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/discipline-header/style.css
+++ b/packages/@coorpacademy-components/src/molecule/discipline-header/style.css
@@ -69,7 +69,7 @@
 }
 
 .lastUpdatedWrapperShort {
- height: 28px;
+ height: 31px;
  align-items: flex-end; 
 }
 
@@ -92,6 +92,7 @@
   color: #536E7A;
   margin-right: 3px;
   align-items: center;
+  padding-bottom: 1px;
 }
 
 .showMore {


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**
Before:
<img width="1045" alt="image" src="https://user-images.githubusercontent.com/22681512/229760476-3ea0e165-2c87-423a-ad47-cab43d386fc8.png">

After:
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/22681512/229760348-17b87260-cddf-453f-b3a7-5fdc4247668a.png">

Small PR to fix:
=>  the style of the icon on the left of "last updated on"
=> the position of the "last updated on" when the text is short
