### PR TITLE
[massive-battle] show uploaded file name in drag and drop components

### DIFF
--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
@@ -112,6 +112,14 @@ class DragAndDrop extends React.Component {
           />
         </div>
       );
+    } else if (previewContent && previewContent.type === 'xlsx' && !loading) {
+      previewView = (
+        <div className={style.previewXlsxContainer}>
+          <div className={style.previewXlsx}>
+            <FileUploadBlockedIcon className={style.iconFile} />
+          </div>
+        </div>
+      );
     } else if (loading) {
       previewView = (
         <div className={style.loaderWrapper}>

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
@@ -113,7 +113,7 @@ class DragAndDrop extends React.Component {
           />
         </div>
       );
-    } else if (previewContent && previewContent.type === 'xlsx' && !loading) {
+    } else if (previewContent && previewContent.type === 'xlsx') {
       previewView = (
         <div className={style.previewXlsxContainer}>
           <div className={style.previewXlsx}>

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/index.js
@@ -4,7 +4,8 @@ import {uniqueId, constant, isEmpty} from 'lodash/fp';
 import {
   NovaSolidStatusClose as Close,
   NovaSolidFilesBasicFileUpload2 as FileUploadIcon,
-  NovaSolidFilesBasicFileBlock2 as FileUploadBlockedIcon
+  NovaSolidFilesBasicFileBlock2 as FileUploadBlockedIcon,
+  NovaSolidFilesBasicFileLines as FileLinesIcon
 } from '@coorpacademy/nova-icons';
 import classnames from 'classnames';
 import Loader from '../loader';
@@ -116,7 +117,7 @@ class DragAndDrop extends React.Component {
       previewView = (
         <div className={style.previewXlsxContainer}>
           <div className={style.previewXlsx}>
-            <FileUploadBlockedIcon className={style.iconFile} />
+            <FileLinesIcon className={style.iconFile} />
           </div>
         </div>
       );

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
@@ -104,33 +104,8 @@ video {
   white-space: nowrap;
 }
 
-.previewXlsxContainer {
-  padding: 16px;
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-}
 
-.previewXlsx {
-background-color: #E5E5E5;
-border-radius: 5px;
-width: 38%;
-height: 70%;
-display: flex;
-align-items: center;
-justify-content: center;
-padding: 34px;
-}
 
-.iconFile {
-  height: 24%;
-  width: 24%;
-  color: #C5C5C9;
-}
 .infosContainer {
   width: 100%;
   height: 100%;
@@ -255,7 +230,7 @@ padding: 34px;
   max-width: 30px;
   max-height: 30px;
   height: 20%;
-  width: 20%;;
+  width: 20%;
   transition: all 0.2s cubic-bezier(0.47, 1.04, 0.46, 2.16);
 }
 
@@ -306,4 +281,29 @@ padding: 34px;
   color: cm_negative_100;
   font-size: 12px;
   margin-top: 8px;
+}
+
+.previewXlsxContainer {
+  composes: preview;
+  background-color: transparent;
+}
+
+.previewXlsx {
+  background-color: #E5E5E5;
+  border-radius: 5px;
+  width: 38%;
+  height: 70%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 34px;
+}
+
+.iconFile {
+  composes: icon;
+  max-width: 32px;
+  max-height: 32px;
+  height: 25%;
+  width: 25%;
+  color: #C5C5C9;
 }

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
@@ -118,17 +118,17 @@ video {
 .previewXlsx {
 background-color: #E5E5E5;
 border-radius: 5px;
-width: 50%;
+width: 38%;
 height: 70%;
 display: flex;
 align-items: center;
 justify-content: center;
-padding: 35px;
+padding: 34px;
 }
 
 .iconFile {
-  height: 25%;
-  width: 25%;
+  height: 24%;
+  width: 24%;
   color: #C5C5C9;
 }
 .infosContainer {

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
@@ -103,6 +103,34 @@ video {
   max-width: 90%;
   white-space: nowrap;
 }
+
+.previewXlsxContainer {
+  padding: 16px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.previewXlsx {
+background-color: #E5E5E5;
+border-radius: 5px;
+width: 50%;
+height: 70%;
+display: flex;
+align-items: center;
+justify-content: center;
+padding: 35px;
+}
+
+.iconFile {
+  height: 25%;
+  width: 25%;
+  color: #C5C5C9;
+}
 .infosContainer {
   width: 100%;
   height: 100%;
@@ -172,7 +200,7 @@ video {
   align-items: center;
   justify-content: space-between;
   margin-top: 16px;
-  padding: 8px 14px 8px 1px;
+  padding: 8px 14px 8px 8px;
   font-size: 12px;
   font-weight: 400;
   position: relative;
@@ -190,6 +218,7 @@ video {
   cursor: pointer;
   color: cm_grey_400;
   margin-left: 6px;
+  margin-right: 8px;
   height: 15px;
   width: 15px;
   position: absolute;

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
@@ -104,8 +104,6 @@ video {
   white-space: nowrap;
 }
 
-
-
 .infosContainer {
   width: 100%;
   height: 100%;

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/style.css
@@ -287,7 +287,7 @@ video {
 }
 
 .previewXlsx {
-  background-color: #E5E5E5;
+  background-color: cm_grey_100;
   border-radius: 5px;
   width: 38%;
   height: 70%;
@@ -303,5 +303,5 @@ video {
   max-height: 32px;
   height: 25%;
   width: 25%;
-  color: #C5C5C9;
+  color: cm_grey_300;
 }

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/with-xlsx.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/with-xlsx.js
@@ -1,0 +1,14 @@
+export default {
+  props: {
+    title: 'Drag & Drop With XLSX',
+    description: 'Drag and drop component with a xlsx',
+    uploadLabel: 'Upload Excel file',
+    previewLabel: 'File Preview',
+    previewContent: {
+      type: 'xlsx',
+      src: 'https://static.coorpacademy.com/content/digital/raw/meta_inc-1677774948417._logo-1-1677774948417.pdf',
+      label: 'opponents-error-report.xlsx'
+    },
+    onReset: () => console.log('reset')
+  }
+};

--- a/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/with-xlsx.js
+++ b/packages/@coorpacademy-components/src/atom/drag-and-drop/test/fixtures/with-xlsx.js
@@ -1,12 +1,12 @@
 export default {
   props: {
     title: 'Drag & Drop With XLSX',
-    description: 'Drag and drop component with a xlsx',
-    uploadLabel: 'Upload Excel file',
+    description: 'XLSX or XLS, smaller than 5mb',
+    uploadLabel: 'Browse',
     previewLabel: 'File Preview',
     previewContent: {
       type: 'xlsx',
-      src: 'https://static.coorpacademy.com/content/digital/raw/meta_inc-1677774948417._logo-1-1677774948417.pdf',
+      src: 'https://setup.coorpacademy.com/assets/templates/import-users-template.xlsx',
       label: 'opponents-error-report.xlsx'
     },
     onReset: () => console.log('reset')

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import isEmpty from 'lodash/fp/isEmpty';
 import RadioWithTitle from '../../atom/radio-with-title';
 import SelectMultiple from '../select-multiple';
 import ImageUpload from '../../atom/image-upload';
@@ -9,7 +10,9 @@ const buildInput = (childType: string, field: any) => {
   return childType === 'select-multiple' ? (
     <SelectMultiple {...field} />
   ) : (
-    <ImageUpload {...field} />
+    <div className={field.loading || isEmpty(field.previewContent) ? style.containerUpload : ''}>
+      <ImageUpload {...field} />
+    </div>
   );
 };
 

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import isEmpty from 'lodash/fp/isEmpty';
 import RadioWithTitle from '../../atom/radio-with-title';
 import SelectMultiple from '../select-multiple';
 import ImageUpload from '../../atom/image-upload';
@@ -6,14 +7,18 @@ import propTypes, {TitleRadioWrapperProps} from './types';
 import style from './style.css';
 
 const getContainerStyle = (field: Record<string, unknown>, childType: string): string => {
-  return childType === 'massive-upload' && field.loading ? style.containerUpload : style.container;
+  return childType === 'massive-upload' && (field.loading || isEmpty(field.previewContent))
+    ? style.containerUpload
+    : style.container;
 };
 
 const buildInput = (childType: string, field: any) => {
   return childType === 'select-multiple' ? (
     <SelectMultiple {...field} />
   ) : (
-    <div className={field.loading ? style.containerImageUpload : ''}>
+    <div
+      className={field.loading || isEmpty(field.previewContent) ? style.containerImageUpload : ''}
+    >
       <ImageUpload {...field} />
     </div>
   );

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/index.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
-import isEmpty from 'lodash/fp/isEmpty';
 import RadioWithTitle from '../../atom/radio-with-title';
 import SelectMultiple from '../select-multiple';
 import ImageUpload from '../../atom/image-upload';
 import propTypes, {TitleRadioWrapperProps} from './types';
 import style from './style.css';
 
+const getContainerStyle = (field: Record<string, unknown>, childType: string): string => {
+  return childType === 'massive-upload' && field.loading ? style.containerUpload : style.container;
+};
+
 const buildInput = (childType: string, field: any) => {
   return childType === 'select-multiple' ? (
     <SelectMultiple {...field} />
   ) : (
-    <div className={field.loading || isEmpty(field.previewContent) ? style.containerUpload : ''}>
+    <div className={field.loading ? style.containerImageUpload : ''}>
       <ImageUpload {...field} />
     </div>
   );
@@ -19,7 +22,7 @@ const buildInput = (childType: string, field: any) => {
 const TitleRadioWrapper = (props: TitleRadioWrapperProps) => {
   const {radioWithTitle, field, childType} = props;
   return (
-    <div className={style.container}>
+    <div className={getContainerStyle(field, childType)}>
       {radioWithTitle ? <RadioWithTitle {...radioWithTitle} /> : null}
       <div className={style.field}>{buildInput(childType, field)}</div>
     </div>

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/style.css
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/style.css
@@ -1,14 +1,20 @@
 .container {
-    display: flex;
-    gap: 16px;
-    flex-direction: column;
-}
-
-.field {
-    margin-left: 40px;
-    max-width: 300px;
+  display: flex;
+  gap: 16px;
+  flex-direction: column;
 }
 
 .containerUpload {
-  height: 141px;
+  composes: container;
+  margin-bottom: 60px ;
+
+}
+
+.field {
+  margin-left: 40px;
+  max-width: 300px;
+}
+
+.containerImageUpload {
+  height: 140px;
 }

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/style.css
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/style.css
@@ -8,3 +8,7 @@
     margin-left: 40px;
     max-width: 300px;
 }
+
+.containerUpload {
+  height: 141px;
+}

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/test/fixtures/upload-opponents-loading.ts
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/test/fixtures/upload-opponents-loading.ts
@@ -1,0 +1,11 @@
+import uploadOpponentsFixture from './upload-opponents';
+
+export default {
+  props: {
+    ...uploadOpponentsFixture.props,
+    field: {
+      ...uploadOpponentsFixture.props.field,
+      loading: true
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/test/fixtures/upload-opponents.ts
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/test/fixtures/upload-opponents.ts
@@ -12,7 +12,7 @@ export default {
       }
     },
     field: {
-      description: 'JPG or PNG, smaller than 5mb',
+      description: 'XLSX or XLS, smaller than 5mb',
       uploadLabel: 'Browse',
       previewLabel: 'File Preview',
       labelButtonLink: 'here',

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/test/fixtures/upload-opponents.ts
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/test/fixtures/upload-opponents.ts
@@ -1,0 +1,26 @@
+export default {
+  props: {
+    radioWithTitle: {
+      title: {
+        type: 'form-group',
+        title: 'Upload a list of specific users',
+        subtitle: 'Using an Excel file (mandatory column: email address)'
+      },
+      checked: false,
+      onChange: (value: boolean) => {
+        console.log('on change', value);
+      }
+    },
+    field: {
+      description: 'JPG or PNG, smaller than 5mb',
+      uploadLabel: 'Browse',
+      previewLabel: 'File Preview',
+      labelButtonLink: 'here',
+      labelLink: 'Need the template? Download it',
+      hrefLink: 'https://setup.coorpacademy.com/assets/templates/import-users-template.xlsx',
+      previewContent: {},
+      loading: false
+    },
+    childType: 'massive-upload'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/test/fixtures/upload-validated-opponents.ts
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/test/fixtures/upload-validated-opponents.ts
@@ -6,7 +6,7 @@ export default {
         title: 'Upload a list of specific users',
         subtitle: 'Using an Excel file (mandatory column: email address)'
       },
-      checked: false,
+      checked: true,
       onChange: (value: boolean) => {
         console.log('on change', value);
       }
@@ -17,7 +17,13 @@ export default {
       previewLabel: 'File Preview',
       labelButtonLink: 'here',
       labelLink: 'Need the template? Download it',
-      hrefLink: 'https://setup.coorpacademy.com/assets/templates/import-users-template.xlsx'
+      hrefLink: 'https://setup.coorpacademy.com/assets/templates/import-users-template.xlsx',
+      previewContent: {
+        type: 'xlsx',
+        src: 'https://static.coorpacademy.com/content/digital/raw/meta_inc-1677774948417._logo-1-1677774948417.pdf',
+        label: 'opponents-error-report.xlsx'
+      },
+      loading: false
     },
     childType: 'massive-upload'
   }

--- a/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/test/fixtures/upload-validated-opponents.ts
+++ b/packages/@coorpacademy-components/src/molecule/title-radio-wrapper/test/fixtures/upload-validated-opponents.ts
@@ -1,3 +1,5 @@
+import fixtureDragAndDropWithXlsx from '../../../../atom/drag-and-drop/test/fixtures/with-xlsx';
+
 export default {
   props: {
     radioWithTitle: {
@@ -12,17 +14,11 @@ export default {
       }
     },
     field: {
-      description: 'JPG or PNG, smaller than 5mb',
-      uploadLabel: 'Browse',
-      previewLabel: 'File Preview',
+      ...fixtureDragAndDropWithXlsx.props,
+      title: '',
       labelButtonLink: 'here',
       labelLink: 'Need the template? Download it',
       hrefLink: 'https://setup.coorpacademy.com/assets/templates/import-users-template.xlsx',
-      previewContent: {
-        type: 'xlsx',
-        src: 'https://static.coorpacademy.com/content/digital/raw/meta_inc-1677774948417._logo-1-1677774948417.pdf',
-        label: 'opponents-error-report.xlsx'
-      },
       loading: false
     },
     childType: 'massive-upload'

--- a/packages/@coorpacademy-components/src/organism/select-opponents/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/organism/select-opponents/test/fixtures/default.ts
@@ -1,5 +1,5 @@
 import SelectCohortes from '../../../../molecule/title-radio-wrapper/test/fixtures/select-cohortes';
-import UploadUsers from '../../../../molecule/title-radio-wrapper/test/fixtures/upload-users';
+import UploadOpponents from '../../../../molecule/title-radio-wrapper/test/fixtures/upload-validated-opponents';
 
 export default {
   props: {
@@ -8,7 +8,7 @@ export default {
         ...SelectCohortes.props
       },
       {
-        ...UploadUsers.props
+        ...UploadOpponents.props
       }
     ]
   }


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR 
- modifies `DragAndDrop` atom to adapt the design when the uploaded file is of type xlsx,
- modifies `TitleRadioWrapper` molecule to fix the design when the upload is loading.

-> https://trello.com/c/skcMggKX/3141-modify-the-draganddrop-component-to-add-the-preview-of-an-xlsx-file

**Result and observation**
- when the uploaded file is of type xlsx:

BEFORE
<img width="408" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/e3f3220e-4b8b-4ab2-b15a-4fff2f0155ef">

AFTER
<img width="408" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/45248072-9209-40de-8024-00564d6bd609">


- fix the design when the upload is loading:

BEFORE
<img width="460" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/f3b4d7ba-f3d0-42ee-adb6-d850fb894378">

AFTER
<img width="460" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/5ad3209c-c369-473e-83b9-d0d092a16564">


**Testing Strategy**

- [x] Manual testing
- [x] Add fixtures
