### PR TITLE
introduce skills chart side panel information item

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
@@ -20,7 +20,7 @@ const SkillsChartSideInformationItem = ({title, value, legend, icon: iconProps})
 );
 
 SkillsChartSideInformationItem.propTypes = {
-  icon: Icon.propTypes,
+  icon: PropTypes.shape(Icon.propTypes),
   title: PropTypes.string,
   value: PropTypes.string,
   legend: PropTypes.shape({

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
@@ -11,8 +11,10 @@ const SkillsChartSideInformationItem = ({title, value, legend, icon: iconProps})
     </div>
     <div className={style.value}>{value}</div>
     <div className={style.legend}>
-      <span className={style.legendLight}>{legend.prefix}</span>{' '}
-      <span className={style.legendBold}>{legend.main}</span>
+      <span
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{__html: legend}}
+      />
     </div>
   </div>
 );

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
@@ -23,10 +23,7 @@ SkillsChartSideInformationItem.propTypes = {
   icon: PropTypes.shape(Icon.propTypes),
   title: PropTypes.string,
   value: PropTypes.string,
-  legend: PropTypes.shape({
-    prefix: PropTypes.string,
-    main: PropTypes.string
-  })
+  legend: PropTypes.string
 };
 
 export default SkillsChartSideInformationItem;

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '../../atom/icon';
+import style from './style.css';
+
+const SkillsChartSideInformationItem = props => {
+  const {title, value, legend, icon: iconProps} = props;
+
+  return (
+    <div className={style.InformationElement}>
+      <div className={style.content}>
+        <div className={style.titleContainer}>
+          <Icon {...iconProps} />
+          <div className={style.title}>{title}</div>
+        </div>
+        <div className={style.value}>{value}</div>
+        <div className={style.legend}>
+          <span className={style.legendLight}>on </span>
+          <span className={style.legendBold}>{legend}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+SkillsChartSideInformationItem.propTypes = {
+  icon: Icon.propTypes,
+  title: PropTypes.string,
+  value: PropTypes.number,
+  legend: PropTypes.string
+};
+
+export default SkillsChartSideInformationItem;

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import defaults from 'lodash/fp/defaults';
 import Icon from '../../atom/icon';
 import style from './style.css';
 
 const SkillsChartSideInformationItem = ({title, value, legend, icon: iconProps}) => (
   <div className={style.InformationElement}>
     <div className={style.titleContainer}>
-      <Icon {...iconProps} />
+      <Icon {...defaults({preset: 's'}, iconProps)} />
       <div className={style.title}>{title}</div>
     </div>
     <div className={style.value}>{value}</div>

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/index.js
@@ -3,31 +3,28 @@ import PropTypes from 'prop-types';
 import Icon from '../../atom/icon';
 import style from './style.css';
 
-const SkillsChartSideInformationItem = props => {
-  const {title, value, legend, icon: iconProps} = props;
-
-  return (
-    <div className={style.InformationElement}>
-      <div className={style.content}>
-        <div className={style.titleContainer}>
-          <Icon {...iconProps} />
-          <div className={style.title}>{title}</div>
-        </div>
-        <div className={style.value}>{value}</div>
-        <div className={style.legend}>
-          <span className={style.legendLight}>on </span>
-          <span className={style.legendBold}>{legend}</span>
-        </div>
-      </div>
+const SkillsChartSideInformationItem = ({title, value, legend, icon: iconProps}) => (
+  <div className={style.InformationElement}>
+    <div className={style.titleContainer}>
+      <Icon {...iconProps} />
+      <div className={style.title}>{title}</div>
     </div>
-  );
-};
+    <div className={style.value}>{value}</div>
+    <div className={style.legend}>
+      <span className={style.legendLight}>{legend.prefix}</span>{' '}
+      <span className={style.legendBold}>{legend.main}</span>
+    </div>
+  </div>
+);
 
 SkillsChartSideInformationItem.propTypes = {
   icon: Icon.propTypes,
   title: PropTypes.string,
-  value: PropTypes.number,
-  legend: PropTypes.string
+  value: PropTypes.string,
+  legend: PropTypes.shape({
+    prefix: PropTypes.string,
+    main: PropTypes.string
+  })
 };
 
 export default SkillsChartSideInformationItem;

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/style.css
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/style.css
@@ -45,11 +45,3 @@
   font-style: normal;
   line-height: 20px;
 }
-
-.legendLight {
-  font-weight: 500;
-}
-
-.legendBold {
-  font-weight: 700;
-}

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/style.css
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/style.css
@@ -1,0 +1,63 @@
+@value colors: "../../variables/colors.css";
+@value cm_grey_50 from colors;
+@value cm_grey_500 from colors;
+@value cm_grey_700 from colors;
+
+.content {
+  border-radius: 12px;
+  background: cm_grey_50;
+  display: flex;
+  padding: 24px;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex: 1 0 0;
+  align-self: stretch;
+}
+
+.InformationElement {
+  height: 152px;
+  width: 316px;
+  margin-bottom: 16px;
+}
+
+.titleContainer {
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.title {
+  color: cm_grey_500;
+  font-family: Gilroy;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 22px;
+  margin-left: 8px;
+}
+
+.value {
+  color: #1D1D2B;
+  font-family: Gilroy;
+  font-size: 28px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 36px;
+}
+
+.legend {
+  color: cm_grey_700;
+  font-family: Gilroy;
+  font-size: 14px;
+  font-style: normal;
+  line-height: 20px;
+}
+
+.legendLight {
+  font-weight: 500;
+}
+
+.legendBold {
+  font-weight: 700;
+}

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/style.css
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/style.css
@@ -4,7 +4,6 @@
 @value cm_grey_700 from colors;
 
 .InformationElement {
-  height: 104px;
   border-radius: 12px;
   background: cm_grey_50;
   display: flex;
@@ -12,7 +11,6 @@
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-start;
-  flex: 1 0 0;
   align-self: stretch;
 }
 

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/style.css
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/style.css
@@ -3,7 +3,8 @@
 @value cm_grey_500 from colors;
 @value cm_grey_700 from colors;
 
-.content {
+.InformationElement {
+  height: 104px;
   border-radius: 12px;
   background: cm_grey_50;
   display: flex;
@@ -13,12 +14,6 @@
   align-items: flex-start;
   flex: 1 0 0;
   align-self: stretch;
-}
-
-.InformationElement {
-  height: 152px;
-  width: 316px;
-  margin-bottom: 16px;
 }
 
 .titleContainer {
@@ -31,14 +26,13 @@
   color: cm_grey_500;
   font-family: Gilroy;
   font-size: 16px;
-  font-style: normal;
   font-weight: 600;
   line-height: 22px;
   margin-left: 8px;
 }
 
 .value {
-  color: #1D1D2B;
+  color: cm_grey_700;
   font-family: Gilroy;
   font-size: 28px;
   font-style: normal;

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-completed.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-completed.js
@@ -1,11 +1,8 @@
-import Icon from '../../../../atom/icon/test/fixtures/default-with-only-icon-name-and-bg-color-green-hex';
-
-const iconProps = Icon.props;
 export default {
   props: {
     title: 'Courses completed',
     value: '165',
     legend: 'on <b>focused skills</b>',
-    icon: {...iconProps, preset: 's'}
+    icon: {iconName: 'book-open-cover', backgroundColor: '#D9F4F7'}
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-completed.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-completed.js
@@ -5,7 +5,7 @@ export default {
   props: {
     title: 'Courses completed',
     value: '165',
-    legend: {prefix: 'on', main: 'focused skills'},
+    legend: 'on <b>focused skills</b>',
     icon: {...iconProps, preset: 's'}
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-completed.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-completed.js
@@ -1,0 +1,11 @@
+import Icon from '../../../../atom/icon/test/fixtures/default-with-only-icon-name-and-bg-color-green-hex';
+
+const iconProps = Icon.props;
+export default {
+  props: {
+    title: 'Courses completed',
+    value: '165',
+    legend: 'focused skills',
+    icon: {...iconProps, preset: 's'}
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-completed.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-completed.js
@@ -5,7 +5,7 @@ export default {
   props: {
     title: 'Courses completed',
     value: '165',
-    legend: 'focused skills',
+    legend: {prefix: 'on', main: 'focused skills'},
     icon: {...iconProps, preset: 's'}
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-learning-hours.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-learning-hours.js
@@ -5,7 +5,7 @@ export default {
   props: {
     title: 'Learning hours',
     value: '28h 6mins',
-    legend: {prefix: 'on', main: 'focused skills'},
+    legend: 'on <b>focused skills</b>',
     icon: {...iconProps, preset: 's', backgroundColor: '#FAD6DE'}
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-learning-hours.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-learning-hours.js
@@ -1,11 +1,8 @@
-import Icon from '../../../../atom/icon/test/fixtures/default-with-only-icon-name-clock';
-
-const iconProps = Icon.props;
 export default {
   props: {
     title: 'Learning hours',
     value: '28h 6mins',
     legend: 'on <b>focused skills</b>',
-    icon: {...iconProps, preset: 's', backgroundColor: '#FAD6DE'}
+    icon: {iconName: 'clock', backgroundColor: '#FAD6DE'}
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-learning-hours.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-learning-hours.js
@@ -1,0 +1,11 @@
+import Icon from '../../../../atom/icon/test/fixtures/default-with-only-icon-name-clock';
+
+const iconProps = Icon.props;
+export default {
+  props: {
+    title: 'Learning hours',
+    value: '28h 6mins',
+    legend: 'focused skills',
+    icon: {...iconProps, preset: 's', backgroundColor: '#FAD6DE'}
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-learning-hours.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-learning-hours.js
@@ -5,7 +5,7 @@ export default {
   props: {
     title: 'Learning hours',
     value: '28h 6mins',
-    legend: 'focused skills',
+    legend: {prefix: 'on', main: 'focused skills'},
     icon: {...iconProps, preset: 's', backgroundColor: '#FAD6DE'}
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-questions-answered.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-questions-answered.js
@@ -5,7 +5,7 @@ export default {
   props: {
     title: 'Questions answered',
     value: '12 585',
-    legend: 'focused skills',
+    legend: {prefix: 'on', main: 'focused skills'},
     icon: {...iconProps, preset: 's', backgroundColor: '#FFDCD1'}
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-questions-answered.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-questions-answered.js
@@ -1,0 +1,11 @@
+import Icon from '../../../../atom/icon/test/fixtures/default-with-only-icon-name-circle-question';
+
+const iconProps = Icon.props;
+export default {
+  props: {
+    title: 'Questions answered',
+    value: '12 585',
+    legend: 'focused skills',
+    icon: {...iconProps, preset: 's', backgroundColor: '#FFDCD1'}
+  }
+};

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-questions-answered.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-questions-answered.js
@@ -1,11 +1,8 @@
-import Icon from '../../../../atom/icon/test/fixtures/default-with-only-icon-name-circle-question';
-
-const iconProps = Icon.props;
 export default {
   props: {
     title: 'Questions answered',
     value: '12 585',
     legend: 'on <b>focused skills</b>',
-    icon: {...iconProps, preset: 's', backgroundColor: '#FFDCD1'}
+    icon: {iconName: 'circle-question', backgroundColor: '#FFDCD1'}
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-questions-answered.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-item/test/fixtures/default-courses-questions-answered.js
@@ -5,7 +5,7 @@ export default {
   props: {
     title: 'Questions answered',
     value: '12 585',
-    legend: {prefix: 'on', main: 'focused skills'},
+    legend: 'on <b>focused skills</b>',
     icon: {...iconProps, preset: 's', backgroundColor: '#FFDCD1'}
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/index.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/index.js
@@ -4,11 +4,16 @@ import {map} from 'lodash/fp';
 import SkillsChartSideInformationItem from '../skills-chart-side-information-item';
 import style from './style.css';
 
-const SkillsChartSideInformationPanel = props => {
-  const {sidePanelItems = []} = props;
-  const sidePanel = map(sidePanelItemProps => {
-    return <SkillsChartSideInformationItem {...sidePanelItemProps} />;
-  }, sidePanelItems);
+const SkillsChartSideInformationPanel = ({sidePanelItems = []}) => {
+  const sidePanel = map(
+    sidePanelItemProps => (
+      <SkillsChartSideInformationItem
+        {...sidePanelItemProps}
+        key={`side-panel-item-${sidePanelItemProps.title}`}
+      />
+    ),
+    sidePanelItems
+  );
   return <div className={style.sidePanel}>{sidePanel}</div>;
 };
 

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/index.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {map} from 'lodash/fp';
+import SkillsChartSideInformationItem from '../skills-chart-side-information-item';
+import style from './style.css';
+
+const SkillsChartSideInformationPanel = props => {
+  const {sidePanelItems = []} = props;
+  const sidePanel = map(sidePanelItemProps => {
+    return <SkillsChartSideInformationItem {...sidePanelItemProps} />;
+  }, sidePanelItems);
+  return <div className={style.sidePanel}>{sidePanel}</div>;
+};
+
+SkillsChartSideInformationPanel.propTypes = {
+  sidePanelItems: PropTypes.arrayOf(SkillsChartSideInformationItem.propTypes)
+};
+
+export default SkillsChartSideInformationPanel;

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/index.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/index.js
@@ -18,7 +18,7 @@ const SkillsChartSideInformationPanel = ({sidePanelItems = []}) => {
 };
 
 SkillsChartSideInformationPanel.propTypes = {
-  sidePanelItems: PropTypes.arrayOf(SkillsChartSideInformationItem.propTypes)
+  sidePanelItems: PropTypes.arrayOf(PropTypes.shape(SkillsChartSideInformationItem.propTypes))
 };
 
 export default SkillsChartSideInformationPanel;

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/style.css
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/style.css
@@ -1,10 +1,10 @@
 .sidePanel {
-display: flex;
-width: 316px;
-flex-direction: column;
-justify-content: center;
-align-items: flex-start;
-gap: 16px;
-align-self: stretch;
+    display: flex;
+    width: 316px;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 16px;
+    align-self: stretch;
  }
  

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/style.css
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/style.css
@@ -1,0 +1,10 @@
+.sidePanel {
+display: flex;
+width: 316px;
+flex-direction: column;
+justify-content: center;
+align-items: flex-start;
+gap: 16px;
+align-self: stretch;
+ }
+ 

--- a/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/molecule/skills-chart-side-information-panel/test/fixtures/default.js
@@ -1,0 +1,9 @@
+import frstSidePanelItem from '../../../skills-chart-side-information-item/test/fixtures/default-courses-completed';
+import secondPanelItem from '../../../skills-chart-side-information-item/test/fixtures/default-courses-questions-answered';
+import thirdPanelItem from '../../../skills-chart-side-information-item/test/fixtures/default-courses-learning-hours';
+
+export default {
+  props: {
+    sidePanelItems: [frstSidePanelItem.props, secondPanelItem.props, thirdPanelItem.props]
+  }
+};


### PR DESCRIPTION
The purpose is to use icon component to implement skills-chart-side-information-item & skills-chart-side-information-panel
result: 

![image](https://github.com/CoorpAcademy/components/assets/111736786/555fb960-68f0-409b-b215-65f546b60d75)
