### PR TITLE
[massive-battle] add atom autocomplete for CM

### DIFF
--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -37,6 +37,7 @@
   "Ok": "Ok",
   "Open": "Open",
   "payment_form_submit": "Start Coorpacademy subscription",
+  "Please select a value": "Please select a value",
   "Post": "Post",
   "premium_unsubscribe_confirmation": "We confirm the cancelling of your subscription which will be effective starting from next month.\n\nIn the meantime, you can continue to enjoy our content on the Coorpacademy platform.",
   "Press the escape key to close the information text": "Press the escape key to close the information text",

--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -37,7 +37,6 @@
   "Ok": "Ok",
   "Open": "Open",
   "payment_form_submit": "Start Coorpacademy subscription",
-  "Please select a value": "Please select a value",
   "Post": "Post",
   "premium_unsubscribe_confirmation": "We confirm the cancelling of your subscription which will be effective starting from next month.\n\nIn the meantime, you can continue to enjoy our content on the Coorpacademy platform.",
   "Press the escape key to close the information text": "Press the escape key to close the information text",

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import {noop, isNil, isEmpty, keys} from 'lodash/fp';
 import {NovaSolidStatusClose as ErrorIcon} from '@coorpacademy/nova-icons';
 import getClassState from '../../util/get-class-state';
