### PR TITLE
Remove disabled on card & update style & add loading fixtures

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/card/index.js
@@ -160,7 +160,7 @@ const Card = memo(function Card(props, context) {
     empty ? style.empty : null
   );
   const disabled = hidden && (!isSelected || isUndefined(isSelected));
-  const handleClick = useMemo(() => e => !disabled && onClick(e), [disabled, onClick]);
+  const handleClick = useMemo(() => e => onClick(e), [onClick]);
   const lock = disabled ? (
     <div className={style.lockContent}>
       <LockIcon className={style.lockIcon} height={48} />

--- a/packages/@coorpacademy-components/src/molecule/card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/card/style.css
@@ -195,6 +195,10 @@
   z-index: 1;
 }
 
+.lockWrapper:hover {
+  cursor: pointer;
+}
+
 .lockWrapper:hover .lockIcon {
   background-color: cm_negative_200;
   color: white;

--- a/packages/@coorpacademy-components/src/molecule/card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/card/style.css
@@ -224,6 +224,8 @@
 
 .lockIcon {
   width: 48px;
+  min-width: 48px;
+  min-height: 48px;
   background-color: negative_100;
   align-self: center;
   border-radius: 16px;

--- a/packages/@coorpacademy-components/src/molecule/card/test/handle-test.tsx
+++ b/packages/@coorpacademy-components/src/molecule/card/test/handle-test.tsx
@@ -46,13 +46,13 @@ test('should no render favorite section if favorite is not defined on the props'
   t.falsy(favoriteSection);
 });
 
-test('should not call onClick with locked card', t => {
-  t.plan(2);
+test('should call onClick with locked card', t => {
+  t.plan(3);
 
   const props = pipe(
     set('favorite', true),
     set('disabled', true),
-    set('onClick', () => t.fail()),
+    set('onClick', () => t.pass()),
     set('onFavoriteClick', () => t.fail())
   )(defaultFixture.props);
 

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/index.js
@@ -176,7 +176,11 @@ const CMPopin = props => {
           </div>
         ) : null}
         {descriptionBtnTxt ? <div className={style.descriptionBtn}>{descriptionBtnTxt}</div> : null}
-        {items ? <div className={style.itemsContainer}>{renderItems()}</div> : null}
+        {items ? (
+          <div className={style.itemsContainer} data-name={'cm-popin-cards'}>
+            {renderItems()}
+          </div>
+        ) : null}
         {renderBtnSwitch()}
         {firstButton || secondButton || thirdButton ? (
           <div className={style.buttonContainer}>

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
@@ -306,7 +306,7 @@ a {
 }
 
 .itemsContainer {
-  height: 369px;
+  max-height: 369px;
   overflow-y: auto;
   width: 100%;
   border-top: 1px solid cm_grey_100;

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
@@ -307,7 +307,6 @@ a {
 .itemsContainer {
   height: 369px;
   overflow-y: auto;
-  padding: inherit;
   width: 100%;
   border-top: 1px solid cm_grey_100;
 }

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
@@ -153,8 +153,11 @@
 
 .lockIcon {
   height: 48px;
+  width: 48px;
   background-color: negative_100;
   border-radius: 16px;
+  min-width: 48px;
+  min-height: 48px;
   color: cm_negative_200;
 }
 

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
@@ -147,6 +147,7 @@
 }
 
 .headerTitle {
+  width: 612px;
   margin-bottom: 16px;
   padding: 2px 0px 2px;
 }

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/popin-with-cards-loading.js
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/popin-with-cards-loading.js
@@ -1,0 +1,13 @@
+import popinWithCards from './popin-with-cards';
+
+export default {
+  props: {
+    ...popinWithCards.props,
+    items: {
+      type: 'content',
+      list: {
+        list: [{}, {}, {}, {}]
+      }
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/template/common/dashboard/index.js
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/index.js
@@ -62,7 +62,11 @@ const Dashboard = props => {
     <div className={style.wrapper} data-name="dashboard">
       {sectionsList}
       {cookie ? <CMPopin {...cookie} /> : null}
-      {popinWithCards ? <CMPopin {...popinWithCards} /> : null}
+      {popinWithCards ? (
+        <div className={style.popinWithCards}>
+          <CMPopin {...popinWithCards} />
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/packages/@coorpacademy-components/src/template/common/dashboard/style.css
+++ b/packages/@coorpacademy-components/src/template/common/dashboard/style.css
@@ -12,6 +12,11 @@
   width: 100%;
 }
 
+.popinWithCards {
+  position: relative;
+  z-index: 7;
+}
+
 @media tablet {
   .hero {
     height: 200px;

--- a/packages/@coorpacademy-components/src/template/common/search-page/style.css
+++ b/packages/@coorpacademy-components/src/template/common/search-page/style.css
@@ -52,7 +52,7 @@
 
 .popinWithCards {
   position: relative;
-  z-index: 6;
+  z-index: 7;
 }
 
 @media mobile {

--- a/packages/@coorpacademy-components/src/template/common/search-page/style.css
+++ b/packages/@coorpacademy-components/src/template/common/search-page/style.css
@@ -52,7 +52,7 @@
 
 .popinWithCards {
   position: relative;
-  z-index: 5;
+  z-index: 6;
 }
 
 @media mobile {

--- a/packages/@coorpacademy-nova-icons/README.md
+++ b/packages/@coorpacademy-nova-icons/README.md
@@ -89,4 +89,4 @@ You can use the props supported by [svg](https://developer.mozilla.org/docs/Web/
 
 ## Contributing
 
-Please, run `yarn test` before submitting a pull request.
+Please, run `yarn test` before submitting a pull request..

--- a/packages/@coorpacademy-nova-icons/README.md
+++ b/packages/@coorpacademy-nova-icons/README.md
@@ -19,6 +19,7 @@ Components bank (react and react-native) based on Nova SVG icons (through [Iconj
 ### Adding an icon - colors & RGAA
 
 #### Colors:
+
 - If you want any path's color to be injected (to be replaced by `currentColor`/`props.color`), set color `#757575`.
 
 ex:
@@ -32,11 +33,12 @@ ex:
     </svg>
 ```
 
-(the last path is going to keep `#4B4C4C` as its color) anything else will remain __as is__
+(the last path is going to keep `#4B4C4C` as its color) anything else will remain **as is**
 
 - You must set `replaceColors` to false (`replaceColors: false`) in ./icons.js _if you don't want_ the original color to be replaced by the script.
 
 ex:
+
 ```javascript
   {
     filePath: path.resolve('./third-party/nova-composition.iconjar/icons/draft.svg'),
@@ -46,12 +48,14 @@ ex:
 
 <br/>
 
-#### RGAA: 
-- if __you want to use an aria-label or alt prop__, you can pass it as a prop directly, this would add __role="img"__ automatically. If __you want an aria-hidden prop__ instead, it will be added automatically if you don't use an `aria-label` or `alt`.
+#### RGAA:
+
+- if **you want to use an aria-label or alt prop**, you can pass it as a prop directly, this would add **role="img"** automatically. If **you want an aria-hidden prop** instead, it will be added automatically if you don't use an `aria-label` or `alt`.
 
 <br/>
 
 ### Adding an icon - final steps
+
 - Drag and drop your SVG file into a collection (in iconJar)
 - Export the new updated iconjar collection (be careful to have the same name when you export, to erase the old one)
 - Add the brand new svg icon's path into `icons.js` file that's in root project (if you're SVG has a color and you want to keep it, you can add the property: `replaceColors: false`)
@@ -63,8 +67,8 @@ ex:
 ## Usage
 
 ```jsx
-import React from 'react';
-import { NovaCompositionCoorpacademyCog } from '@coorpacademy/nova-icons';
+import React from "react";
+import { NovaCompositionCoorpacademyCog } from "@coorpacademy/nova-icons";
 
 const MyComponent = () => (
   <NovaCompositionCoorpacademyCog width={32} height={32} color="#123456" />
@@ -73,7 +77,7 @@ const MyComponent = () => (
 export default MyComponent;
 ```
 
-__Note__: React-Native component will automatically be resolved as [Metro](https://github.com/facebook/metro) supports `.native.js` extension.
+**Note**: React-Native component will automatically be resolved as [Metro](https://github.com/facebook/metro) supports `.native.js` extension.
 
 <br/>
 


### PR DESCRIPTION
Trello ticket : [[component] New component Popin with cards (desktop + mobile)](https://trello.com/c/t9IGxywY/3131-component-new-component-popin-with-cards-desktop-mobile)

**Detailed purpose of the PR**
- Allow the disabled card to accept click event
![Kapture 2023-09-05 at 15 15 59](https://github.com/CoorpAcademy/components/assets/113359769/bdd2703b-e079-4720-a7ad-42e58fa39955)

- Fix the style of the icon in responsive mode
![Capture d’écran 2023-09-05 à 15 13 21](https://github.com/CoorpAcademy/components/assets/113359769/05d3a27d-0304-4f68-b97e-2bc12d120940)

- Add the loading cards fixtures of the popin.
![Capture d’écran 2023-09-05 à 15 02 40](https://github.com/CoorpAcademy/components/assets/113359769/98a72330-8cf1-4659-b546-cc7af31d25ba)

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
