### PR TITLE
[massive-battle] create new component and update `BrandFormGroup` component

### DIFF
--- a/packages/@coorpacademy-components/src/atom/title/index.js
+++ b/packages/@coorpacademy-components/src/atom/title/index.js
@@ -10,6 +10,8 @@ const getTitleStyle = (type, size) => {
       switch (size) {
         case 'standard':
           return style.titleFormGroup;
+        case 'medium':
+          return style.mediumTitleFormGroup;
         case 'small':
           return style.smallTitleFormGroup;
       }
@@ -26,6 +28,8 @@ const getSubtitleStyle = (type, size) => {
           return style.subtitleFormGroup;
         case 'small':
           return style.smallSubtitleFormGroup;
+        case 'small-without-margin':
+          return style.smallSubtitleFormGroupWithoutMargin;
         case 'extra-small':
           return style.extraSmallSubtitleFormGroup;
       }
@@ -61,7 +65,7 @@ Title.propTypes = {
   subtitle: PropTypes.string,
   type: PropTypes.oneOf(['page', 'form-group']),
   'data-name': PropTypes.string,
-  titleSize: PropTypes.oneOf(['standard', 'small']),
-  subtitleSize: PropTypes.oneOf(['standard', 'small', 'extra-small'])
+  titleSize: PropTypes.oneOf(['standard', 'medium', 'small']),
+  subtitleSize: PropTypes.oneOf(['standard', 'small', 'small-without-margin', 'extra-small'])
 };
 export default Title;

--- a/packages/@coorpacademy-components/src/atom/title/style.css
+++ b/packages/@coorpacademy-components/src/atom/title/style.css
@@ -20,6 +20,11 @@
     font-size: 18px;
 }
 
+.mediumTitleFormGroup {
+    composes: title;
+    font-size: 16px;
+}
+
 .smallTitleFormGroup {
     composes: title;
     font-size: 14px;
@@ -51,10 +56,14 @@
     color: cm_grey_400;
 }
 
-
 .smallSubtitleFormGroup{
     composes: subtitleFormGroup;
     max-width: 450px
+}
+
+.smallSubtitleFormGroupWithoutMargin{
+    composes: smallSubtitleFormGroup;
+    margin: 0;  
 }
 
 .extraSmallSubtitleFormGroup{

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/index.js
@@ -23,6 +23,7 @@ import Title from '../../atom/title';
 import Roles from '../coorp-manager-roles';
 import TitleAndCheckBoxWrapper from '../title-and-checkbox-wrapper';
 import ButtonLink from '../../atom/button-link';
+import TitleAndInput from '../../organism/title-and-input';
 import style from './style.css';
 
 const inputContainerStyle = {
@@ -86,6 +87,8 @@ const buildInput = field => {
       return <Roles {...field} />;
     case 'titleAndCheckBoxWrapper':
       return <TitleAndCheckBoxWrapper {...field} />;
+    case 'titleAndInput':
+      return <TitleAndInput {...field} />;
     default:
       return <InputText {...field} />;
   }
@@ -93,11 +96,12 @@ const buildInput = field => {
 
 const buildField = (field, index) => {
   const input = buildInput(field);
-  const {theme, size = 'default'} = field;
+  const {theme, size = 'default'} = field.type === 'titleAndInput' ? field.field : field;
   const styleInput = theme === 'coorpmanager' ? inputContainerStyle[size] : style.field;
+  const styleField = field.type === 'titleAndInput' ? style.fieldMassiveBattle : styleInput;
 
   return (
-    <div className={styleInput} key={index}>
+    <div className={styleField} key={index}>
       {input}
     </div>
   );
@@ -227,7 +231,11 @@ BrandFormGroup.propTypes = {
         ...Roles.propTypes,
         type: PropTypes.oneOf(['roles'])
       }),
-      PropTypes.shape(InputText.propTypes)
+      PropTypes.shape(InputText.propTypes),
+      PropTypes.shape({
+        ...TitleAndInput.propTypes,
+        type: PropTypes.oneOf(['titleAndInput'])
+      })
     ])
   )
 };

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/style.css
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/style.css
@@ -73,6 +73,10 @@
   width: 100%;
 }
 
