### PR TITLE
fix learning profile banner

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/dashboard/learning-profile-banner/style.css
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/learning-profile-banner/style.css
@@ -148,10 +148,6 @@
     font-size: 16px;
     line-height: 19px;
   }
-  
-  .cta {
-    max-width: 175px;
-  }
 }
 
 @media mobile {
@@ -162,6 +158,8 @@
 
   .banner {
     justify-content: center;
+    padding-right: 24px;
+    padding-left: 24px;
   }
 
   .right {
@@ -183,7 +181,7 @@
   }
 
   .cta {
-    max-width: 150px;
+    margin-top: 12px;
   }
 }
 


### PR DESCRIPTION
The purpose is to have more padding in mobile version & fixing button size what ever the device is
Result:
![image](https://github.com/CoorpAcademy/components/assets/111736786/b00d8cae-efcb-406e-a256-0cead862a44c)