-import Provider from '../provider';
 import style from './style.css';
 
 const themeStyle = {
@@ -15,7 +14,7 @@ const themeStyle = {
 
 const renderSuggestion = suggestion => <span>{suggestion.name}</span>;
 
-const Autocomplete = (props, context) => {
+const Autocomplete = props => {
   const {
     placeholder = '',
     value,
@@ -23,6 +22,7 @@ const Autocomplete = (props, context) => {
     required,
     modified = false,
     error = false,
+    errorMessage,
     suggestions = [],
     onChange = noop,
     onFetch = noop,
@@ -33,7 +33,6 @@ const Autocomplete = (props, context) => {
     theme = 'default'
   } = props;
 
-  const {translate} = context;
   const mainClass = themeStyle[theme];
   const title = `${propsTitle}${required ? '*' : ''}`;
   const className = getClassState(style.default, style.modified, style.error, modified, error);
@@ -72,7 +71,7 @@ const Autocomplete = (props, context) => {
       <div
         className={style.errorText}
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{__html: translate('Please select a value')}}
+        dangerouslySetInnerHTML={{__html: errorMessage}}
       />
     ) : null;
   return (
@@ -116,6 +115,7 @@ Autocomplete.propTypes = {
   required: PropTypes.bool,
   modified: PropTypes.bool,
   error: PropTypes.bool,
+  errorMessage: PropTypes.string,
   suggestions: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,
@@ -128,10 +128,6 @@ Autocomplete.propTypes = {
   onClear: PropTypes.func,
   onBlur: PropTypes.func,
   onSuggestionSelected: PropTypes.func
-};
-
-Autocomplete.contextTypes = {
-  translate: Provider.childContextTypes.translate
 };
 
 export default Autocomplete;

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import {noop, isNil, isEmpty, keys} from 'lodash/fp';
 import {NovaSolidStatusClose as ErrorIcon} from '@coorpacademy/nova-icons';
 import getClassState from '../../util/get-class-state';
+import Provider from '../provider';
 import style from './style.css';
 
 const themeStyle = {
@@ -14,7 +15,7 @@ const themeStyle = {
 
 const renderSuggestion = suggestion => <span data-testid={suggestion.name}>{suggestion.name}</span>;
 
-const Autocomplete = props => {
+const Autocomplete = (props, context) => {
   const {
     placeholder = '',
     value,
@@ -32,8 +33,9 @@ const Autocomplete = props => {
     theme = 'default'
   } = props;
 
+  const {translate} = context;
   const mainClass = themeStyle[theme];
-  const title = `${propsTitle}${required ? ' *' : ''}`;
+  const title = `${propsTitle}${required ? '*' : ''}`;
   const className = getClassState(style.default, style.modified, style.error, modified, error);
 
   const handleChange = useCallback(
@@ -47,9 +49,11 @@ const Autocomplete = props => {
     [onBlur]
   );
   const handleSuggestionsFetchRequested = useCallback(e => onFetch(e), [onFetch]);
+
   const handleSuggestionsClearRequested = useCallback(e => onClear(e), [onClear]);
   const handleSuggestionsSelected = useCallback(
     (e, data) => onSuggestionSelected(data),
+
     [onSuggestionSelected]
   );
 
@@ -70,7 +74,7 @@ const Autocomplete = props => {
       <div
         className={style.errorText}
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{__html: 'error'}}
+        dangerouslySetInnerHTML={{__html: translate('Please select a value')}}
       />
     ) : null;
   return (
@@ -126,6 +130,10 @@ Autocomplete.propTypes = {
   onClear: PropTypes.func,
   onBlur: PropTypes.func,
   onSuggestionSelected: PropTypes.func
+};
+
+Autocomplete.contextTypes = {
+  translate: Provider.childContextTypes.translate
 };
 
 export default Autocomplete;

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import Autosuggest from 'react-autosuggest';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -7,7 +7,7 @@ import {NovaSolidStatusClose as ErrorIcon} from '@coorpacademy/nova-icons';
 import getClassState from '../../util/get-class-state';
 import style from './style.css';
 
-const themeStyle = {
+const THEME_STYLE = {
   coorpmanager: style.coorpmanager,
   default: style.default
 };
@@ -33,9 +33,12 @@ const Autocomplete = props => {
     theme = 'default'
   } = props;
 
-  const mainClass = themeStyle[theme];
-  const title = `${propsTitle}${required ? '*' : ''}`;
-  const className = getClassState(style.default, style.modified, style.error, modified, error);
+  const mainClass = THEME_STYLE[theme];
+  const title = useMemo(() => `${propsTitle}${required ? '*' : ''}`, [propsTitle, required]);
+  const className = useMemo(
+    () => getClassState(style.default, style.modified, style.error, modified, error),
+    [modified, error]
+  );
 
   const handleChange = useCallback(
     e => {
@@ -122,7 +125,7 @@ Autocomplete.propTypes = {
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     })
   ),
-  theme: PropTypes.oneOf(keys(themeStyle)),
+  theme: PropTypes.oneOf(keys(THEME_STYLE)),
   onChange: PropTypes.func,
   onFetch: PropTypes.func,
   onClear: PropTypes.func,

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -2,9 +2,14 @@ import React, {useMemo} from 'react';
 import Autosuggest from 'react-autosuggest';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import {noop, isNil} from 'lodash/fp';
+import {noop, isNil, isEmpty, keys} from 'lodash/fp';
 import getClassState from '../../util/get-class-state';
 import style from './style.css';
+
+const themeStyle = {
+  coorpmanager: style.coorpmanager,
+  default: style.default
+};
 
 const renderSuggestion = suggestion => <span>{suggestion.name}</span>;
 
@@ -22,9 +27,12 @@ const Autocomplete = props => {
     onClear = noop,
     onBlur = noop,
     onSuggestionSelected = noop,
-    title: propsTitle
+    title: propsTitle,
+    theme = 'default',
+    'aria-label': ariaLabel = 'Input Text'
   } = props;
 
+  const mainClass = themeStyle[theme];
   const title = `${propsTitle}${required ? ' *' : ''}`;
   const className = getClassState(style.default, style.modified, style.error, modified, error);
 
@@ -44,14 +52,15 @@ const Autocomplete = props => {
     placeholder,
     value,
     onChange: handleChange,
-    onBlur: handleBlur
+    onBlur: handleBlur,
+    ariaLabel
   };
 
   return (
-    <div className={classnames(className, isNil(title) && style.isNoTitle)}>
+    <div className={classnames(mainClass, className, isNil(title) && style.isNoTitle)}>
       <label>
-        <span className={style.title}>{title}</span>
-        <div>
+        <span className={classnames(style.title, isEmpty(value) && style.noValue)}>{title}</span>
+        <div className={style.inputContainer}>
           <Autosuggest
             theme={{
               container: style.container,
@@ -92,6 +101,8 @@ Autocomplete.propTypes = {
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     })
   ),
+  theme: PropTypes.oneOf(keys(themeStyle)),
+  'aria-label': PropTypes.string,
   onChange: PropTypes.func,
   onFetch: PropTypes.func,
   onClear: PropTypes.func,

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -3,6 +3,7 @@ import Autosuggest from 'react-autosuggest';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {noop, isNil, isEmpty, keys} from 'lodash/fp';
+import {NovaSolidStatusClose as ErrorIcon} from '@coorpacademy/nova-icons';
 import getClassState from '../../util/get-class-state';
 import style from './style.css';
 
@@ -56,6 +57,17 @@ const Autocomplete = props => {
     ariaLabel
   };
 
+  const errorIconView =
+    theme === 'coorpmanager' && error ? <ErrorIcon className={style.leftIcon} /> : null;
+
+  const errorText =
+    theme === 'coorpmanager' && error ? (
+      <div
+        className={style.errorText}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{__html: 'error'}}
+      />
+    ) : null;
   return (
     <div className={classnames(mainClass, className, isNil(title) && style.isNoTitle)}>
       <label>
@@ -80,6 +92,8 @@ const Autocomplete = props => {
             focusInputOnSuggestionClick={false}
             onSuggestionSelected={handleSuggestionsSelected}
           />
+          {errorIconView}
+          {errorText}
         </div>
       </label>
       <div className={style.description}>{description}</div>

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useCallback} from 'react';
 import Autosuggest from 'react-autosuggest';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -12,7 +12,7 @@ const themeStyle = {
   default: style.default
 };
 
-const renderSuggestion = suggestion => <span>{suggestion.name}</span>;
+const renderSuggestion = suggestion => <span data-testid={suggestion.name}>{suggestion.name}</span>;
 
 const Autocomplete = props => {
   const {
@@ -29,32 +29,37 @@ const Autocomplete = props => {
     onBlur = noop,
     onSuggestionSelected = noop,
     title: propsTitle,
-    theme = 'default',
-    'aria-label': ariaLabel = 'Input Text'
+    theme = 'default'
   } = props;
 
   const mainClass = themeStyle[theme];
   const title = `${propsTitle}${required ? ' *' : ''}`;
   const className = getClassState(style.default, style.modified, style.error, modified, error);
 
-  const handleChange = useMemo(() => e => onChange(e), [onChange]);
-  const handleBlur = useMemo(
-    () => (e, selectedSuggestion) => onBlur(e, selectedSuggestion),
+  const handleChange = useCallback(
+    e => {
+      onChange(e);
+    },
+    [onChange]
+  );
+  const handleBlur = useCallback(
+    (e, selectedSuggestion) => onBlur(e, selectedSuggestion),
     [onBlur]
   );
-  const handleSuggestionsFetchRequested = useMemo(() => e => onFetch(e), [onFetch]);
-  const handleSuggestionsClearRequested = useMemo(() => e => onClear(e), [onClear]);
-  const handleSuggestionsSelected = useMemo(
-    () => (e, data) => onSuggestionSelected(data),
+  const handleSuggestionsFetchRequested = useCallback(e => onFetch(e), [onFetch]);
+  const handleSuggestionsClearRequested = useCallback(e => onClear(e), [onClear]);
+  const handleSuggestionsSelected = useCallback(
+    (e, data) => onSuggestionSelected(data),
     [onSuggestionSelected]
   );
 
   const inputProps = {
     placeholder,
     value,
-    onChange: handleChange,
+    onChange: noop,
     onBlur: handleBlur,
-    ariaLabel
+    onInput: handleChange,
+    'data-testid': 'autocomplete-input'
   };
 
   const errorIconView =
@@ -116,7 +121,6 @@ Autocomplete.propTypes = {
     })
   ),
   theme: PropTypes.oneOf(keys(themeStyle)),
-  'aria-label': PropTypes.string,
   onChange: PropTypes.func,
   onFetch: PropTypes.func,
   onClear: PropTypes.func,

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -24,7 +24,7 @@ const Autocomplete = props => {
     error = false,
     errorMessage,
     suggestions = [],
-    onChange = noop,
+    onInput = noop,
     onFetch = noop,
     onClear = noop,
     onBlur = noop,
@@ -40,11 +40,11 @@ const Autocomplete = props => {
     [modified, error]
   );
 
-  const handleChange = useCallback(
+  const handleInput = useCallback(
     e => {
-      onChange(e);
+      onInput(e);
     },
-    [onChange]
+    [onInput]
   );
   const handleBlur = useCallback(
     (e, selectedSuggestion) => onBlur(e, selectedSuggestion),
@@ -62,7 +62,7 @@ const Autocomplete = props => {
     value,
     onChange: noop,
     onBlur: handleBlur,
-    onInput: handleChange,
+    onInput: handleInput,
     'data-testid': 'autocomplete-input'
   };
 
@@ -126,7 +126,7 @@ Autocomplete.propTypes = {
     })
   ),
   theme: PropTypes.oneOf(keys(THEME_STYLE)),
-  onChange: PropTypes.func,
+  onInput: PropTypes.func,
   onFetch: PropTypes.func,
   onClear: PropTypes.func,
   onBlur: PropTypes.func,

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -69,7 +69,7 @@ const Autocomplete = props => {
       />
     ) : null;
   return (
-    <div className={classnames(mainClass, className, isNil(title) && style.isNoTitle)}>
+    <div className={classnames(mainClass, className, isNil(propsTitle) && style.isNoTitle)}>
       <label>
         <span className={classnames(style.title, isEmpty(value) && style.noValue)}>{title}</span>
         <div className={style.inputContainer}>

--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -13,7 +13,7 @@ const themeStyle = {
   default: style.default
 };
 
-const renderSuggestion = suggestion => <span data-testid={suggestion.name}>{suggestion.name}</span>;
+const renderSuggestion = suggestion => <span>{suggestion.name}</span>;
 
 const Autocomplete = (props, context) => {
   const {
@@ -49,11 +49,9 @@ const Autocomplete = (props, context) => {
     [onBlur]
   );
   const handleSuggestionsFetchRequested = useCallback(e => onFetch(e), [onFetch]);
-
   const handleSuggestionsClearRequested = useCallback(e => onClear(e), [onClear]);
   const handleSuggestionsSelected = useCallback(
     (e, data) => onSuggestionSelected(data),
-
     [onSuggestionSelected]
   );
 

--- a/packages/@coorpacademy-components/src/atom/autocomplete/style.css
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/style.css
@@ -5,6 +5,8 @@
 @value dark from colors;
 @value medium from colors;
 @value white from colors;
+@value cm_positive_100 from colors;
+@value cm_negative_100 from colors;
 @value cm_grey_100 from colors;
 @value cm_grey_150 from colors;
 @value cm_grey_400 from colors;
@@ -241,3 +243,29 @@
   background-color: cm_grey_150;
 }
 
+.coorpmanager.error .leftIcon {
+  background-color: cm_negative_100;
+  color: white;
+  border-radius: 50%;
+  padding: 2px;
+  width: 10px;
+  height: 10px;
+  position: absolute;
+  right: 17px;
+  top: 14px;
+}
+
+.coorpmanager .errorText {
+  flex-grow: 0;
+  opacity: 0.5;
+  font-family: Gilroy;
+  font-size: 10px;
+  font-weight: 500;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: 1.2;
+  letter-spacing: normal;
+  text-align: left;
+  padding-top: 8px;
+  color: cm_negative_100;
+}

--- a/packages/@coorpacademy-components/src/atom/autocomplete/style.css
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/style.css
@@ -135,7 +135,6 @@
     background-color: #ddd;
 }
 
-
 /******************************* coorpmanager theme ***************************************/
 
 .coorpmanager {
@@ -155,7 +154,6 @@
   align-items: flex-start;
   flex-direction: column;
   position: relative;
-
 }
 
 .coorpmanager .title {

--- a/packages/@coorpacademy-components/src/atom/autocomplete/style.css
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/style.css
@@ -5,6 +5,10 @@
 @value dark from colors;
 @value medium from colors;
 @value white from colors;
+@value cm_grey_100 from colors;
+@value cm_grey_150 from colors;
+@value cm_grey_400 from colors;
+@value cm_grey_700 from colors;
 
 .default {
     display: flex;
@@ -128,3 +132,112 @@
 .suggestionHighlighted {
     background-color: #ddd;
 }
+
+
+/******************************* coorpmanager theme ***************************************/
+
+.coorpmanager {
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  position: relative;
+}
+
+.coorpmanager label {
+  width: 100%;
+  height: 100%;
+  margin-right: 0;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  position: relative;
+
+}
+
+.coorpmanager .title {
+  flex-grow: 0;
+  font-family: Gilroy;
+  font-size: 10px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: 1.2;
+  letter-spacing: normal;
+  text-align: left;
+  z-index: 1;
+  color: cm_grey_400;
+  width: auto;
+  transition: all 0.25s linear;
+  pointer-events: none;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  position: absolute;
+  top: 7px;
+  left: 16px;
+}
+
+.coorpmanager .title.noValue{
+  font-size: 14px;
+  font-weight: 500;
+  color: cm_grey_700;
+  top: 14px;
+}
+
+.coorpmanager:focus-within .title.noValue {
+  font-size: 10px;
+  font-weight: bold;
+  color: cm_grey_400;
+  top: 7px;
+}
+
+.coorpmanager .inputContainer {
+  width: 100%
+}
+  
+.coorpmanager input {
+  width: 100%;
+  height: 44px;
+  margin: 0px;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  flex-grow: 0;
+  justify-content: center;
+  background-color: cm_grey_100;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 7px;
+  color: cm_grey_700;
+  font-family: Gilroy;
+  font-size: 14px;
+  font-weight: 500;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: 44px;
+  letter-spacing: normal;
+  outline: none;
+  padding: 19px 30px 5px 16px;
+  text-align: left;
+  transition: all 0.25s linear;
+} 
+
+.coorpmanager .suggestionsContainerOpen {
+  width: 100%;
+}
+
+.coorpmanager:focus-within input::placeholder {
+  color: cm_grey_400;
+}
+
+.coorpmanager input::placeholder {
+  color: transparent;
+  transition: color 0.25s linear;
+}
+
+.coorpmanager input:hover {
+  background-color: cm_grey_150;
+}
+

--- a/packages/@coorpacademy-components/src/atom/autocomplete/style.css
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/style.css
@@ -228,10 +228,20 @@
 
 .coorpmanager .suggestionsContainerOpen {
   width: 100%;
+  margin-left: 0;
+  border-radius: 7px;
 }
 
 .coorpmanager:focus-within input::placeholder {
   color: cm_grey_400;
+}
+
+.coorpmanager .suggestionsList {
+  border-radius: 7px;
+}
+
+.coorpmanager .suggestionHighlighted {
+  border-radius: 5px;
 }
 
 .coorpmanager input::placeholder {

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-default.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-default.js
@@ -1,0 +1,25 @@
+export default {
+  props: {
+    title: 'Input name',
+    placeholder: "Type 'c'",
+    value: 'This is an input',
+    description: '',
+    required: false,
+    modified: false,
+    error: false,
+    suggestions: [],
+    theme: 'coorpmanager',
+    onChange: value => {
+      console.log(`onChange ${value}`);
+    },
+    onFetch: ({value}) => {
+      console.log(`onFetch ${value}`);
+    },
+    onClear: () => {
+      console.log('onClear');
+    },
+    onSuggestionSelected: data => {
+      console.log('onSuggestionSelected', data);
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-default.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-default.js
@@ -1,24 +1,10 @@
 export default {
   props: {
-    title: 'Input name',
-    value: 'c',
+    title: 'Population',
+    placeholder: "Type 'c'",
+    value: '',
     description: '',
     required: false,
-    error: false,
-    suggestions: [
-      {
-        name: 'C',
-        value: 1972
-      },
-      {
-        name: 'C#',
-        value: 2000
-      },
-      {
-        name: 'C++',
-        value: 1983
-      }
-    ],
     theme: 'coorpmanager',
     onChange: value => {
       console.log(`onChange ${value}`);

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-default.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-default.js
@@ -1,11 +1,24 @@
 export default {
   props: {
     title: 'Input name',
-    value: 'This is an input',
+    value: 'c',
     description: '',
     required: false,
     error: false,
-    suggestions: [],
+    suggestions: [
+      {
+        name: 'C',
+        value: 1972
+      },
+      {
+        name: 'C#',
+        value: 2000
+      },
+      {
+        name: 'C++',
+        value: 1983
+      }
+    ],
     theme: 'coorpmanager',
     onChange: value => {
       console.log(`onChange ${value}`);

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-default.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-default.js
@@ -6,8 +6,8 @@ export default {
     description: '',
     required: false,
     theme: 'coorpmanager',
-    onChange: value => {
-      console.log(`onChange ${value}`);
+    onInput: value => {
+      console.log(`onInput ${value}`);
     },
     onFetch: ({value}) => {
       console.log(`onFetch ${value}`);

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-default.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-default.js
@@ -1,11 +1,9 @@
 export default {
   props: {
     title: 'Input name',
-    placeholder: "Type 'c'",
     value: 'This is an input',
     description: '',
     required: false,
-    modified: false,
     error: false,
     suggestions: [],
     theme: 'coorpmanager',

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-error.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-error.js
@@ -1,0 +1,10 @@
+import {defaultsDeep} from 'lodash/fp';
+import CmDefault from './cm-default';
+
+const {props} = CmDefault;
+
+export default {
+  props: defaultsDeep(props, {
+    error: true
+  })
+};

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-error.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-error.js
@@ -5,6 +5,7 @@ const {props} = CmDefault;
 
 export default {
   props: defaultsDeep(props, {
-    error: true
+    error: true,
+    errorMessage: 'Please select a value'
   })
 };

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-filled.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-filled.js
@@ -19,8 +19,8 @@ export default {
       }
     ],
     theme: 'coorpmanager',
-    onChange: value => {
-      console.log(`onChange ${value}`);
+    onInput: value => {
+      console.log(`onInput ${value}`);
     },
     onFetch: ({value}) => {
       console.log(`onFetch ${value}`);

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-filled.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/cm-filled.js
@@ -1,10 +1,24 @@
 export default {
   props: {
     title: 'Population',
-    placeholder: "Type 'c'",
-    value: '',
+    value: 'c',
     description: '',
     required: false,
+    suggestions: [
+      {
+        name: 'C',
+        value: 1972
+      },
+      {
+        name: 'C#',
+        value: 2000
+      },
+      {
+        name: 'C++',
+        value: 1983
+      }
+    ],
+    theme: 'coorpmanager',
     onChange: value => {
       console.log(`onChange ${value}`);
     },

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/default.js
@@ -5,8 +5,8 @@ export default {
     value: '',
     description: '',
     required: false,
-    onChange: value => {
-      console.log(`onChange ${value}`);
+    onInput: value => {
+      console.log(`onInput ${value}`);
     },
     onFetch: ({value}) => {
       console.log(`onFetch ${value}`);

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/filled.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/filled.js
@@ -25,9 +25,9 @@ export default {
         value: 2007
       }
     ],
-    onChange: e => {
+    onInput: e => {
       const value = e.target.value;
-      console.log(`onChange ${value}`, e);
+      console.log(`onInput ${value}`, e);
     },
     onFetch: e => {
       const {value} = e;

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/no-title.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/no-title.js
@@ -4,8 +4,8 @@ export default {
     value: '',
     description: '',
     required: false,
-    onChange: value => {
-      console.log(`onChange ${value}`);
+    onInput: value => {
+      console.log(`onInput ${value}`);
     },
     onFetch: ({value}) => {
       console.log(`onFetch ${value}`);

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/no-title.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/fixtures/no-title.js
@@ -1,11 +1,9 @@
 export default {
   props: {
-    title: 'Population',
     placeholder: "Type 'c'",
     value: '',
     description: '',
     required: false,
-
     onChange: value => {
       console.log(`onChange ${value}`);
     },

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/index.js
@@ -7,10 +7,10 @@ import defaultFixture from './fixtures/default';
 
 browserEnv();
 
-test('should call the onChange and onClear functions with the new value of the input', t => {
+test('should call the onInput and onClear functions with the new value of the input', t => {
   t.plan(3);
 
-  const onChange = e => {
+  const onInput = e => {
     t.is(e.target.value, 'Foo');
   };
 
@@ -21,7 +21,7 @@ test('should call the onChange and onClear functions with the new value of the i
   const inputProps = {
     placeholder: '',
     value: '',
-    onChange,
+    onInput,
     'data-testid': 'autocomplete-input'
   };
 

--- a/packages/@coorpacademy-components/src/atom/autocomplete/test/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/test/index.js
@@ -1,0 +1,45 @@
+import test from 'ava';
+import browserEnv from 'browser-env';
+import React from 'react';
+import {fireEvent, render} from '@testing-library/react';
+import Autocomplete from '..';
+import defaultFixture from './fixtures/default';
+
+browserEnv();
+
+test('should call the onChange and onClear functions with the new value of the input', t => {
+  t.plan(3);
+
+  const onChange = e => {
+    t.is(e.target.value, 'Foo');
+  };
+
+  const onClear = () => {
+    t.pass();
+  };
+
+  const inputProps = {
+    placeholder: '',
+    value: '',
+    onChange,
+    'data-testid': 'autocomplete-input'
+  };
+
+  const defaultProps = {
+    ...defaultFixture.props,
+    onClear
+  };
+  const {getByTestId} = render(
+    <Autocomplete
+      {...{
+        ...defaultProps,
+        ...inputProps
+      }}
+    />
+  );
+  const inputAutocomplete = getByTestId('autocomplete-input');
+  t.truthy(inputAutocomplete);
+
+  fireEvent.input(inputAutocomplete, {target: {value: 'Foo'}});
+  fireEvent.blur(inputAutocomplete);
+});


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR adds skin CM to autocomplete component.
-> https://trello.com/c/QLSyCUWX/3033-add-skin-cm-to-autocomplete-component

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

![Kapture 2023-06-06 at 14 07 32](https://github.com/CoorpAcademy/components/assets/79636283/01bacb82-528e-47b2-ae57-2634686100e0)

![Kapture 2023-06-06 at 17 02 04](https://github.com/CoorpAcademy/components/assets/79636283/3a335614-b212-4034-ac52-84664dc27cca)


<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->


**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [x] Unit testing