+.fieldMassiveBattle {
+  margin: 0 0 48px 0;
+}
+
 .imageUploadContainer {
  display: flex;
  flex-direction: column;

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/cm-massive-battle.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/cm-massive-battle.js
@@ -1,5 +1,6 @@
 import TitleAndAutocomplete from '../../../../organism/title-and-input/test/fixtures/autocomplete-and-title';
 import TitleAndSelectOpponents from '../../../../organism/title-and-input/test/fixtures/select-opponents-and-title';
+import TitleAndSelectMultiple from '../../../../organism/title-and-input/test/fixtures/select-multiple-and-title';
 
 export default {
   props: {
@@ -27,39 +28,8 @@ export default {
         childType: 'autoComplete'
       },
       {
-        type: 'titleAndInput',
-        title: {
-          title: '4. Difficulty level',
-          type: 'form-group',
-          subtitle: 'Level of difficulty (if it is easy, the population is more likely to win)'
-        },
-        field: {
-          title: 'Difficulty level',
-          description: 'Level of difficulty (if it is easy, the population is more likely to win)',
-          required: true,
-          multiple: false,
-          theme: 'coorpmanager',
-          options: [
-            {
-              value: '0.2',
-              name: 'Easy (20% of well answered questions)',
-              selected: true
-            },
-            {
-              value: '0.5',
-              name: 'Average (50% of well answered questions)',
-              selected: false
-            },
-            {
-              value: '0.8',
-              name: 'Hard (80% of well answered questions)',
-              selected: false
-            }
-          ],
-          onChange: value => console.log('onChange', value),
-          onError: () => true
-        },
-        childType: 'selectMultiple'
+        ...TitleAndSelectMultiple.props,
+        type: 'titleAndInput'
       }
     ]
   }

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/cm-massive-battle.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/cm-massive-battle.js
@@ -23,7 +23,8 @@ export default {
         field: {
           ...TitleAndAutocomplete.props.field,
           title: 'Choose a course'
-        }
+        },
+        childType: 'autoComplete'
       },
       {
         type: 'titleAndInput',
@@ -34,7 +35,6 @@ export default {
         },
         field: {
           title: 'Difficulty level',
-          type: 'selectMultiple',
           description: 'Level of difficulty (if it is easy, the population is more likely to win)',
           required: true,
           multiple: false,
@@ -58,7 +58,8 @@ export default {
           ],
           onChange: value => console.log('onChange', value),
           onError: () => true
-        }
+        },
+        childType: 'selectMultiple'
       }
     ]
   }

