### PR TITLE
Lock lottie-web to former version 5.11.0 :closed_lock_with_key:

### DIFF
--- a/packages/@coorpacademy-components/package.json
+++ b/packages/@coorpacademy-components/package.json
@@ -70,7 +70,7 @@
     "hammerjs": "^2.0.8",
     "isomorphic-unfetch": "^3.1.0",
     "lodash": "^4.17.21",
-    "lottie-web": "^5.9.6",
+    "lottie-web": "5.11.0",
     "postcss": "^8.4.16",
     "postcss-calc": "^8.2.4",
     "postcss-color-function": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12680,10 +12680,10 @@ lottie-react-native@^5.1.4:
     invariant "^2.2.2"
     react-native-safe-modules "^1.0.3"
 
-lottie-web@^5.9.6:
-  version "5.9.6"
-  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.9.6.tgz#62ae68563355d3e04aa75d53dec3dd4bea0e57c9"
-  integrity sha512-JFs7KsHwflugH5qIXBpB4905yC1Sub2MZWtl/elvO/QC6qj1ApqbUZJyjzJseJUtVpgiDaXQLjBlIJGS7UUUXA==
+lottie-web@5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.11.0.tgz#04bb9fd6cdfbb10e586985dd666de6c727619d95"
+  integrity sha512-9vSt0AtdOH98GKDXwD5LPfFg9Pcmxt5+1BllAbudKM5iqPxpJnJUfuGaP45OyudDrESCOBgsjnntVUTygBNlzw==
 
 loud-rejection@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
## Detailed purpose of the PR

the latest 5.12.2 has changed structure with just build that break mooc webpack build
