### PR TITLE
Disabled support on header items

### DIFF
--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -328,6 +328,7 @@ class MoocHeader extends React.Component {
             <Link
               href={item.href}
               data-name="item-badge"
+              disabled={item.disabled}
               className={classnames(
                 style.itemBadge,
                 item.selected && style.activePage,
@@ -346,6 +347,7 @@ class MoocHeader extends React.Component {
             key={itemName}
             data-name={`item-${itemName}`}
             href={item.href}
+            disabled={item.disabled}
             className={classnames(
               style.item,
               item.disabled && item.selected && style.activePage,
@@ -383,6 +385,7 @@ class MoocHeader extends React.Component {
           <Link
             href={item.href}
             key={itemName}
+            disabled={item.disabled}
             className={classnames(style.option, item.disabled && style.disabled)}
             data-name={`item-more-${itemName}`}
             target={item.target || null}

--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -46,6 +46,7 @@ class MoocHeader extends React.Component {
           name: PropTypes.string,
           href: PropTypes.string,
           selected: PropTypes.bool,
+          disabled: PropTypes.bool,
           counter: PropTypes.number,
           'page-count-aria-label': PropTypes.string
         })
@@ -57,6 +58,7 @@ class MoocHeader extends React.Component {
           name: PropTypes.string,
           href: PropTypes.string,
           selected: PropTypes.bool,
+          disabled: PropTypes.bool,
           counter: PropTypes.number
         })
       )
@@ -319,7 +321,6 @@ class MoocHeader extends React.Component {
               color: primaryColor
             }
           : null;
-
         const {'page-count-aria-label': pageCountAriaLabel} = item;
         const itemLabel = item.selected ? `${item.title}. ${activePageAriaLabel}` : item.title;
         const pageBadge =
@@ -327,7 +328,11 @@ class MoocHeader extends React.Component {
             <Link
               href={item.href}
               data-name="item-badge"
-              className={style.itemBadge}
+              className={classnames(
+                style.itemBadge,
+                item.selected && style.activePage,
+                item.disabled && style.disabled
+              )}
               aria-label={pageCountAriaLabel}
             >
               {item.counter}
@@ -341,8 +346,12 @@ class MoocHeader extends React.Component {
             key={itemName}
             data-name={`item-${itemName}`}
             href={item.href}
-            className={item.selected ? style.activePage : style.item}
-            skinHover
+            className={classnames(
+              style.item,
+              item.disabled && item.selected && style.activePage,
+              item.disabled && style.disabled
+            )}
+            skinHover={!item.disabled}
             onClick={this.handleLinkClick}
             target={item.target || null}
             aria-label={itemLabel}
@@ -374,12 +383,12 @@ class MoocHeader extends React.Component {
           <Link
             href={item.href}
             key={itemName}
-            className={style.option}
+            className={classnames(style.option, item.disabled && style.disabled)}
             data-name={`item-more-${itemName}`}
             target={item.target || null}
             aria-label={itemLabel}
             onClick={this.handleLinkClick}
-            skinHover
+            skinHover={!item.disabled}
             style={{
               ...activeColor
             }}

--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -166,6 +166,7 @@
 .option.disabled {
   cursor: default;
   color: cm_grey_200;
+  pointer-events: none;
 }
 .menuWrapper {
   display: flex;
@@ -202,6 +203,7 @@
 .item.disabled {
   cursor: default;
   color: cm_grey_200;
+  pointer-events: none;
 }
 
 .item .bar {

--- a/packages/@coorpacademy-components/src/organism/mooc-header/style.css
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/style.css
@@ -8,6 +8,7 @@
 @value brand from colors;
 @value black from colors;
 @value dark from colors;
+@value cm_grey_200 from colors;
 @value battle from colors;
 @value orangeAdd from colors;
 @value transparent from colors;
@@ -159,10 +160,13 @@
   text-overflow: ellipsis;
 }
 
-.option:hover {
+.option:not(.disabled):hover {
   color: brand;
 }
-
+.option.disabled {
+  cursor: default;
+  color: cm_grey_200;
+}
 .menuWrapper {
   display: flex;
   align-items: flex-end;
@@ -195,8 +199,9 @@
   text-decoration: none;
 }
 
-.activePage {
-  composes: item;
+.item.disabled {
+  cursor: default;
+  color: cm_grey_200;
 }
 
 .item .bar {
@@ -219,18 +224,18 @@
   display: none;
 }
 
-.activePage .bar {
+.activePage:not(.disabled) .bar {
   left: 0;
   width: 100%;
 }
 
-.option:hover  .line {
+.option:not(.disabled):hover  .line {
   height: 40px;
   width: 3px;
   display: inherit;
 }
 
-.item:hover .bar {
+.item:not(.disabled):hover .bar {
   left: 0;
   width: 100%;
 }
@@ -709,14 +714,14 @@
 
   .item .bar {
     background-color: brand;
-  width: 3px;
-  height: 0;
-  left: 0;
-  position: absolute;
-  transition: all 0.2s ease-out;
-  display: none;
+    width: 3px;
+    height: 0;
+    left: 0;
+    position: absolute;
+    transition: all 0.2s ease-out;
+    display: none;
   }
-  .item:hover .bar {
+  .item:not(.disabled):hover .bar {
     height: 40px;
     width: 3px;
     display: inherit;

--- a/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/test/fixtures/default.js
@@ -55,6 +55,7 @@ export default {
         {
           title: 'Battles',
           href: '#',
+          disabled: true,
           selected: false
         },
         {
@@ -65,6 +66,7 @@ export default {
         {
           title: 'Review',
           href: '#',
+          disabled: true,
           selected: false
         }
       ],
@@ -77,6 +79,7 @@ export default {
         {
           title: 'Médias',
           href: '#',
+          disabled: true,
           selected: false
         },
         {


### PR DESCRIPTION
[IDEA 5539 - Safran - désactiver battles, révision et badges (car pas de cours coorp)](https://app.prodpad.com/ideas/5539/canvas)
Sur la plateforme [https://safran-supply-chain-academy.coorpacademy.com](https://safran-supply-chain-academy.coorpacademy.com/dashboard), pouvez-vous svp disable les onglets Battles, Révision, et Badges (grisés). Sur Battles et Révision, avoir l'info hover : "Available soon" lorsqu'on passe la souris dessus.
Et par la même occasion, puisque j'ai été soudoyée par Morgane Lacroix, peut-on faire la même chose sur [https://safran-digital-academy-si-data.coorpacademy.com](https://safran-digital-academy-si-data.coorpacademy.com/dashboard) mais sans hover. Merci !



<img width="1204" alt="Capture d’écran 2024-02-09 à 15 02 58" src="https://github.com/CoorpAcademy/components/assets/15608581/e1755faf-36a6-44ca-acc6-17cac0a918bf">

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
