### PR TITLE
Fix pageLink in footer

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-footer/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-footer/style.css
@@ -105,7 +105,7 @@
   color: rgba(255, 255, 255, 0.7);
   font-weight: bold;
   font-size: 14px;
-  max-width: 200px;
+  max-width: 250px;
   cursor: pointer;
   padding-bottom: 6.5px;
   /* because when we have an OnClick event, the component "Link"


### PR DESCRIPTION
[IDEA 5547 - Augmenter le nombre de caractères affichés dans les liens du footer (affichage ordinateur)](https://app.prodpad.com/ideas/5547/canvas)
Hello,
Dans le footer de la plateforme, nous avons dû ajouter une page pour le client La Poste dont le lien d'accès est "Accessibilité : partiellement conforme".
Or, si le lien apparaît bien en affichage mobile, il est coupé en affichage "ordinateur" standard (voir PJ).
Est-ce possible d'augmenter le nombre de caractères affichés s'il vous plaît ?
Merci :)
PS : Le lien est visible sur la plateforme suivante https://institutgroupelaposte-staging.coorpacademy.com/


#### BEFORE
<img width="1728" alt="Capture d’écran 2024-02-07 à 14 28 23" src="https://github.com/CoorpAcademy/components/assets/15608581/3fc50b1e-bc9f-4414-958f-7654e221e2e7">

#### AFTER
<img width="1728" alt="Capture d’écran 2024-02-07 à 14 27 56" src="https://github.com/CoorpAcademy/components/assets/15608581/972f82c8-2590-4f06-936a-c1e5b8d3e1dc">




**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
