### PR TITLE
[massive-battle] modify TitleAndCheckBoxWrapper and SelectOpponents components 

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/title-and-checkbox-wrapper/index.js
+++ b/packages/@coorpacademy-components/src/molecule/title-and-checkbox-wrapper/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {isUndefined} from 'lodash/fp';
-import ImageUpload from '../../atom/image-upload';
+import InputFileDraggable from '../../atom/input-file-draggable';
 import InputTextWithTitle from '../../atom/input-text-with-title';
 import SelectMultiple from '../select-multiple';
 import CheckboxWithTitle from '../../atom/checkbox-with-title';
@@ -12,7 +12,7 @@ import style from './style.css';
 const CHILD = {
   'input-text': InputTextWithTitle,
   'drag-and-drop-wrapper': DragAndDropWrapper,
-  'image-upload': ImageUpload,
+  'image-upload': InputFileDraggable,
   'select-multiple': SelectMultiple
 };
 const TitleAndCheckBoxWrapper = props => {
@@ -53,7 +53,7 @@ TitleAndCheckBoxWrapper.propTypes = {
       childType: PropTypes.oneOf(['drag-and-drop-wrapper'])
     }),
     PropTypes.shape({
-      ...ImageUpload.propTypes,
+      ...InputFileDraggable.propTypes,
       childType: PropTypes.oneOf(['image-upload'])
     }),
     PropTypes.shape({

--- a/packages/@coorpacademy-components/src/molecule/title-and-checkbox-wrapper/index.js
+++ b/packages/@coorpacademy-components/src/molecule/title-and-checkbox-wrapper/index.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {isUndefined} from 'lodash/fp';
+import ImageUpload from '../../atom/image-upload';
 import InputTextWithTitle from '../../atom/input-text-with-title';
+import SelectMultiple from '../select-multiple';
 import CheckboxWithTitle from '../../atom/checkbox-with-title';
 import Title from '../../atom/title';
 import DragAndDropWrapper from '../drag-and-drop-wrapper';
@@ -8,7 +11,9 @@ import style from './style.css';
 
 const CHILD = {
   'input-text': InputTextWithTitle,
-  'drag-and-drop-wrapper': DragAndDropWrapper
+  'drag-and-drop-wrapper': DragAndDropWrapper,
+  'image-upload': ImageUpload,
+  'select-multiple': SelectMultiple
 };
 const TitleAndCheckBoxWrapper = props => {
   const {checkboxWithTitle, child, sectionTitle} = props;
@@ -22,7 +27,13 @@ const TitleAndCheckBoxWrapper = props => {
           <Title {...sectionTitle} type={'form-group'} />
         </div>
       ) : null}
-      <div className={checkboxWithTitle || sectionTitle ? style.child : null}>
+      <div
+        className={
+          checkboxWithTitle || (sectionTitle && isUndefined(sectionTitle.removeMargin))
+            ? style.child
+            : null
+        }
+      >
         <Child {...child} />
       </div>
     </div>
@@ -31,7 +42,7 @@ const TitleAndCheckBoxWrapper = props => {
 
 TitleAndCheckBoxWrapper.propTypes = {
   checkboxWithTitle: PropTypes.shape(CheckboxWithTitle.propTypes),
-  sectionTitle: PropTypes.shape(Title.propTypes),
+  sectionTitle: PropTypes.shape({...Title.propTypes, removeMargin: PropTypes.bool}),
   child: PropTypes.oneOfType([
     PropTypes.shape({
       ...InputTextWithTitle.propTypes,
@@ -40,6 +51,14 @@ TitleAndCheckBoxWrapper.propTypes = {
     PropTypes.shape({
       ...DragAndDropWrapper.propTypes,
       childType: PropTypes.oneOf(['drag-and-drop-wrapper'])
+    }),
+    PropTypes.shape({
+      ...ImageUpload.propTypes,
+      childType: PropTypes.oneOf(['image-upload'])
+    }),
+    PropTypes.shape({
+      ...SelectMultiple.propTypes,
+      childType: PropTypes.oneOf(['select-multiple'])
     })
   ])
 };

--- a/packages/@coorpacademy-components/src/organism/select-opponents/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/select-opponents/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import map from 'lodash/fp/map';
-import TitleRadioWrapper from '../../molecule/title-radio-wrapper';
-import {TitleRadioWrapperProps} from '../../molecule/title-radio-wrapper/types';
-import propTypes, {SelectOpponentsProps} from './types';
+import TitleAndCheckBoxWrapper from '../../molecule/title-and-checkbox-wrapper';
+import propTypes, {SelectOpponentsProps, TitleAndCheckBoxWrapperProps} from './types';
 import style from './style.css';
 
 // @ts-expect-error (need to get the index)
@@ -12,10 +11,13 @@ const SelectOpponents = (props: SelectOpponentsProps) => {
   const {items} = props;
   return (
     <ul className={style.container}>
-      {mapWithIndex((item: TitleRadioWrapperProps, key: number) => {
+      {mapWithIndex((item: TitleAndCheckBoxWrapperProps, key: number) => {
         return (
-          <li key={`select-opponents-item-${key}`} className={style.item}>
-            <TitleRadioWrapper {...item} />
+          <li
+            key={`select-opponents-item-${key}`}
+            className={item.child.childType === 'image-upload' ? style.itemImageUpload : style.item}
+          >
+            <TitleAndCheckBoxWrapper {...item} />
           </li>
         );
       }, items)}

--- a/packages/@coorpacademy-components/src/organism/select-opponents/style.css
+++ b/packages/@coorpacademy-components/src/organism/select-opponents/style.css
@@ -8,4 +8,10 @@
 
 .item {
     list-style-type: none;
+    max-width: 300px;
+}
+
+.itemImageUpload {
+    composes: item;
+    margin-left: 40px;
 }

--- a/packages/@coorpacademy-components/src/organism/select-opponents/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/organism/select-opponents/test/fixtures/default.ts
@@ -1,14 +1,72 @@
-import SelectCohortes from '../../../../molecule/title-radio-wrapper/test/fixtures/select-cohortes';
-import UploadOpponents from '../../../../molecule/title-radio-wrapper/test/fixtures/upload-validated-opponents';
+import fixtureDragAndDropWithXlsx from '../../../../atom/drag-and-drop/test/fixtures/with-xlsx';
 
 export default {
   props: {
     items: [
       {
-        ...SelectCohortes.props
+        sectionTitle: {
+          title: 'Select one or several cohortes',
+          subtitle: 'in the drop-down list',
+          titleSize: 'small',
+          subtitleSize: 'extra-small',
+          removeMargin: true
+        },
+        child: {
+          theme: 'coorpmanager',
+          placeholder: 'Select cohorte(s)',
+          title: 'Cohortes',
+          description: 'You should select a cohorte',
+          multiple: true,
+          disabled: false,
+          error: '',
+          hint: '',
+          options: [
+            {
+              name: 'ABRERA FCM',
+              value: 'abrera-fcm',
+              selected: false
+            },
+            {
+              name: 'ABRERA FIS',
+              value: 'abrera-fis',
+              selected: false
+            },
+            {
+              name: 'ALLARIZ',
+              value: 'allariz',
+              selected: false
+            },
+            {
+              name: 'ALMUSSAFESS FCM',
+              value: 'almussafes-fcm',
+              selected: false
+            }
+          ],
+          onChange: (value: any) => console.log('onChange', value),
+          onError: () => true,
+          childType: 'select-multiple'
+        }
       },
       {
-        ...UploadOpponents.props
+        sectionTitle: {
+          title: 'Upload a list of specific users',
+          subtitle: 'Using an Excel file (mandatory column: email address)',
+          titleSize: 'small',
+          subtitleSize: 'extra-small',
+          removeMargin: true
+        },
+        child: {
+          ...fixtureDragAndDropWithXlsx.props,
+          title: '',
+          previewContent: {},
+          labelButtonLink: 'here',
+          labelLink: 'Need the template? Download it',
+          hrefLink: 'https://setup.coorpacademy.com/assets/templates/import-users-template.xlsx',
+          loading: false,
+          disabled: true,
+          imageTypes: 'image/*',
+          childType: 'image-upload'
+        }
       }
     ]
   }

--- a/packages/@coorpacademy-components/src/organism/select-opponents/types.ts
+++ b/packages/@coorpacademy-components/src/organism/select-opponents/types.ts
@@ -1,13 +1,20 @@
 import PropTypes from 'prop-types';
-import {TitleRadioWrapperProps} from '../../molecule/title-radio-wrapper/types';
-import TitleRadioWrapper from '../../molecule/title-radio-wrapper';
+import TitleAndCheckBoxWrapper from '../../molecule/title-and-checkbox-wrapper';
 
 export const propTypes = {
-  items: PropTypes.arrayOf(PropTypes.shape(TitleRadioWrapper.propTypes))
+  items: PropTypes.arrayOf(PropTypes.shape(TitleAndCheckBoxWrapper.propTypes))
+};
+
+export type TitleAndCheckBoxWrapperProps = {
+  child: {
+    childType: 'select-multiple' | 'image-upload';
+    [x: string]: unknown;
+  };
+  [x: string]: unknown;
 };
 
 export type SelectOpponentsProps = {
-  items: TitleRadioWrapperProps[];
+  items: TitleAndCheckBoxWrapperProps[];
 };
 
 export default propTypes;


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR : 
- modifies props and cancels some dispatch of actions to use the new component (https://github.com/CoorpAcademy/components/pull/2805).
- updates import of input-draggable component in `TitleAndCheckBoxWrapper` component.

-> https://trello.com/c/edmnhZX7/3165-massive-battle-x-all

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
