### PR TITLE
fix select style

### DIFF
--- a/packages/@coorpacademy-components/src/atom/select/style.css
+++ b/packages/@coorpacademy-components/src/atom/select/style.css
@@ -85,7 +85,7 @@ div.coorpmanager label.selectWrapper {
 .selectSpan {
   display: none;
   position: relative;
-  z-index: 10;
+  z-index: 1;
   white-space: nowrap;
   pointer-events: none;
   height: 18px;
@@ -167,7 +167,7 @@ div.coorpmanager label.selectWrapper {
   pointer-events: none;
   width: 12px;
   height: 12px;
-  z-index: 11;
+  z-index: 2;
 }
 
 .selectedArrow {


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR fixes the `select` component style bug. 
-> https://trello.com/c/382GQZ73/3106-mooc-bug-daffichage-du-select-all-courses

**Result and observation**

Before
<img width="1508" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/a1121a72-bd78-45d4-9d17-46335866f9a7">

After
![Kapture 2023-06-15 at 15 02 18](https://github.com/CoorpAcademy/components/assets/79636283/09ef5cc3-97ab-4a8c-a365-c87c9695a9fa)

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
