### PR TITLE
[RGAA] refacto div to nav in mooc header

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -717,14 +717,14 @@ class MoocHeader extends React.Component {
             </Link>
           </div>
           {searchFormView}
-          <div
+          <nav
             className={isMenuOpen ? style.menuWrapper : style.hiddenMenuWrapper}
             data-name="menu-wrapper"
           >
             {pagesView}
             {userView || linksView}
             {settingsView}
-          </div>
+          </nav>
         </div>
       </header>
     );


### PR DESCRIPTION
Ticket trello : [9.2 - Dans chaque page web, la structure du document est-elle cohérente (hors cas particuliers) ?](https://trello.com/c/djFheq9v/167-92-dans-chaque-page-web-la-structure-du-document-est-elle-coh%C3%A9rente-hors-cas-particuliers)

**Detailed purpose of the PR**

Refacto the div element in mooc header into nav element to match the rgaa rule below.

**Result and observation**
![Capture d’écran 2023-05-24 à 15 34 57](https://github.com/CoorpAcademy/components/assets/113359769/7f0f374c-1bcf-45d9-999a-1bf180bc5e34)


**Testing Strategy**
- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
