### PR TITLE
RGAA: 11.4 - Filters switch, move label to the right

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/filters/filters-wapper.css
+++ b/packages/@coorpacademy-components/src/molecule/filters/filters-wapper.css
@@ -48,6 +48,17 @@
   user-select: none;
 }
 
+.switchContainer {
+  display: flex;
+}
+
+.switchTitle {
+  composes: title;
+  display: flex;
+  padding-top: 26px;
+  padding-left: 8px;
+}
+
 .timerSubtitle {
   border-radius: 25px;
   color: dark;
@@ -71,7 +82,7 @@
 }
 
 .toggle {
-  padding-top: 10px;
+  padding-top: 24px;
 }
 
 @media tablet {

--- a/packages/@coorpacademy-components/src/molecule/filters/filters-wrapper.js
+++ b/packages/@coorpacademy-components/src/molecule/filters/filters-wrapper.js
@@ -44,13 +44,18 @@ const FiltersWapper = (props, context) => {
         );
       case 'switch':
         return (
-          <div data-name="choice" data-filter-type={fieldName} className={style.choice} key={idx}>
-            <p id={`title-id-${idx}`} className={style.title}>
-              {filter.title}
-            </p>
+          <div
+            data-name="choice"
+            data-filter-type={fieldName}
+            className={classnames(style.choice, style.switchContainer)}
+            key={idx}
+          >
             <div className={style.toggle}>
               <InputSwitch {...filter.display} aria-labelledby={`title-id-${idx}`} />
             </div>
+            <label id={`title-id-${idx}`} className={style.switchTitle}>
+              {filter.title}
+            </label>
           </div>
         );
       default:


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- RGAA: 11.4 - Filters switch, move label to the right

**Result and observation**
<img width="1166" alt="Screenshot 2023-06-26 at 17 39 02" src="https://github.com/CoorpAcademy/components/assets/33550261/a3dd7188-490a-483f-9d16-b0d709ef4aec">

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
