### PR TITLE
list item - activate overflow hidden

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/list-overflow-hidden.js
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/list-overflow-hidden.js
@@ -1,0 +1,20 @@
+import filesList from '../../../../organism/list-items/test/fixtures/files-list-overflow-hidden';
+
+export default {
+  props: {
+    mode: 'list',
+    onClose: () => true,
+    header: {
+      title: {
+        title: 'Files details',
+        subtitle: 'See the files you chose to upload',
+        type: 'form-group'
+      },
+      headerIcon: 'fileZipped'
+    },
+    items: {
+      type: 'list',
+      list: filesList.props
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/list-item/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/index.js
@@ -18,7 +18,8 @@ const ListItem = ({
   order,
   'aria-label': ariaLabel,
   contentType,
-  isBulkStyle = false
+  isBulkStyle = false,
+  isOverflowHidden = false
 }) => {
   let isPublished = false;
 
@@ -48,7 +49,9 @@ const ListItem = ({
 
   return (
     <div className={classnames(style.wrapper, isBulkStyle && style.gridLayout)}>
-      <div className={style.dataColumnsWrapper}>
+      <div
+        className={classnames(style.dataColumnsWrapper, isOverflowHidden && style.hiddenOverflowX)}
+      >
         {isPublished && contentType === 'certification' ? orderView : null}
         <div className={style.title} title={title}>
           {title}
@@ -119,6 +122,7 @@ ListItem.propTypes = {
     })
   ),
   isBulkStyle: PropTypes.bool,
+  isOverflowHidden: PropTypes.bool,
   order: PropTypes.number,
   'aria-label': PropTypes.string,
   contentType: PropTypes.string,

--- a/packages/@coorpacademy-components/src/organism/list-item/style.css
+++ b/packages/@coorpacademy-components/src/organism/list-item/style.css
@@ -91,6 +91,7 @@
 
 .hiddenOverflowX {
   overflow-x: hidden;
+  margin-right: 5px;
 }
 
 .hiddenOverflowX:hover {

--- a/packages/@coorpacademy-components/src/organism/list-item/style.css
+++ b/packages/@coorpacademy-components/src/organism/list-item/style.css
@@ -88,3 +88,11 @@
   align-items: center;
   align-content: space-between;
 }
+
+.hiddenOverflowX {
+  overflow-x: hidden;
+}
+
+.hiddenOverflowX:hover {
+  overflow-x: auto;
+}

--- a/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/file-overflow-hidden.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/file-overflow-hidden.js
@@ -1,0 +1,24 @@
+export default {
+  props: {
+    id: 'default',
+    title:
+      'very_long_filename_to_test_hidden_overflow_behavior_very_long_filename_to_test_hidden_overflow_behavior_very_long_filename_to_test_hidden_overflow_behavior_.zip',
+    buttonLink: {
+      type: 'secondary',
+      ariaLabel: 'aria button',
+      dataName: 'default-button',
+      icon: {
+        position: 'left',
+        type: 'close'
+      },
+      onClick: () => console.log('click'),
+      customStyle: {
+        paddingTop: '12px',
+        paddingRight: '24px',
+        paddingBottom: '12px',
+        paddingLeft: '24px'
+      }
+    },
+    isOverflowHidden: true
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/files-list-overflow-hidden.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/files-list-overflow-hidden.js
@@ -1,0 +1,28 @@
+import file from '../../../list-item/test/fixtures/file-overflow-hidden';
+
+const ids_ = Array.from({length: 12}, (_, index) => (index + 1).toString());
+const listeItems = ids_.map(id => {
+  return {
+    ...file.props,
+    id
+  };
+});
+
+export default {
+  props: {
+    title: `${listeItems.length} files to upload`,
+    'aria-label': 'aria list',
+    buttonLink: {
+      type: 'text',
+      label: 'Remove all',
+      'aria-label': 'aria button',
+      'data-name': 'default-button',
+      icon: {
+        position: 'left',
+        type: 'close'
+      },
+      onClick: () => console.log('click')
+    },
+    content: {items: listeItems, type: 'list'}
+  }
+};


### PR DESCRIPTION
ticket
purpose: align remove buttons
solution: set overflow of list - item 
result: 
![image](https://github.com/CoorpAcademy/components/assets/111736786/12b92f4c-4a78-4a4c-bdfb-12c3a0705906)
on hover:
![image](https://github.com/CoorpAcademy/components/assets/111736786/47da974d-34b8-4c06-89ae-e0ffc4c18879)
