### PR TITLE
[massive-battle] modify CMPopin to add a link

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/cm-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/index.js
@@ -19,6 +19,7 @@ import InputSwitch from '../../atom/input-switch';
 import Title from '../../atom/title';
 import CardsGrid from '../../organism/cards-grid';
 import ListItems from '../../organism/list-items';
+import Link from '../../atom/link';
 import style from './style.css';
 import propTypes from './types';
 
@@ -46,7 +47,8 @@ const CMPopin = props => {
     cookieTitle,
     descriptionBtnTxt,
     listBtnSwicth,
-    items
+    items,
+    link
   } = props;
   const logo = {
     AlertDiamond,
@@ -240,6 +242,7 @@ const CMPopin = props => {
                 dangerouslySetInnerHTML={{__html: descriptionText}}
               />
             ) : null}
+            {link ? <Link {...link} /> : null}
           </div>
         ) : null}
         {descriptionBtnTxt ? <div className={style.descriptionBtn}>{descriptionBtnTxt}</div> : null}

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/popin-with-link.js
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/popin-with-link.js
@@ -1,29 +1,13 @@
+import defaultFixture from './default';
+
 export default {
   props: {
+    ...defaultFixture.props,
     content: 'Some users were not imported',
     descriptionText:
       'The massive battle will only be send to 265 users. 35 out of 300 users were not imported.',
-    onClose: () => {
-      console.log('close');
-    },
-    firstButton: {
-      label: 'Cancel',
-      type: 'secondary',
-      handleOnclick: () => {
-        console.log('cancel');
-      },
-      'aria-label': 'Cancel this operation'
-    },
-    secondButton: {
-      label: 'Undo',
-      type: 'primary',
-      handleOnclick: () => {
-        console.log('undo');
-      },
-      'aria-label': 'Undo this operation'
-    },
+    icon: 'AlertDiamond',
     link: {
-      href: '#',
       children: ['Download report'],
       onClick: () => {
         console.log('hello');

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/popin-with-link.js
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/popin-with-link.js
@@ -1,0 +1,41 @@
+export default {
+  props: {
+    content: 'Some users were not imported',
+    descriptionText:
+      'The massive battle will only be send to 265 users. 35 out of 300 users were not imported.',
+    onClose: () => {
+      console.log('close');
+    },
+    firstButton: {
+      label: 'Cancel',
+      type: 'secondary',
+      handleOnclick: () => {
+        console.log('cancel');
+      },
+      'aria-label': 'Cancel this operation'
+    },
+    secondButton: {
+      label: 'Undo',
+      type: 'primary',
+      handleOnclick: () => {
+        console.log('undo');
+      },
+      'aria-label': 'Undo this operation'
+    },
+    link: {
+      href: '#',
+      children: ['Download report'],
+      onClick: () => {
+        console.log('hello');
+      },
+      download: true,
+      style: {
+        textDecoration: 'underline',
+        margin: '20px',
+        fontFamily: 'Gilroy',
+        fontSize: '16px',
+        fontWeight: '500'
+      }
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/types.ts
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/types.ts
@@ -3,6 +3,7 @@ import {keys} from 'lodash/fp';
 import Cta from '../../atom/button-link';
 import InputSwitch from '../../atom/input-switch';
 import Title from '../../atom/title';
+import Link from '../../atom/link';
 import {TitleProps} from '../../atom/title/types';
 import CardsGrid from '../../organism/cards-grid';
 import ListItems from '../../organism/list-items';
@@ -58,7 +59,8 @@ const propTypes = {
       PropTypes.shape(CardsGrid.propTypes),
       PropTypes.shape(ListItems.propTypes)
     ])
-  })
+  }),
+  link: PropTypes.shape(Link.propTypes)
 };
 
 type PopinHeaderProps = {
@@ -93,6 +95,7 @@ export type CMPopinProps = {
       | PropTypes.InferProps<typeof CardsGrid.propTypes>
       | PropTypes.InferProps<typeof ListItems.propTypes>;
   };
+  link?: PropTypes.InferProps<typeof Link.propTypes>;
 };
 
 export default propTypes;


### PR DESCRIPTION
**Detailed purpose of the PR**
This PR modifies `CMPopin` component to add a download link (for the massive battle form).
-> https://trello.com/c/bPPSlz1O/1394-mb-cibl%C3%A9e-par-import-am%C3%A9lioration

**Result and observation**
<img width="1505" alt="image" src="https://github.com/CoorpAcademy/components/assets/79636283/1d782753-5ad4-4dfa-a455-0f35a99588fb">


**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
