### PR TITLE
Fix autoprefixer warnings

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/style.css
@@ -149,7 +149,7 @@
 .headerContent {
   gap: 16px;
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   width: 100%;
   padding-bottom: 16px;

--- a/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/style.css
+++ b/packages/@coorpacademy-components/src/molecule/expandible-actionable-table/style.css
@@ -88,7 +88,7 @@
 .columnFirst .columFirstWrapper,
 .columnFirstSticky .columFirstWrapper {
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   gap: 16px;
 }
 
@@ -114,7 +114,7 @@
   color: cm_grey_700;
   border-top: 1px solid light;
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
 }
 
 .columnLastSticky {

--- a/packages/@coorpacademy-components/src/molecule/quick-access-card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/quick-access-card/style.css
@@ -68,7 +68,7 @@
   width: 100%;
   display: flex;
   align-items: end;
-  justify-content: end;
+  justify-content: flex-end;
   flex: 1;
 }
 


### PR DESCRIPTION
```
autoprefixer: start value has mixed support, consider using flex-start instead
autoprefixer: end value has mixed support, consider using flex-end instead
```