### PR TITLE
fix last update position discipline header

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/discipline-header/style.css
+++ b/packages/@coorpacademy-components/src/molecule/discipline-header/style.css
@@ -31,8 +31,9 @@
 }
 
 .courseWrapper {
-  display: inline-block;
+  display: flex;
   vertical-align: top;
+  flex-direction: column;
   padding-left: 30px;
 }
 
@@ -69,13 +70,12 @@
 }
 
 .lastUpdatedWrapperShort {
- height: 31px;
- align-items: flex-end; 
+ margin-top: auto;
 }
 
 .lastUpdatedWrapper {
   display: flex;
-  margin-top: 8px;
+  padding-top: 6px;
 }
 
 .lastUpdatedText {
@@ -100,11 +100,11 @@
   font-size: 14px;
   transition: all time ease-in-out;
   cursor: pointer;
-  order: 1;
   font-family: Gilroy;
   font-weight: bold;
   text-align: left;
   color: brand;
+  padding-top: 2px;
 }
 
 .showMore:hover {


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->
https://trello.com/c/QvHlGQPc/3038-add-update-date-on-discipline-page

**Detailed purpose of the PR**

After fixing the bug that cause the showmore to appear on correct text size it caused the last update to not be at the right position anymore. This PR contains the fix that correct that.


Before:
<img width="1299" alt="image" src="https://user-images.githubusercontent.com/22681512/230147999-81461516-42dd-40c1-ae45-49ae2acc967e.png">

After:
<img width="1474" alt="image" src="https://user-images.githubusercontent.com/22681512/230148133-e549a274-6289-44c2-a42c-12d6328a0244.png">
