### PR TITLE
Render popin in dashboard and searchPage templates

### DIFF
--- a/packages/@coorpacademy-components/src/template/common/dashboard/index.js
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/index.js
@@ -25,6 +25,7 @@ const Dashboard = props => {
     hero,
     welcome,
     cookie,
+    popinWithCards,
     'arrows-aria-label': showMoreOnLeftOrRightAriaLabel
   } = props;
 
@@ -61,6 +62,7 @@ const Dashboard = props => {
     <div className={style.wrapper} data-name="dashboard">
       {sectionsList}
       {cookie ? <CMPopin {...cookie} /> : null}
+      {popinWithCards ? <CMPopin {...popinWithCards} className={style.popinWithCards} /> : null}
     </div>
   );
 };
@@ -78,6 +80,7 @@ Dashboard.propTypes = {
     ])
   ),
   cookie: PropTypes.shape(CMPopin.propTypes),
-  'arrows-aria-label': CardsList.propTypes['arrows-aria-label']
+  'arrows-aria-label': CardsList.propTypes['arrows-aria-label'],
+  popinWithCards: PropTypes.shape(CMPopin.propTypes)
 };
 export default Dashboard;

--- a/packages/@coorpacademy-components/src/template/common/dashboard/index.js
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/index.js
@@ -62,7 +62,7 @@ const Dashboard = props => {
     <div className={style.wrapper} data-name="dashboard">
       {sectionsList}
       {cookie ? <CMPopin {...cookie} /> : null}
-      {popinWithCards ? <CMPopin {...popinWithCards} className={style.popinWithCards} /> : null}
+      {popinWithCards ? <CMPopin {...popinWithCards} /> : null}
     </div>
   );
 };

--- a/packages/@coorpacademy-components/src/template/common/dashboard/style.css
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/style.css
@@ -12,6 +12,10 @@
   width: 100%;
 }
 
+.popinWithCards {
+  z-index: 5;
+}
+
 @media tablet {
   .hero {
     height: 200px;

--- a/packages/@coorpacademy-components/src/template/common/dashboard/style.css
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/style.css
@@ -12,10 +12,6 @@
   width: 100%;
 }
 
-.popinWithCards {
-  z-index: 5;
-}
-
 @media tablet {
   .hero {
     height: 200px;

--- a/packages/@coorpacademy-components/src/template/common/dashboard/test/fixtures/with-cookie-and-popin-cards.js
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/test/fixtures/with-cookie-and-popin-cards.js
@@ -1,0 +1,11 @@
+import popinWithCards from '../../../../../molecule/cm-popin/test/fixtures/popin-with-cards';
+import cookieProps from '../../../../../molecule/cm-popin/test/fixtures/cookie';
+import Default from './default';
+
+export default {
+  props: {
+    ...Default.props,
+    cookie: cookieProps.props,
+    popinWithCards: popinWithCards.props
+  }
+};

--- a/packages/@coorpacademy-components/src/template/common/search-page/index.js
+++ b/packages/@coorpacademy-components/src/template/common/search-page/index.js
@@ -6,6 +6,7 @@ import Button from '../../../atom/button';
 import Filters from '../../../molecule/filters';
 import CardsGrid from '../../../organism/cards-grid';
 import CardsList from '../../../molecule/dashboard/cards-list';
+import CMPopin from '../../../molecule/cm-popin';
 import style from './style.css';
 
 const SearchPage = (props, context) => {
@@ -19,7 +20,8 @@ const SearchPage = (props, context) => {
     moreSortAriaLabel,
     moreFilterAriaLabel,
     filterGroupAriaLabel,
-    sortAriaLabel
+    sortAriaLabel,
+    popinWithCards
   } = props;
 
   const {skin} = context;
@@ -60,6 +62,11 @@ const SearchPage = (props, context) => {
         </div>
         {cardsView}
       </div>
+      {popinWithCards ? (
+        <div className={style.popinWithCards}>
+          <CMPopin {...popinWithCards} />
+        </div>
+      ) : null}
     </div>
   );
 };
@@ -78,7 +85,8 @@ SearchPage.propTypes = {
   moreSortAriaLabel: PropTypes.string,
   moreFilterAriaLabel: PropTypes.string,
   filterGroupAriaLabel: PropTypes.string,
-  sortAriaLabel: PropTypes.string
+  sortAriaLabel: PropTypes.string,
+  popinWithCards: PropTypes.shape(CMPopin.propTypes)
 };
 
 export default SearchPage;

--- a/packages/@coorpacademy-components/src/template/common/search-page/style.css
+++ b/packages/@coorpacademy-components/src/template/common/search-page/style.css
@@ -50,6 +50,11 @@
   color: black;
 }
 
+.popinWithCards {
+  position: relative;
+  z-index: 5;
+}
+
 @media mobile {
   .cardsWrapper {
     padding: 5px 0;

--- a/packages/@coorpacademy-components/src/template/common/search-page/test/fixtures/with-popin-cards.js
+++ b/packages/@coorpacademy-components/src/template/common/search-page/test/fixtures/with-popin-cards.js
@@ -1,0 +1,9 @@
+import popinWithCards from '../../../../../molecule/cm-popin/test/fixtures/popin-with-cards';
+import Default from './default';
+
+export default {
+  props: {
+    ...Default.props,
+    popinWithCards: popinWithCards.props
+  }
+};


### PR DESCRIPTION
Trello ticket : 

**Detailed purpose of the PR**
- add the `popinWithCards` property in dashboard and searchPage templates
- update the style of the templates to render the popin

**Result and observation**

***Dashboard (with cookie popin)***
![Capture d’écran 2023-08-23 à 11 57 13](https://github.com/CoorpAcademy/components/assets/113359769/3ab308f9-1bc6-447f-90ba-3c8533997394)

**SearchPage**
![Capture d’écran 2023-08-23 à 11 57 25](https://github.com/CoorpAcademy/components/assets/113359769/ccc88323-0b8a-4d22-a1a9-1ac2d9c96521)

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
