### PR TITLE
fix show more on Discipline header

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/discipline-header/index.js
+++ b/packages/@coorpacademy-components/src/molecule/discipline-header/index.js
@@ -43,7 +43,7 @@ class DisciplineHeader extends React.Component {
     super(props);
     this.state = {
       fullDisplay: false,
-      offsetHeightShowMore: 0
+      scrollHeightShowMore: 0
     };
     this.handleToggleDisplay = this.handleToggleDisplay.bind(this);
     this.setHandle = this.setHandle.bind(this);
@@ -56,17 +56,17 @@ class DisciplineHeader extends React.Component {
   }
 
   setHandle(el) {
-    this.setState({offsetHeightShowMore: getOr(0, 'offsetHeight', el)});
+    this.setState({scrollHeightShowMore: getOr(0, 'scrollHeight', el)});
   }
 
   render() {
     const {image, title, description, video, lastUpdated} = this.props;
-    const {fullDisplay, offsetHeightShowMore} = this.state;
+    const {fullDisplay, scrollHeightShowMore} = this.state;
     const {translate} = this.context;
-    const maxHeightCourseInfos = 209;
+    const maxHeightCourseInfos = 215;
     const hasMediaContent = image || video;
     const toggleLabel = fullDisplay ? translate('See less') : translate('Show more');
-    const shortCourseText = offsetHeightShowMore <= maxHeightCourseInfos;
+    const shortCourseText = scrollHeightShowMore <= maxHeightCourseInfos;
     const courseSeeMoreButtonStyle = shortCourseText ? style.showMoreHidden : style.showMore;
 
     return (
@@ -77,7 +77,10 @@ class DisciplineHeader extends React.Component {
           </div>
         ) : null}
         <div className={style.courseWrapper}>
-          <div className={fullDisplay ? style.courseTextWrapperFull : style.courseTextWrapperShort}>
+          <div
+            className={fullDisplay ? style.courseTextWrapperFull : style.courseTextWrapperShort}
+            ref={this.setHandle}
+          >
             <div
               data-name="title"
               className={classnames(style.title, style.innerHTML)}
@@ -88,7 +91,6 @@ class DisciplineHeader extends React.Component {
               className={style.innerHTML}
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{__html: description}}
-              ref={this.setHandle}
             />
           </div>
           <div className={courseSeeMoreButtonStyle} onClick={this.handleToggleDisplay}>

--- a/packages/@coorpacademy-components/src/molecule/discipline-header/style.css
+++ b/packages/@coorpacademy-components/src/molecule/discipline-header/style.css
@@ -113,7 +113,7 @@
 
 .courseTextWrapperShort {
   composes: courseTextWrapperFull;
-  height: 213px;
+  max-height: 213px;
   overflow: hidden;
 }
 

--- a/packages/@coorpacademy-components/src/molecule/discipline-header/test/fixtures/medium-description.js
+++ b/packages/@coorpacademy-components/src/molecule/discipline-header/test/fixtures/medium-description.js
@@ -1,0 +1,10 @@
+export default {
+  props: {
+    title: 'Optimisez vos connaissances : apprendre ou à laisser !',
+    description:
+      'Pop Quiz, c’est l’interro surprise pour tester vos connaissances en 5 minutes chrono !Connaissez-vous les différentes méthodes d’apprentissage ? Répondez correctement à 15 questions, remportez 60 étoiles et découvrez (ou redécouvrez) les bonnes pratiques à adopter pour optimiser votre apprentissage. Savez-vous comment stimuler votre mémoire ? Renforcer votre attention ? Apprendre de vos pairs ?',
+    image:
+      'https://api.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/CoorpAcademy/content-digital-core/cockpit-digital-2016/default/shutterstock_777835606-1616609267419.jpg&h=500&w=500&q=90&m=contain',
+    lastUpdated: 'Last update on 03/2023'
+  }
+};

--- a/packages/@coorpacademy-components/src/template/common/discipline/test/fixtures/medium-description.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/test/fixtures/medium-description.js
@@ -1,0 +1,14 @@
+import {defaultsDeep} from 'lodash/fp';
+import disciplineHeader from '../../../../../molecule/discipline-header/test/fixtures/medium-description';
+import Default from './default';
+
+const {props} = Default;
+const {title, description, video} = disciplineHeader.props;
+
+export default {
+  props: defaultsDeep(props, {
+    title,
+    description,
+    video
+  })
+};


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

This PR fix the show more displaying on the correct text size ( switching from offsetHeight to scrollHeight )


Before:
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/22681512/230031780-3e821805-96cb-4b90-9f47-a9da081da48e.png">
After:
<img width="1072" alt="image" src="https://user-images.githubusercontent.com/22681512/230032431-25ecf407-e79e-41c5-bd81-b583206498fd.png">


**Testing Strategy**

Added some fixtures to represent the limit text size where the bug used to occur
