### PR TITLE
[digitlearning] override comment placeholder

### DIFF
--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -94,5 +94,10 @@
   "close_button_ariaLabel": "Close review slide",
   "post_comment_aria_label": "Post your comment",
   "validate_aria_label": "Validate your answer and go to next step",
-  "stars": "stars"
+  "stars": "stars",
+  "custom":{
+    "digitlearning": {
+      "comment_aria_label": "Rate this course"
+    }
+  }
 }

--- a/packages/@coorpacademy-components/locales/es/global.json
+++ b/packages/@coorpacademy-components/locales/es/global.json
@@ -94,5 +94,10 @@
   "close_button_ariaLabel": "Cerrar pantalla de reseña",
   "post_comment_aria_label": "Publique su comentario",
   "validate_aria_label": "Valide su respuesta y vaya al paso siguiente",
-  "stars": "estrellas"
+  "stars": "estrellas",
+  "custom":{
+    "digitlearning": {
+      "comment_aria_label": "Califica este curso"
+    }
+  }
 }

--- a/packages/@coorpacademy-components/locales/fr/global.json
+++ b/packages/@coorpacademy-components/locales/fr/global.json
@@ -94,5 +94,10 @@
   "close_button_ariaLabel": "Fermez la diapositive de révision",
   "post_comment_aria_label": "Postez votre commentaire",
   "validate_aria_label": "Validez votre réponse et passez à l'étape suivante",
-  "stars": "étoiles"
+  "stars": "étoiles",
+  "custom":{
+    "digitlearning": {
+      "comment_aria_label": "Notez ce cours"
+    }
+  }
 }

--- a/packages/@coorpacademy-components/locales/it/global.json
+++ b/packages/@coorpacademy-components/locales/it/global.json
@@ -94,5 +94,10 @@
   "close_button_ariaLabel": "Chiudi la slide di revisione",
   "post_comment_aria_label": "Pubblica il tuo commento",
   "validate_aria_label": "Convalida la tua risposta e vai al passaggio successivo",
-  "stars": "stelle"
+  "stars": "stelle",
+  "custom":{
+    "digitlearning": {
+      "comment_aria_label": "Vota questo corso"
+    }
+  }
 }

--- a/packages/@coorpacademy-components/locales/nl/global.json
+++ b/packages/@coorpacademy-components/locales/nl/global.json
@@ -94,5 +94,10 @@
   "close_button_ariaLabel": "Sluit de beoordelingsdia",
   "post_comment_aria_label": "Plaats uw reactie",
   "validate_aria_label": "Valideer uw antwoord en ga naar de volgende stap",
-  "stars": "sterren"
+  "stars": "sterren",
+  "custom":{
+    "digitlearning": {
+      "comment_aria_label": "Beoordeel deze cursus"
+    }
+  }
 }


### PR DESCRIPTION
[IDEA 5615 - BNP - Modifications wording forum](https://app.prodpad.com/ideas/5615/canvas)
Hello,
Pour répondre à une demande client qui souhaite pouvoir noter nos cours et ses cours custom, et donc vous éviter un dev, nous avons modifié le wording du titre du forum en demandant aux users de laisser une note
Or ceci fonctionne partiellement car l'espace commentaire lui-même demande à laisser un commentaire. pouvez-vous svp modifier le wording de Ajoutez un commentaire > Notez ce cours en VF / Rate this course en VENG, dans [https://digitlearning.coorpacademy.com](https://digitlearning.coorpacademy.com/discipline/dis_EJ7s-ndZC)
Apparemment ce n'est pas dans le mooc mais dans les composants, donc Elena ne peut pas le faire.
https://d1pb598te31jsy.cloudfront.net/f67f3c2b3f6bfe1e0ede2730649533b4c21cc1dd.png
Merci !

<img src="https://d1pb598te31jsy.cloudfront.net/f67f3c2b3f6bfe1e0ede2730649533b4c21cc1dd.png"/>

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
