### PR TITLE
At last tweaks to analytics dashboard component for coorp manager

### DIFF
--- a/packages/@coorpacademy-components/src/organism/brand-analytics/index.js
+++ b/packages/@coorpacademy-components/src/organism/brand-analytics/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {noop, getOr} from 'lodash/fp';
+import {noop, getOr, has} from 'lodash/fp';
 import Sidebar from '../sidebar';
 import Provider from '../../atom/provider';
 import Loader from '../../template/app-player/loading';
@@ -14,23 +14,23 @@ const Analytics = (props, context) => {
     if (selected) {
       if (url) return <iframe src={url} className={style.dashboardIframe} frameBorder="0" />;
       if (!error) return <Loader />;
-    } else if (!error) {
-      return (
-        <div
-          className={style.dashboardNoSelection}
-          style={{color: getOr('#00B0FF', 'common.primary', skin)}}
-        >
-          {translate('Select a dashboard in the Sidebar')}
-        </div>
-      );
     }
-    return null;
+    if (error) return null;
+
+    return (
+      <div
+        className={style.dashboardNoSelection}
+        style={{color: getOr('#00B0FF', 'common.primary', skin)}}
+      >
+        {translate('Select a dashboard in the Sidebar')}
+      </div>
+    );
   };
   return (
     <div className={style.dashboardSelection}>
-      <h1 className={style.dashboardTitle}>
-        {getOr(translate('No Selected Dashboard'), 'name', selected)}
-      </h1>
+      {has('name', selected) ? (
+        <h1 className={style.noSelectedDashboard}>{translate('No Selected Dashboard')}</h1>
+      ) : null}
       {body()}
     </div>
   );

--- a/packages/@coorpacademy-components/src/organism/brand-analytics/style.css
+++ b/packages/@coorpacademy-components/src/organism/brand-analytics/style.css
@@ -12,8 +12,8 @@
   text-align: center;
   margin: 0 20px 20px 0px;
   display: flex;
-  flex-direction: column;  
-  min-height: 700px;
+  flex-direction: column;
+  min-height: 2000px;
 }
 
 .dashboardSelection {

--- a/packages/@coorpacademy-components/src/organism/brand-analytics/style.css
+++ b/packages/@coorpacademy-components/src/organism/brand-analytics/style.css
@@ -22,11 +22,12 @@
   flex: 1;
 }
 
-.dashboardTitle {
+.noSelectedDashboard {
   font-size: 24px;
   color: dark;
   border: 1px solid light;
   padding: 10px;
+  background-color: lightMediumGray;
   flex-grow: 0;
 }
 


### PR DESCRIPTION
## Detailed purpose of the PR

Bump (at last) dashboard min-height :bar_chart:
and remove unnecessary dashboard title.

It should like like this once components bumped on coorp manager

|avant|apres|
|:---:|:--:|
|<img width="1190" alt="avant" src="https://github.com/CoorpAcademy/components/assets/2601132/9ed6c69b-9e13-41ef-878b-097f266101ad">|<img width="1190" alt="Capture d’écran 2023-12-08 à 17 08 20" src="https://github.com/CoorpAcademy/components/assets/2601132/d8608660-5385-43ab-a004-e0eaeb211379">|
|![Capture d’écran 2023-12-08 à 17 12 35](https://github.com/CoorpAcademy/components/assets/2601132/cef07d20-e114-4cec-921e-02fd1750ca4a)|![Capture d’écran 2023-12-08 à 17 12 58](https://github.com/CoorpAcademy/components/assets/2601132/00f32f72-4e19-4432-977b-41b316885ab7)|

Enfin il sera possible de scroller les dashboards :raised_hands:

<!-- on n'est jamais mieux servi que par soi meme :smirk: -->
