### PR TITLE
[RGAA] Rga11.1 aria label on player web and review slide

### DIFF
--- a/packages/@coorpacademy-app-review/locales/en/review.json
+++ b/packages/@coorpacademy-app-review/locales/en/review.json
@@ -19,6 +19,7 @@
     "Continue": "Continue",
     "Type here": "Type here",
     "Select an answer": "Select an answer",
+    "answer_the_question": "Answer the question",
     "presentation": {
       "aria_label": "Review Presentation Container",
       "title": "What is<br/>Revision Mode ?",

--- a/packages/@coorpacademy-app-review/src/types/slides.ts
+++ b/packages/@coorpacademy-app-review/src/types/slides.ts
@@ -84,6 +84,7 @@ export type SelectionTemplate = {
   name: string;
   onChange?: Function;
   options?: DropDownOption[];
+  'aria-label': string;
 };
 
 export type Template = {

--- a/packages/@coorpacademy-app-review/src/views/slides/map-api-slide-to-ui.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/map-api-slide-to-ui.ts
@@ -170,7 +170,8 @@ const templateSelectProps = (
       const newAnswers = updateTemplateAnswer(text, answers, index, maxLength);
       dispatch(editAnswer(newAnswers));
     },
-    options: isEmpty(answer) ? concat([temporaryOption], selectOptions) : selectOptions
+    options: isEmpty(answer) ? concat([temporaryOption], selectOptions) : selectOptions,
+    'aria-label': translate('Select an answer')
   };
 };
 

--- a/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/template.ts
+++ b/packages/@coorpacademy-app-review/src/views/slides/test/fixtures/template.ts
@@ -132,7 +132,8 @@ export const templateUISlide: Partial<ReviewSlide> = {
               validOption: true,
               selected: false
             }
-          ]
+          ],
+          'aria-label': 'Select an answer'
         },
         {
           type: 'text',
@@ -171,7 +172,8 @@ export const templateUISlide: Partial<ReviewSlide> = {
               validOption: true,
               selected: false
             }
-          ]
+          ],
+          'aria-label': 'Select an answer'
         }
       ]
     }