--- a/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/cm-massive-battle.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-form-group/test/fixtures/cm-massive-battle.js
@@ -1,0 +1,65 @@
+import TitleAndAutocomplete from '../../../../organism/title-and-input/test/fixtures/autocomplete-and-title';
+import TitleAndSelectOpponents from '../../../../organism/title-and-input/test/fixtures/select-opponents-and-title';
+
+export default {
+  props: {
+    title: 'Massive Battle',
+    fields: [
+      {
+        ...TitleAndAutocomplete.props,
+        type: 'titleAndInput'
+      },
+      {
+        ...TitleAndSelectOpponents.props,
+        type: 'titleAndInput'
+      },
+      {
+        type: 'titleAndInput',
+        title: {
+          type: 'form-group',
+          title: '3. Course',
+          subtitle: 'Choose one course to challenge your colleagues on'
+        },
+        field: {
+          ...TitleAndAutocomplete.props.field,
+          title: 'Choose a course'
+        }
+      },
+      {
+        type: 'titleAndInput',
+        title: {
+          title: '4. Difficulty level',
+          type: 'form-group',
+          subtitle: 'Level of difficulty (if it is easy, the population is more likely to win)'
+        },
+        field: {
+          title: 'Difficulty level',
+          type: 'selectMultiple',
+          description: 'Level of difficulty (if it is easy, the population is more likely to win)',
+          required: true,
+          multiple: false,
+          theme: 'coorpmanager',
+          options: [
+            {
+              value: '0.2',
+              name: 'Easy (20% of well answered questions)',
+              selected: true
+            },
+            {
+              value: '0.5',
+              name: 'Average (50% of well answered questions)',
+              selected: false
+            },
+            {
+              value: '0.8',
+              name: 'Hard (80% of well answered questions)',
+              selected: false
+            }
+          ],
+          onChange: value => console.log('onChange', value),
+          onError: () => true
+        }
+      }
+    ]
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
@@ -162,7 +162,7 @@ const SelectMultiple = (
       )}
     >
       {title}
-      {isCMTheme ? (
+      {description && isCMTheme ? (
         <div className={style.infoIconWrapper}>
           <InfoIcon className={style.infoIcon} />
           <div className={style.descriptionLabel}>{description}</div>

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/style.css
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/style.css
@@ -6,5 +6,5 @@
 
 .field {
     margin-left: 40px;
-    width: 40%;
+    max-width: 300px;
 }

--- a/packages/@coorpacademy-components/src/organism/brand-form/index.js
+++ b/packages/@coorpacademy-components/src/organism/brand-form/index.js
@@ -81,7 +81,7 @@ const BrandForm = (props, context) => {
   } = props;
   const {skin} = context;
   const darkColor = get('common.dark', skin);
-  const massiveBattleForm = groups[0].fields[0].type === 'titleAndInput';
+  const massiveBattleForm = groups[0]?.fields[0]?.type === 'titleAndInput';
   const backView = back ? (
     <p className={style.back}>
       <ArrowLeft style={{color: darkColor}} className={style.arrowBack} />

--- a/packages/@coorpacademy-components/src/organism/brand-form/index.js
+++ b/packages/@coorpacademy-components/src/organism/brand-form/index.js
@@ -20,7 +20,8 @@ const buildButtonSection = (
   isModified,
   isPending,
   darkColor,
-  theme
+  theme,
+  massiveBattleForm
 ) => {
   if (!onSubmit && !onReset) {
     return null;
@@ -28,7 +29,11 @@ const buildButtonSection = (
 
   const disabledSubmit = disabled || isPending || !isModified;
   const submitButton = onSubmit ? (
-    <div data-tip={tooltip.title} data-for="submitButton" className={style.saveButton}>
+    <div
+      data-tip={tooltip.title}
+      data-for="submitButton"
+      className={massiveBattleForm ? style.massiveBattleButton : style.saveButton}
+    >
       {theme === 'coorpmanager' ? (
         <ButtonLink
           type="primary"
@@ -47,7 +52,7 @@ const buildButtonSection = (
   const cancelBackground = {backgroundColor: darkColor};
 
   const resetButton = onReset ? (
-    <div className={style.resetButton}>
+    <div className={massiveBattleForm ? style.massiveBattleButton : style.resetButton}>
       <Button type="reset" submitValue={resetValue} style={cancelBackground} />
     </div>
   ) : null;
@@ -76,7 +81,7 @@ const BrandForm = (props, context) => {
   } = props;
   const {skin} = context;
   const darkColor = get('common.dark', skin);
-
+  const massiveBattleForm = groups[0].fields[0].type === 'titleAndInput';
   const backView = back ? (
     <p className={style.back}>
       <ArrowLeft style={{color: darkColor}} className={style.arrowBack} />
@@ -104,7 +109,8 @@ const BrandForm = (props, context) => {
     isModified,
     isPending,
     darkColor,
-    theme
+    theme,
+    massiveBattleForm
   );
 
   const handleSubmit = useMemo(

--- a/packages/@coorpacademy-components/src/organism/brand-form/index.js
+++ b/packages/@coorpacademy-components/src/organism/brand-form/index.js
@@ -52,7 +52,7 @@ const buildButtonSection = (
   const cancelBackground = {backgroundColor: darkColor};
 
   const resetButton = onReset ? (
-    <div className={massiveBattleForm ? style.massiveBattleButton : style.resetButton}>
+    <div className={style.resetButton}>
       <Button type="reset" submitValue={resetValue} style={cancelBackground} />
     </div>
   ) : null;

--- a/packages/@coorpacademy-components/src/organism/brand-form/style.css
+++ b/packages/@coorpacademy-components/src/organism/brand-form/style.css
@@ -60,6 +60,11 @@
   composes: button;
 }
 
+.massiveBattleButton {
+  composes: button;
+  margin-bottom: 40px;
+}
+
 .loaderContainer {
   width: 100%;
   height: 50vh;

--- a/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import has from 'lodash/fp/has';
 import Title from '../../atom/title';
 import Autocomplete from '../../atom/autocomplete';
 import SelectMultiple from '../../molecule/select-multiple';
@@ -21,7 +20,8 @@ const buildInput = (childType: string, field: any) => {
 const TitleAndInput = (props: TitleAndInputProps) => {
   const {title, field, childType} = props;
   const input = buildInput(childType, field);
-  const styleInput = has('items', field) ? style.selectOpponentContainer : style.inputContainer;
+  const styleInput =
+    childType === 'selectOpponents' ? style.selectOpponentContainer : style.inputContainer;
   return (
     <div>
       <Title

--- a/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
@@ -7,10 +7,8 @@ import SelectOpponents from '../select-opponents';
 import propTypes, {TitleAndInputProps} from './types';
 import style from './style.css';
 
-const buildInput = (field: any) => {
-  const {type} = field;
-
-  switch (type) {
+const buildInput = (childType: string, field: any) => {
+  switch (childType) {
     case 'autoComplete':
       return <Autocomplete {...field} />;
     case 'selectMultiple':
@@ -21,8 +19,8 @@ const buildInput = (field: any) => {
 };
 
 const TitleAndInput = (props: TitleAndInputProps) => {
-  const {title, field} = props;
-  const input = buildInput(field);
+  const {title, field, childType} = props;
+  const input = buildInput(childType, field);
   const styleInput = has('items', field) ? style.selectOpponentContainer : style.inputContainer;
   return (
     <div>

--- a/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
@@ -21,7 +21,7 @@ const TitleAndInput = (props: TitleAndInputProps) => {
   const {title, field, childType} = props;
   const input = buildInput(childType, field);
   const styleInput =
-    childType === 'selectOpponents' ? style.selectOpponentContainer : style.inputContainer;
+    childType === 'selectOpponents' ? style.selectOpponentsContainer : style.inputContainer;
   return (
     <div>
       <Title

--- a/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import has from 'lodash/fp/has';
+import Title from '../../atom/title';
+import Autocomplete from '../../atom/autocomplete';
+import SelectMultiple from '../../molecule/select-multiple';
+import SelectOpponents from '../select-opponents';
+import propTypes, {TitleAndInputProps} from './types';
+import style from './style.css';
+
+const buildInput = (field: any) => {
+  const {type} = field;
+
+  switch (type) {
+    case 'autoComplete':
+      return <Autocomplete {...field} />;
+    case 'selectMultiple':
+      return <SelectMultiple {...field} />;
+    default:
+      return <SelectOpponents {...field} />;
+  }
+};
+
+const TitleAndInput = (props: TitleAndInputProps) => {
+  const {title, field} = props;
+  const input = buildInput(field);
+  const styleInput = has('items', field) ? style.selectOpponentContainer : style.inputContainer;
+  return (
+    <div>
+      <Title
+        {...title}
+        type={'form-group'}
+        titleSize={'medium'}
+        subtitleSize={'small-without-margin'}
+      />
+      <div className={styleInput}>{input}</div>
+    </div>
+  );
+};
+
+TitleAndInput.propTypes = propTypes;
+
+export default TitleAndInput;

--- a/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
@@ -6,7 +6,10 @@ import SelectOpponents from '../select-opponents';
 import propTypes, {TitleAndInputProps} from './types';
 import style from './style.css';
 
-const buildInput = (childType: string, field: any) => {
+const buildInput = (
+  childType: TitleAndInputProps['childType'],
+  field: TitleAndInputProps['field']
+) => {
   switch (childType) {
     case 'autoComplete':
       return <Autocomplete {...field} />;

--- a/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/index.tsx
@@ -12,7 +12,7 @@ const buildInput = (childType: string, field: any) => {
       return <Autocomplete {...field} />;
     case 'selectMultiple':
       return <SelectMultiple {...field} />;
-    default:
+    case 'selectOpponents':
       return <SelectOpponents {...field} />;
   }
 };

--- a/packages/@coorpacademy-components/src/organism/title-and-input/style.css
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/style.css
@@ -3,7 +3,7 @@
     max-width: 300px;
 }
 
-.selectOpponentContainer {
+.selectOpponentsContainer {
     margin-top: 16px;
 }
 

--- a/packages/@coorpacademy-components/src/organism/title-and-input/style.css
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/style.css
@@ -1,0 +1,9 @@
+.inputContainer {
+    margin-top: 16px;
+    max-width: 300px;
+}
+
+.selectOpponentContainer {
+    margin-top: 16px;
+}
+

--- a/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/autocomplete-and-title.js
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/autocomplete-and-title.js
@@ -8,9 +8,8 @@ export default {
       subtitle: 'Define the user who will send the battle'
     },
     field: {
-      ...Autocomplete.props,
-      type: 'autoComplete'
+      ...Autocomplete.props
     },
-    type: 'titleAndInput'
+    childType: 'autoComplete'
   }
 };

--- a/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/autocomplete-and-title.js
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/autocomplete-and-title.js
@@ -1,0 +1,16 @@
+import Autocomplete from '../../../../atom/autocomplete/test/fixtures/cm-default';
+
+export default {
+  props: {
+    title: {
+      type: 'form-group',
+      title: '1. Battle sender',
+      subtitle: 'Define the user who will send the battle'
+    },
+    field: {
+      ...Autocomplete.props,
+      type: 'autoComplete'
+    },
+    type: 'titleAndInput'
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/select-multiple-and-title.js
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/select-multiple-and-title.js
@@ -1,0 +1,16 @@
+import SelectMultiple from '../../../../molecule/select-multiple/test/fixtures/checked-cm-theme';
+
+export default {
+  props: {
+    title: {
+      type: 'form-group',
+      title: '4. Difficulty level',
+      subtitle: 'If it is easy, the population is more likely to win'
+    },
+    field: {
+      ...SelectMultiple.props,
+      type: 'selectMultiple'
+    },
+    type: 'titleAndInput'
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/select-multiple-and-title.js
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/select-multiple-and-title.js
@@ -8,9 +8,8 @@ export default {
       subtitle: 'If it is easy, the population is more likely to win'
     },
     field: {
-      ...SelectMultiple.props,
-      type: 'selectMultiple'
+      ...SelectMultiple.props
     },
-    type: 'titleAndInput'
+    childType: 'selectMultiple'
   }
 };

--- a/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/select-multiple-and-title.js
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/select-multiple-and-title.js
@@ -1,14 +1,35 @@
-import SelectMultiple from '../../../../molecule/select-multiple/test/fixtures/checked-cm-theme';
-
 export default {
   props: {
     title: {
       type: 'form-group',
       title: '4. Difficulty level',
-      subtitle: 'If it is easy, the population is more likely to win'
+      subtitle: 'Level of difficulty (if it is easy, the population is more likely to win)'
     },
     field: {
-      ...SelectMultiple.props
+      title: 'Difficulty level',
+      description: 'Level of difficulty (if it is easy, the population is more likely to win)',
+      required: true,
+      multiple: false,
+      theme: 'coorpmanager',
+      options: [
+        {
+          value: '0.2',
+          name: 'Easy (20% of well answered questions)',
+          selected: true
+        },
+        {
+          value: '0.5',
+          name: 'Average (50% of well answered questions)',
+          selected: false
+        },
+        {
+          value: '0.8',
+          name: 'Hard (80% of well answered questions)',
+          selected: false
+        }
+      ],
+      onChange: value => console.log('onChange', value),
+      onError: () => true
     },
     childType: 'selectMultiple'
   }

--- a/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/select-opponents-and-title.js
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/select-opponents-and-title.js
@@ -1,0 +1,15 @@
+import SelectOpponents from '../../../select-opponents/test/fixtures/default';
+
+export default {
+  props: {
+    title: {
+      type: 'form-group',
+      title: '2. Opponents',
+      subtitle: 'Choose the population who will receive the battle'
+    },
+    field: {
+      ...SelectOpponents.props
+    },
+    type: 'titleAndInput'
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/select-opponents-and-title.js
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/test/fixtures/select-opponents-and-title.js
@@ -10,6 +10,6 @@ export default {
     field: {
       ...SelectOpponents.props
     },
-    type: 'titleAndInput'
+    childType: 'selectOpponents'
   }
 };

--- a/packages/@coorpacademy-components/src/organism/title-and-input/types.ts
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/types.ts
@@ -21,7 +21,10 @@ export type TitleAndInputProps = {
     type: string;
     'data-name': string;
   };
-  field: typeof SelectMultiple.propTypes | typeof Autocomplete.propTypes | SelectOpponentsProps;
+  field:
+    | React.ComponentProps<typeof SelectMultiple>
+    | React.ComponentProps<typeof Autocomplete>
+    | SelectOpponentsProps;
   childType: string;
 };
 

--- a/packages/@coorpacademy-components/src/organism/title-and-input/types.ts
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/types.ts
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+import Autocomplete from '../../atom/autocomplete';
+import Title from '../../atom/title';
+import SelectMultiple from '../../molecule/select-multiple';
+import SelectOpponents from '../select-opponents';
+import {SelectOpponentsProps} from '../select-opponents/types';
+
+const propTypes = {
+  type: PropTypes.string.isRequired,
+  title: PropTypes.shape(Title.propTypes).isRequired,
+  field: PropTypes.oneOfType([
+    PropTypes.shape(Autocomplete.propTypes),
+    PropTypes.shape(SelectMultiple.propTypes),
+    PropTypes.shape(SelectOpponents.propTypes)
+  ])
+};
+export type TitleAndInputProps = {
+  type: string;
+  title: {
+    title: string;
+    subtitle: string;
+    type: string;
+    'data-name': string;
+  };
+  field: typeof SelectMultiple.propTypes | typeof Autocomplete.propTypes | SelectOpponentsProps;
+};
+
+export default propTypes;

--- a/packages/@coorpacademy-components/src/organism/title-and-input/types.ts
+++ b/packages/@coorpacademy-components/src/organism/title-and-input/types.ts
@@ -6,16 +6,15 @@ import SelectOpponents from '../select-opponents';
 import {SelectOpponentsProps} from '../select-opponents/types';
 
 const propTypes = {
-  type: PropTypes.string.isRequired,
   title: PropTypes.shape(Title.propTypes).isRequired,
   field: PropTypes.oneOfType([
     PropTypes.shape(Autocomplete.propTypes),
     PropTypes.shape(SelectMultiple.propTypes),
     PropTypes.shape(SelectOpponents.propTypes)
-  ])
+  ]),
+  childType: PropTypes.oneOf(['autoComplete', 'selectMultiple', 'selectOpponents']).isRequired
 };
 export type TitleAndInputProps = {
-  type: string;
   title: {
     title: string;
     subtitle: string;
@@ -23,6 +22,7 @@ export type TitleAndInputProps = {
     'data-name': string;
   };
   field: typeof SelectMultiple.propTypes | typeof Autocomplete.propTypes | SelectOpponentsProps;
+  childType: string;
 };
 
 export default propTypes;


### PR DESCRIPTION
**Detailed purpose of the PR**
* Create component organism `TitleAndInput`.
* Modify atom `Title` to add different sizes of title and subtitle.
* Import component `TitleAndInput` in `BrandFormGroup`.
* Modify organism `BrandForm` to add margin between form's button and 'history' section.
* Fix  bug related to tooltip style of organism `SelectMultiple`.

Trello ticket : https://trello.com/c/tm8VfS3e/3097-adapt-rewardfrom-component-with-radio-button

**Result and observation**
* component `TitleAndInput`:
<img width="1509" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/c6b3e91f-776f-476a-b19e-08892a69bc06">

<img width="1508" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/a7b32b92-52f9-42e5-89e5-327e3603a115">


* component `BrandFormGroup`:
![Kapture 2023-07-11 at 18 15 32](https://github.com/CoorpAcademy/components/assets/79636283/302fa1e8-8602-47ad-95e7-6340f1e6e455)

* component `BrandForm`:
BEFORE
<img width="1508" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/a1d6facf-9c1d-45b0-acfe-c3a6927e976c">

AFTER
<img width="1508" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/0e067064-227a-4eda-9ced-b0ea9494efc5">

* component `SelectMultiple`:
BEFORE
<img width="1135" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/4efe14e8-f02a-406c-987d-596b8aeb0388">
AFTER
<img width="1135" alt="Screenshot 2023-07-12 at 11 09 07" src="https://github.com/CoorpAcademy/components/assets/79636283/7c2ac676-7aeb-49a1-a228-f7bdbc39221d">

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
