### PR TITLE
fix popin content

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
@@ -46,8 +46,7 @@
 }
 
 .popin {
-  overflow: auto;
-  width: 434px;
+  width: fit-content;
   flex-grow: 0;
   margin: 16px;
   padding: 16px 16px 20px 16px;


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR fixes the popin component style bug.
-> https://trello.com/c/a2GN1VPq/3071-css-agrandir-la-largeur-de-la-notification-davertissement-vous-quittez-le-cours-sans-le-valider-en-allemand-car-elle-ne-passe-pa

**Result and observation**
Before
<img width="1158" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/9c2dff11-4c49-4d94-8f2a-b7ba0a89e679">

After
<img width="1158" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/f59ca4f9-9f96-47b7-a397-296707605b2f">

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
