### PR TITLE
Faurecia-vr video provider support

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/video-iframe/index.js
+++ b/packages/@coorpacademy-components/src/molecule/video-iframe/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import qs from 'qs';
-import {noop} from 'lodash/fp';
+import {noop, includes} from 'lodash/fp';
 import Provider from '../../atom/provider';
 import {SrcPropType} from '../../util/proptypes';
 import style from './style.css';
@@ -23,7 +23,15 @@ const getUrl = ({url, type, id, query = {}, opts = {}}) => {
 
 class VideoIframe extends React.Component {
   static propTypes = {
-    type: PropTypes.oneOf(['youtube', 'uptale', 'kontiki', 'jwplayer', 'omniPlayer', 'h5p']),
+    type: PropTypes.oneOf([
+      'youtube',
+      'uptale',
+      'kontiki',
+      'jwplayer',
+      'omniPlayer',
+      'h5p',
+      'faurecia-vr'
+    ]),
     width: PropTypes.string,
     height: PropTypes.string,
     url: SrcPropType,
@@ -47,18 +55,15 @@ class VideoIframe extends React.Component {
   render() {
     const {type, id, url, autoplay = false, width = '100%', height = '400px'} = this.props;
     const src = getUrl({url, type, id, autoplay});
-
+    const properties = {
+      allow: includes(type, ['faurecia-vr']) ? 'xr-spatial-tracking;fullscreen' : null,
+      allowFullScreen: true,
+      allowvr: includes(type, ['uptale', 'faurecia-vr']) ? 'yes' : null,
+      scrolling: includes(type, ['uptale', 'faurecia-vr']) ? 'no' : null,
+      frameBorder: '0'
+    };
     return (
-      <iframe
-        src={src}
-        width={width}
-        height={height}
-        frameBorder={0}
-        className={style.iframe}
-        allowvr={type === 'uptale' ? 'yes' : null}
-        scrolling={type === 'uptale' ? 'no' : null}
-        allowFullScreen
-      />
+      <iframe {...properties} src={src} width={width} height={height} className={style.iframe} />
     );
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/video-iframe/test/fixtures/faurecia-vr.js
+++ b/packages/@coorpacademy-components/src/molecule/video-iframe/test/fixtures/faurecia-vr.js
@@ -1,0 +1,6 @@
+export default {
+  props: {
+    type: 'faurecia-vr',
+    url: 'https://learning-lab-forvr-preprod.app.corp/Experiences/WebGL/1?player=true'
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/video-iframe/test/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/video-iframe/test/index.tsx
@@ -11,7 +11,7 @@ test.afterEach(() => {
 });
 
 test('should render properly a kontiki iframe', t => {
-  t.plan(1);
+  t.plan(8);
   const props = {
     type: 'kontiki',
     src: 'foo'
@@ -20,10 +20,17 @@ test('should render properly a kontiki iframe', t => {
   const {container} = render(<VideoIframe {...props} />);
   const video = container.querySelector('iframe');
   t.truthy(video);
+  t.is(video?.getAttribute('allow'), null);
+  t.is(video?.getAttribute('allowFullScreen'), '');
+  t.is(video?.getAttribute('allowvr'), null);
+  t.is(video?.getAttribute('scrolling'), null);
+  t.is(video?.getAttribute('frameBorder'), '0');
+  t.is(video?.getAttribute('width'), '100%');
+  t.is(video?.getAttribute('height'), '400px');
 });
 
 test('should render properly a youtube iframe', t => {
-  t.plan(1);
+  t.plan(9);
   const props = {
     type: 'youtube',
     id: 'foo'
@@ -32,10 +39,18 @@ test('should render properly a youtube iframe', t => {
   const {container} = render(<VideoIframe {...props} />);
   const video = container.querySelector('iframe');
   t.truthy(video);
+  t.is(video?.getAttribute('allow'), null);
+  t.is(video?.getAttribute('allowFullScreen'), '');
+  t.is(video?.getAttribute('allowvr'), null);
+  t.is(video?.getAttribute('scrolling'), null);
+  t.is(video?.getAttribute('frameBorder'), '0');
+  t.is(video?.getAttribute('src'), 'https://www.youtube.com/embed/foo?');
+  t.is(video?.getAttribute('width'), '100%');
+  t.is(video?.getAttribute('height'), '400px');
 });
 
 test('should render properly a omniPlayer iframe', t => {
-  t.plan(1);
+  t.plan(9);
   const props = {
     type: 'omniPlayer',
     id: 'foo'
@@ -44,10 +59,41 @@ test('should render properly a omniPlayer iframe', t => {
   const {container} = render(<VideoIframe {...props} />);
   const video = container.querySelector('iframe');
   t.truthy(video);
+  t.is(video?.getAttribute('allow'), null);
+  t.is(video?.getAttribute('allowFullScreen'), '');
+  t.is(video?.getAttribute('allowvr'), null);
+  t.is(video?.getAttribute('scrolling'), null);
+  t.is(video?.getAttribute('frameBorder'), '0');
+  t.is(video?.getAttribute('src'), 'https://mms.myomni.live/foo');
+  t.is(video?.getAttribute('width'), '100%');
+  t.is(video?.getAttribute('height'), '400px');
+});
+
+test('should render properly a faurecia-vr iframe', t => {
+  t.plan(9);
+  const props = {
+    type: 'faurecia-vr',
+    url: 'https://learning-lab-forvr-preprod.app.corp/Experiences/WebGL/1?player=true'
+  };
+
+  const {container} = render(<VideoIframe {...props} />);
+  const video = container.querySelector('iframe');
+  t.truthy(video);
+  t.is(video?.getAttribute('allow'), 'xr-spatial-tracking;fullscreen');
+  t.is(video?.getAttribute('allowFullScreen'), '');
+  t.is(video?.getAttribute('allowvr'), 'yes');
+  t.is(video?.getAttribute('scrolling'), 'no');
+  t.is(video?.getAttribute('frameBorder'), '0');
+  t.is(
+    video?.getAttribute('src'),
+    'https://learning-lab-forvr-preprod.app.corp/Experiences/WebGL/1?player=true'
+  );
+  t.is(video?.getAttribute('width'), '100%');
+  t.is(video?.getAttribute('height'), '400px');
 });
 
 test('should render properly a h5p iframe', t => {
-  t.plan(1);
+  t.plan(9);
   const props = {
     type: 'h5p',
     url: 'https://coorpacademy.h5p.com/content/1291025352652664897/embed'
@@ -56,10 +102,21 @@ test('should render properly a h5p iframe', t => {
   const {container} = render(<VideoIframe {...props} />);
   const video = container.querySelector('iframe');
   t.truthy(video);
+  t.is(video?.getAttribute('allow'), null);
+  t.is(video?.getAttribute('allowFullScreen'), '');
+  t.is(video?.getAttribute('allowvr'), null);
+  t.is(video?.getAttribute('scrolling'), null);
+  t.is(video?.getAttribute('frameBorder'), '0');
+  t.is(
+    video?.getAttribute('src'),
+    'https://coorpacademy.h5p.com/content/1291025352652664897/embed'
+  );
+  t.is(video?.getAttribute('width'), '100%');
+  t.is(video?.getAttribute('height'), '400px');
 });
 
 test('should render properly a uptale iframe', t => {
-  t.plan(1);
+  t.plan(9);
   const props = {
     type: 'uptale',
     id: 'foo'
@@ -68,10 +125,18 @@ test('should render properly a uptale iframe', t => {
   const {container} = render(<VideoIframe {...props} />);
   const video = container.querySelector('iframe');
   t.truthy(video);
+  t.is(video?.getAttribute('allow'), null);
+  t.is(video?.getAttribute('allowFullScreen'), '');
+  t.is(video?.getAttribute('allowvr'), 'yes');
+  t.is(video?.getAttribute('scrolling'), 'no');
+  t.is(video?.getAttribute('frameBorder'), '0');
+  t.is(video?.getAttribute('src'), 'https://my.uptale.io/Experience/Launch?id=foo');
+  t.is(video?.getAttribute('width'), '100%');
+  t.is(video?.getAttribute('height'), '400px');
 });
 
 test('should render properly a jwplayer iframe', t => {
-  t.plan(1);
+  t.plan(9);
   const props = {
     type: 'jwplayer',
     id: 'foo'
@@ -80,4 +145,12 @@ test('should render properly a jwplayer iframe', t => {
   const {container} = render(<VideoIframe {...props} />);
   const video = container.querySelector('iframe');
   t.truthy(video);
+  t.is(video?.getAttribute('allow'), null);
+  t.is(video?.getAttribute('allowFullScreen'), '');
+  t.is(video?.getAttribute('allowvr'), null);
+  t.is(video?.getAttribute('scrolling'), null);
+  t.is(video?.getAttribute('frameBorder'), '0');
+  t.is(video?.getAttribute('src'), 'https://content.jwplatform.com/players/foo-7IMa4DCK.html');
+  t.is(video?.getAttribute('width'), '100%');
+  t.is(video?.getAttribute('height'), '400px');
 });

--- a/packages/@coorpacademy-components/src/molecule/video-player/index.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/index.js
@@ -56,6 +56,7 @@ class VideoPlayer extends React.Component {
       case 'application/uptale':
       case 'application/h5p':
       case 'application/omniPlayer':
+      case 'application/faurecia-vr':
         return (
           <VideoIframe
             key={id}

--- a/packages/@coorpacademy-components/src/molecule/video-player/prop-types.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/prop-types.js
@@ -62,6 +62,7 @@ export default {
     'application/jwplayer',
     'application/omniPlayer',
     'application/h5p',
+    'application/faurecia-vr',
     'video/mp4'
   ]).isRequired
 };

--- a/packages/@coorpacademy-components/src/molecule/video-player/test/fixtures/faurecia-vr.js
+++ b/packages/@coorpacademy-components/src/molecule/video-player/test/fixtures/faurecia-vr.js
@@ -1,0 +1,12 @@
+export default {
+  props: {
+    mimeType: 'application/faurecia-vr',
+    url: 'https://learning-lab-forvr-preprod.app.corp/Experiences/WebGL/1?player=true',
+    width: '1000px',
+    height: '700px',
+    onPlay: () => console.log('onPlay faurecia-vr'),
+    onResume: () => console.log('onResume faurecia-vr'),
+    onPause: () => console.log('onPause faurecia-vr'),
+    onEnded: () => console.log('onEnded faurecia-vr')
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/resource-browser/test/fixtures/faurecia-vr.js
+++ b/packages/@coorpacademy-components/src/organism/resource-browser/test/fixtures/faurecia-vr.js
@@ -1,0 +1,36 @@
+export default {
+  props: {
+    resources: [
+      {
+        _id: '590b862e2e967f64333ad45f',
+        type: 'video',
+        poster:
+          '//static.coorpacademy.com/content/CoorpAcademy/content/cockpitRecette-joan/default/popeye-1598889976702.jpeg',
+        description: 'Suspects 1',
+        mimeType: 'application/faurecia-vr',
+        url: 'https://learning-lab-forvr-preprod.app.corp/Experiences/WebGL/1?player=true',
+        width: '100%',
+        subtitles: [],
+        posters: [],
+        src: [],
+        onClick: () => {},
+        selected: true
+      },
+      {
+        _id: '590b862e2e967f64333ad407',
+        type: 'video',
+        poster:
+          '//static.coorpacademy.com/content/CoorpAcademy/content/cockpitRecette-joan/default/popeye2-1598889983417.jpeg',
+        description: 'Suspects 2',
+        mimeType: 'application/faurecia-vr',
+        url: 'https://learning-lab-forvr-preprod.app.corp/Experiences/WebGL/1?player=true',
+        width: '100%',
+        subtitles: [],
+        posters: [],
+        src: [],
+        selected: false,
+        onClick: () => {}
+      }
+    ]
+  }
+};

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/test/fixtures/context-with-faurecia-vr-video.js
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/test/fixtures/context-with-faurecia-vr-video.js
@@ -1,0 +1,22 @@
+import Context from './context';
+
+export default {
+  props: {
+    ...Context.props,
+    slideContext: {
+      ...Context.props.slideContext,
+      media: {
+        type: 'video',
+        src: [
+          {
+            videoId: '1291025352652664897',
+            mimeType: 'application/faurecia-vr',
+            url: 'https://learning-lab-forvr-preprod.app.corp/Experiences/WebGL/1?player=true',
+            width: '100%',
+            height: '343px'
+          }
+        ]
+      }
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/test/fixtures/media-faurecia-vr.js
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/test/fixtures/media-faurecia-vr.js
@@ -1,0 +1,27 @@
+import Cta from '../../../../../../atom/cta/test/fixtures/primary';
+import Footer from '../../footer/test/fixtures/media-selected';
+import ResourceBrowser from '../../../../../../organism/resource-browser/test/fixtures/faurecia-vr';
+
+const {props} = Cta;
+const footerProps = Footer.props;
+const resourceProps = ResourceBrowser.props;
+
+export default {
+  props: {
+    ...resourceProps,
+    ...footerProps,
+    typeClue: 'media',
+    starsDiff: 4,
+    step: {
+      current: 2,
+      total: 6
+    },
+    showNewMedia: false,
+    question:
+      'Amongst these businesses, which have suffered setbacks for not knowing how to putting users first?',
+    cta: {
+      ...props,
+      submitValue: 'Back to Question'
+    }
+  }
+};


### PR DESCRIPTION

A I-Frame will be shared to Coorp Academy. This I-frame give the possibility to be played in VR and 
in fullscreen. So for that this i-frame will contain this following option to be run on navigator: 
 
allow="xr-spatial-tracking;fullscreen"

<img width="1715" alt="Capture d’écran 2023-11-24 à 13 30 09" src="https://github.com/CoorpAcademy/components/assets/15608581/301955c4-708f-4b9f-bed4-d72b4386541e">


**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
