### PR TITLE
Progress-bar for adaptive

### DIFF
--- a/packages/@coorpacademy-player-store/src/definitions/models.js
+++ b/packages/@coorpacademy-player-store/src/definitions/models.js
@@ -135,6 +135,7 @@ type Chapter = {|
   bestScore?: number,
   isConditional: boolean,
   time: number,
+  nbSlides?: number,
   version: string
 |};
 

--- a/packages/@coorpacademy-player-store/src/utils/state-extract.js
+++ b/packages/@coorpacademy-player-store/src/utils/state-extract.js
@@ -583,7 +583,7 @@ export const getProgressionSteps = (state: State): ProgressionSteps | null => {
   const progression = getCurrentProgression(state);
   const chapter = getCurrentChapter(state);
 
-  if (!progression || !chapter || isContentAdaptive(state)) {
+  if (!progression || !chapter || (chapter && isContentAdaptive(state) && !chapter.nbSlides)) {
     return null;
   }
 

--- a/packages/@coorpacademy-player-store/src/utils/test/state-extract.js
+++ b/packages/@coorpacademy-player-store/src/utils/test/state-extract.js
@@ -1259,6 +1259,18 @@ test('getProgressionSteps should return null if chapter is adaptive', t => {
   t.is(getProgressionSteps(state), null);
 });
 
+test('getProgressionSteps should get current step and total steps from state with a adaptive course with an overide nbSlides ', t => {
+  const current = 50;
+  const nbSlides = 100;
+  const state = pipe(
+    set('data.progressions.entities.12.content', {ref: '1337', type: 'chapter'}),
+    set('data.contents.chapter.entities.1337.nbSlides', nbSlides),
+    set('data.contents.chapter.entities.1337.info', {nbSlides})
+  )(getStateWithContent(true, {step: {current}}));
+
+  t.deepEqual(getProgressionSteps(state), {current, total: nbSlides});
+});
+
 test('getNextContent should return nextChapter if microlearning progression', t => {
   const progression = {
     content: {ref: '1.B1', type: 'chapter'},


### PR DESCRIPTION
In the "adaptive" linear chapter, we will define the number of slides to be displayed to the learner. In this case, it is possible to display the current step and the total number of slides.


### result on the mooc (2chapters with 5 slides show) 
<img width="1188" alt="Capture d’écran 2024-03-21 à 10 43 12" src="https://github.com/CoorpAcademy/coorpacademy-cockpit/assets/15608581/0c617d11-34f4-4770-94f3-b92899fb9922">

I deployed it on batman
https://batman-staging.coorpacademy.com/content/discipline/dis_E1QlPw2z1g?lang=fr



[IDEA 5602 - Coorp adaptive content sur GO1](https://app.prodpad.com/ideas/5602/canvas)
Hello,
Il y a ce tiicket dans le support GO1 :
Hi there, we’ve had feedback from an influential partner that this LO [36897751](https://staff.go1.co/lo/36897751) is not providing a seamless user experience.
 
The feedback is:
• The description does not clearly articulate what the LO is – whilst we know it is an interactive, it is simply a quiz, nowhere in does it state this.
• After entering the quiz, it does not provide an indication on progress, for example how many questions have been answered and how many are remaining.
 
Please can this be shared with Coorpacademy with a view on whether it can be updated to provide a better experience.
 
Thanks




**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
