### PR TITLE
[RGAA] 11.1 & 2: Use the same "Add your comment" trad for the placeholder + title + aria-label on Discussion text field

### DIFF
--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -75,7 +75,7 @@
   "Validated": "Validated",
   "Video Loading Error": "An error occurred while loading the video, please try again.",
   "Wait_creation": "The platform is being created. This can take several seconds. Please wait...",
-  "comment_aria_label": "add your comment",
+  "comment_aria_label": "Add your comment",
   "zuora_discount_code_submit": "Apply",
   "zuora_discount_code": "Promo code",
   "mandatory_fields": "*Mandatory fields",

--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -75,7 +75,6 @@
   "Validated": "Validated",
   "Video Loading Error": "An error occurred while loading the video, please try again.",
   "Wait_creation": "The platform is being created. This can take several seconds. Please wait...",
-  "Write something here": "Write something here",
   "comment_aria_label": "add your comment",
   "zuora_discount_code_submit": "Apply",
   "zuora_discount_code": "Promo code",

--- a/packages/@coorpacademy-components/src/molecule/forum/forum-comment/index.js
+++ b/packages/@coorpacademy-components/src/molecule/forum/forum-comment/index.js
@@ -53,8 +53,8 @@ const ForumComment = (props, context) => {
         {avatarView}
         <div className={style.comment}>
           <textarea
-            placeholder={translate('Write something here')}
-            title={translate('Write something here')}
+            placeholder={translate('comment_aria_label')}
+            title={translate('comment_aria_label')}
             aria-label={translate('comment_aria_label')}
             value={value}
             onChange={onChange}


### PR DESCRIPTION
**Detailed purpose of the PR**

- [RGAA] 11.1 & 2: Use the same "Add your comment" trad for the placeholder + title + aria-label on Discussion text field

**Result and observation**
Before:

![Screenshot 2023-05-31 at 16 40 33](https://github.com/CoorpAcademy/components/assets/33550261/efe41171-44e9-42f9-8fd2-52d4daa7f11b)

After:

![Screenshot 2023-05-31 at 16 39 26](https://github.com/CoorpAcademy/components/assets/33550261/0b15e072-ad27-4472-ac40-9171f455ef3a)