--- a/packages/@coorpacademy-components/src/molecule/questions/free-text/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/free-text/index.js
@@ -38,6 +38,7 @@ const FreeText = (props, legacyContext) => {
         data-name="free-text-input"
         type="text"
         aria-label={ariaLabel || value || placeholder}
+        title={ariaLabel || value || placeholder}
         className={style.freeText}
         placeholder={placeholder}
         value={value}

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-drag/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-drag/index.js
@@ -38,6 +38,8 @@ const Choices = ({answers}) => {
             id={checkboxId}
             type="checkbox"
             value={title}
+            title={title}
+            aria-label={title}
             checked={selected}
             onChange={onClick}
             className={style.hiddenCheckbox}

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-drag/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-drag/index.js
@@ -112,7 +112,7 @@ const QcmDrag = ({answers, help, groupAriaLabel}, legacyContext) => {
   const primarySkinColor = getOr('#00B0FF', 'common.primary', skin);
 
   return (
-    <div className={style.wrapper} role="group" aria-label={groupAriaLabel}>
+    <div className={style.wrapper} role="group" aria-label={groupAriaLabel} title={groupAriaLabel}>
       <SelectedAnswerSections answers={answers} help={help} backgroundColor={primarySkinColor} />
       <div data-name="qcm-drag-answers" className={style.answers}>
         <Choices answers={answers} />

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
@@ -52,6 +52,8 @@ const QCMImage = (props, legacyContext) => {
                   id={checkboxId}
                   type="checkbox"
                   value={title}
+                  title={title}
+                  aria-label={title}
                   checked={selected}
                   onChange={onClick}
                   className={style.hiddenCheckbox}

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
@@ -40,6 +40,7 @@ const QCMImage = (props, legacyContext) => {
             className={style.imageWrapper}
             data-name="answerImage"
             aria-label={ariaLabel || title}
+            title={ariaLabel || title}
             style={{
               backgroundImage: `url(${image})`
             }}
@@ -70,6 +71,7 @@ const QCMImage = (props, legacyContext) => {
       className={style.wrapper}
       role="group"
       aria-label={groupAriaLabel}
+      title={groupAriaLabel}
     >
       {answersViews}
     </div>

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm/index.js
@@ -24,6 +24,7 @@ const QCM = (props, legacyContext) => {
           <div
             data-name="answer"
             aria-label={ariaLabel || title}
+            title={ariaLabel || title}
             className={classnames(longAnswerClass, style.innerHTML, selectedAnswerClass)}
             onClick={onClick}
             style={{

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm/index.js
@@ -52,7 +52,13 @@ const QCM = (props, legacyContext) => {
   );
 
   return (
-    <div data-name="qcm" className={style.wrapper} role="group" aria-label={groupAriaLabel}>
+    <div
+      data-name="qcm"
+      className={style.wrapper}
+      role="group"
+      aria-label={groupAriaLabel}
+      title={groupAriaLabel}
+    >
       {answersViews}
     </div>
   );

--- a/packages/@coorpacademy-components/src/molecule/questions/question-range/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/question-range/index.js
@@ -17,7 +17,7 @@ const QuestionRange = (props, legacyContext) => {
   };
 
   return (
-    <div className={style.wrapper} role="group" aria-label={groupAriaLabel}>
+    <div className={style.wrapper} role="group" aria-label={groupAriaLabel} title={groupAriaLabel}>
       <span
         style={titleStyle}
         className={classnames(style.title, style.innerHTML)}

--- a/packages/@coorpacademy-components/src/molecule/questions/template/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/index.js
@@ -45,6 +45,7 @@ const Template = ({template, answers, groupAriaLabel}) => {
       className={style.wrapper}
       role="group"
       aria-label={groupAriaLabel}
+      title={groupAriaLabel}
     >
       {templateCompose}
     </div>

--- a/packages/@coorpacademy-components/src/molecule/questions/template/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/test/fixtures/default.js
@@ -15,6 +15,7 @@ export default {
         theme: 'template',
         name: 'sel31191',
         label: ' ',
+        'aria-label': 'Select the correct answer',
         onChange: value => console.log(value),
         options: [
           {

--- a/packages/@coorpacademy-components/src/molecule/questions/template/test/fixtures/multiple.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/template/test/fixtures/multiple.js
@@ -15,6 +15,7 @@ export default {
         type: 'select',
         name: 'sel31192',
         label: ' ',
+        'aria-label': 'Select the correct answer',
         onChange: value => console.log(value),
         options: [
           {
@@ -34,6 +35,7 @@ export default {
         type: 'select',
         name: 'sel31193',
         label: ' ',
+        'aria-label': 'Select the correct answer',
         onChange: value => console.log(value),
         options: [
           {
@@ -52,6 +54,7 @@ export default {
         type: 'select',
         name: 'sel31194',
         label: ' ',
+        'aria-label': 'Select the correct answer',
         onChange: value => console.log(value),
         options: [
           {
@@ -66,6 +69,7 @@ export default {
           }
         ]
       }
-    ]
+    ],
+    groupAriaLabel: 'Answer the question'
   }
 };

--- a/packages/@coorpacademy-player-web/src/map-state-to-props/answer.js
+++ b/packages/@coorpacademy-player-web/src/map-state-to-props/answer.js
@@ -143,7 +143,8 @@ const templateSelectProps = (options, store) => {
         updateTemplateAnswer(answers, index, maxLength),
         editAnswerAction_(state, slide)
       ),
-      options: isEmpty(answer) ? [temporaryOption].concat(selectOptions) : selectOptions
+      options: isEmpty(answer) ? [temporaryOption].concat(selectOptions) : selectOptions,
+      'aria-label': translate('Select an answer')
     };
   };
 };

--- a/packages/@coorpacademy-player-web/src/map-state-to-props/test/answer.js
+++ b/packages/@coorpacademy-player-web/src/map-state-to-props/test/answer.js
@@ -62,7 +62,7 @@ test('should create edited qcm props', t => {
 });
 
 test('should create edited template props', t => {
-  t.plan(23);
+  t.plan(24);
 
   const state = {
     ui: {
@@ -89,6 +89,7 @@ test('should create edited template props', t => {
   t.true(isFunction(props.answers[0].onChange));
   t.is(props.answers[1].type, 'select');
   t.is(props.answers[1].name, 'sel31191');
+  t.is(props.answers[1]['aria-label'], '__Select an answer');
   t.true(isFunction(props.answers[1].onChange));
   const selectOptions = props.answers[1].options;
   t.true(Array.isArray(selectOptions));


### PR DESCRIPTION
Trello card : [11.1 | 11.2- Chaque champ de formulaire a-t-il une étiquette ? - Chaque étiquette associée à un champ de formulaire est-elle pertinente (hors cas particuliers) ?](https://trello.com/c/tmQQHocS/100-111-112-chaque-champ-de-formulaire-a-t-il-une-%C3%A9tiquette-chaque-%C3%A9tiquette-associ%C3%A9e-%C3%A0-un-champ-de-formulaire-est-elle-pertinente-h)

Related to the following PR :
Mooc Side : [[RGAA] 11.1 and 11.2 - add title attribute on battle and signin pages](https://github.com/CoorpAcademy/coorpacademy/pull/17500)

Traductions : [[RGAA] add arialabelledby for select playlist in battle](https://github.com/CoorpAcademy/coorpacademy/pull/17501)

**Detailed purpose of the PR**
- Add aria-label to select template props in slides in app-review and player-web 
![Capture d’écran 2023-04-18 à 16 28 32](https://user-images.githubusercontent.com/113359769/232808961-94e8f001-1d09-4e33-bbef-7894cde79f0f.png)

- Add the key `answer_the_question` to locales in app-review directory.
![Capture d’écran 2023-04-20 à 17 32 52](https://user-images.githubusercontent.com/113359769/233415624-6da14364-65af-4c8a-9ed0-40861df07143.png)

**Result and observation**

**Testing Strategy**
- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
