### PR TITLE
[RGAA - regression fix] fix scope content condition

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/scope-tabs/index.js
+++ b/packages/@coorpacademy-components/src/molecule/scope-tabs/index.js
@@ -37,15 +37,14 @@ Tab.propTypes = {
 
 const ScopeTabs = (props, context) => {
   const {onClick, selected = 0, levels = []} = props;
-  return levels.length > 1 ? (
-    <nav>
-      <ul data-name="scopeTabs" className={style.tabs}>
-        {levels.map((level, index) => (
-          <Tab key={index} index={index} level={level} onClick={onClick} selected={selected} />
-        ))}
-      </ul>
-    </nav>
-  ) : null;
+  const scopeContent = (
+    <ul data-name="scopeTabs" className={style.tabs}>
+      {levels.map((level, index) => (
+        <Tab key={index} index={index} level={level} onClick={onClick} selected={selected} />
+      ))}
+    </ul>
+  );
+  return levels.length > 1 ? <nav>{scopeContent}</nav> : <div>{scopeContent}</div>;
 };
 
 ScopeTabs.propTypes = {


### PR DESCRIPTION
RGAA 9.2 rule.

**Detailed purpose of the PR**
Found a graphic regressiion before the core dependencies PR was merged on the MOOC.
Basic level disappeared from courses when there is only one level.

***Environnement : staging***

<img width="1301" alt="Capture d’écran 2023-05-04 à 10 24 12" src="https://user-images.githubusercontent.com/113359769/236153528-0b928872-81be-4f37-95ac-e393486bb0b8.png">

**Result and observation**

***Environnement : staging***
1 element
<img width="1680" alt="Capture d’écran 2023-05-04 à 11 12 32" src="https://user-images.githubusercontent.com/113359769/236161326-7d3c8a43-bcf5-4801-bcd0-db112d51bfea.png">
Few elements
<img width="1680" alt="Capture d’écran 2023-05-04 à 11 12 22" src="https://user-images.githubusercontent.com/113359769/236161392-7f55378a-c525-433a-8596-f4f4f2e05847.png">

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
