### PR TITLE
fix the news section preview

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/news/style.css
+++ b/packages/@coorpacademy-components/src/molecule/news/style.css
@@ -26,18 +26,20 @@
   display: flex;
   align-items: center;
   flex: 3;
+  height: 100%;
 }
 
 .linkImage {
   height: 100%;
   display: flex;
   flex: 3;
+  height: 100%;
   align-items: center;
 }
 
 .image img {
   width: 100%;
-  height: auto;
+  height: 100%;
 }
 
 .infos {
@@ -50,6 +52,7 @@
   justify-content: space-around;
   min-width: 0;
   flex: 4;
+  height: 100%;
   display: flex;
 }
 
@@ -112,6 +115,7 @@
 
   .image {
     flex: 3;
+    height: 100%;
   }
 
   .infos {
@@ -119,6 +123,7 @@
     position: relative;
     justify-content: flex-start;
     flex: 4;
+    height: 100%;
     display: flex;
   }
 
@@ -150,6 +155,7 @@
 
   .image {
     flex: 3;
+    height: 100%;
     height: 100px;
   }
 
@@ -157,6 +163,7 @@
     padding: 15px;
     justify-content: center;
     flex: 4;
+    height: 100%;
     display: flex;
   }
 

--- a/packages/@coorpacademy-components/src/molecule/news/style.css
+++ b/packages/@coorpacademy-components/src/molecule/news/style.css
@@ -16,6 +16,7 @@
   border: 1px solid light;
   box-sizing: border-box;
   overflow: hidden;
+  display: flex;
 }
 
 .image {
@@ -24,11 +25,13 @@
   flex: 0 0 450px;
   display: flex;
   align-items: center;
+  flex: 1;
 }
 
 .linkImage {
   height: 100%;
   display: flex;
+  flex: 1;
   align-items: center;
 }
 
@@ -46,6 +49,8 @@
   flex-direction: column;
   justify-content: space-around;
   min-width: 0;
+  flex: 2;
+  display: flex;
 }
 
 .title {
@@ -102,16 +107,19 @@
 @media tablet {
   .news {
     height: 150px;
+    display: flex;
   }
 
   .image {
-    flex: 0 0 250px;
+    flex: 1;
   }
 
   .infos {
     padding: 30px;
     position: relative;
     justify-content: flex-start;
+    flex: 2;
+    display: flex;
   }
 
   .author {
@@ -137,16 +145,19 @@
     cursor: pointer;
     height: 100px;
     border: 1px solid light;
+    display: flex;
   }
 
   .image {
-    flex: 0 0 100px;
+    flex: 1;
     height: 100px;
   }
 
   .infos {
     padding: 15px;
     justify-content: center;
+    flex: 2;
+    display: flex;
   }
 
   .title {

--- a/packages/@coorpacademy-components/src/molecule/news/style.css
+++ b/packages/@coorpacademy-components/src/molecule/news/style.css
@@ -25,13 +25,13 @@
   flex: 0 0 450px;
   display: flex;
   align-items: center;
-  flex: 1;
+  flex: 3;
 }
 
 .linkImage {
   height: 100%;
   display: flex;
-  flex: 1;
+  flex: 3;
   align-items: center;
 }
 
@@ -49,7 +49,7 @@
   flex-direction: column;
   justify-content: space-around;
   min-width: 0;
-  flex: 2;
+  flex: 4;
   display: flex;
 }
 
@@ -111,14 +111,14 @@
   }
 
   .image {
-    flex: 1;
+    flex: 3;
   }
 
   .infos {
     padding: 30px;
     position: relative;
     justify-content: flex-start;
-    flex: 2;
+    flex: 4;
     display: flex;
   }
 
@@ -149,14 +149,14 @@
   }
 
   .image {
-    flex: 1;
+    flex: 3;
     height: 100px;
   }
 
   .infos {
     padding: 15px;
     justify-content: center;
-    flex: 2;
+    flex: 4;
     display: flex;
   }
 


### PR DESCRIPTION
[Ticket](https://trello.com/c/payUHq1l/565-am%C3%A9lioration-news-preview)
fix the news section preview
Avant 
<img width="1280" alt="image" src="https://github.com/CoorpAcademy/components/assets/58167920/e0a74df8-bee9-4740-ba1a-6cb214c551d4">

Aprés 
<img width="1285" alt="image" src="https://github.com/CoorpAcademy/components/assets/58167920/5947c3d5-eb17-4328-a14f-6bda12599db3">


**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
