### PR TITLE
fix icon component size & padding 

### DIFF
--- a/packages/@coorpacademy-components/src/atom/icon/index.js
+++ b/packages/@coorpacademy-components/src/atom/icon/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, {number} from 'prop-types';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {fas} from '@fortawesome/pro-solid-svg-icons';
 import {library} from '@fortawesome/fontawesome-svg-core';
@@ -13,22 +13,22 @@ library.add(fas);
 
 const DEFAULT_PRESET = 'm';
 const ICON_LUMINOSITY = 32;
-const DEFAULT_WRAPPER_SIZE = 24;
-const ICON_PADDING = 16;
+const DEFAULT_WRAPPER_SIZE = 40;
+const ICON_PADDING = 8;
 export const DEFAULT_ICON_COLOR = 'hsl(0, 0%, 32%)';
 
 const SIZE_CONFIGS = {
   s: {
-    faSize: 'sm',
-    wrapperSize: 16
+    faSize: 12,
+    wrapperSize: 32
   },
   m: {
-    faSize: 'lg',
+    faSize: 16,
     wrapperSize: DEFAULT_WRAPPER_SIZE
   },
   xl: {
-    faSize: 'xl',
-    wrapperSize: 32
+    faSize: 20,
+    wrapperSize: 48
   }
 };
 
@@ -49,7 +49,7 @@ const Icon = React.memo(function Icon({
     ? merge(SIZE_CONFIGS[DEFAULT_PRESET], size)
     : getOr(SIZE_CONFIGS[DEFAULT_PRESET], toLower(preset), SIZE_CONFIGS);
 
-  const wrapperSize = effectiveSize.wrapperSize - ICON_PADDING;
+  const wrapperSize = effectiveSize.wrapperSize - ICON_PADDING * 2;
 
   const iconWrapperStyle = {
     backgroundColor,
@@ -63,7 +63,7 @@ const Icon = React.memo(function Icon({
       <FontAwesomeIcon
         icon={`fa-${iconName}`}
         color={effectiveIconColor}
-        size={effectiveSize.faSize}
+        font-size={effectiveSize.faSize}
       />
     </div>
   );
@@ -75,24 +75,7 @@ Icon.propTypes = {
   backgroundColor: PropTypes.string,
   preset: PropTypes.oneOf(['s', 'm', 'xl']),
   size: PropTypes.shape({
-    faSize: PropTypes.oneOf([
-      '2xs',
-      'xs',
-      'sm',
-      'lg',
-      'xl',
-      '2xl',
-      '1x',
-      '2x',
-      '3x',
-      '4x',
-      '5x',
-      '6x',
-      '7x',
-      '8x',
-      '9x',
-      '10x'
-    ]),
+    faSize: number,
     wrapperSize: PropTypes.number
   })
 };

--- a/packages/@coorpacademy-components/src/atom/icon/index.js
+++ b/packages/@coorpacademy-components/src/atom/icon/index.js
@@ -13,13 +13,14 @@ library.add(fas);
 
 const DEFAULT_PRESET = 'm';
 const ICON_LUMINOSITY = 32;
-const DEFAULT_WRAPPER_SIZE = 40;
+const DEFAULT_WRAPPER_SIZE = 24;
+const ICON_PADDING = 16;
 export const DEFAULT_ICON_COLOR = 'hsl(0, 0%, 32%)';
 
 const SIZE_CONFIGS = {
   s: {
     faSize: 'sm',
-    wrapperSize: 32
+    wrapperSize: 16
   },
   m: {
     faSize: 'lg',
@@ -27,7 +28,7 @@ const SIZE_CONFIGS = {
   },
   xl: {
     faSize: 'xl',
-    wrapperSize: 48
+    wrapperSize: 32
   }
 };
 
@@ -48,10 +49,13 @@ const Icon = React.memo(function Icon({
     ? merge(SIZE_CONFIGS[DEFAULT_PRESET], size)
     : getOr(SIZE_CONFIGS[DEFAULT_PRESET], toLower(preset), SIZE_CONFIGS);
 
+  const wrapperSize = effectiveSize.wrapperSize - ICON_PADDING;
+
   const iconWrapperStyle = {
     backgroundColor,
-    width: effectiveSize.wrapperSize,
-    height: effectiveSize.wrapperSize
+    width: wrapperSize,
+    height: wrapperSize,
+    padding: ICON_PADDING
   };
 
   return (

--- a/packages/@coorpacademy-components/src/atom/icon/style.css
+++ b/packages/@coorpacademy-components/src/atom/icon/style.css
@@ -1,5 +1,4 @@
 .iconWrapper {
-  padding: 8px;
   border-radius: 8px;
   display: flex;
   align-items: center;

--- a/packages/@coorpacademy-components/src/atom/icon/test/fixtures/size.js
+++ b/packages/@coorpacademy-components/src/atom/icon/test/fixtures/size.js
@@ -4,8 +4,8 @@ export default {
     iconColor: '#1B7B88',
     backgroundColor: '#D9F4F7',
     size: {
-      faSize: '2xs',
-      wrapperSize: 30
+      faSize: 24,
+      wrapperSize: 56
     }
   }
 };


### PR DESCRIPTION
purpose: 
preset sizes (s, m, xl) should have (32, 40, 48 px) including padding 
user should be able to set size or preset (having in his mind size including padding) 
fix:

- subtract padding 
- set icon size (faSize) using font-size (in px) 

|**size**|xl|m|s|
|-|-|-|-|
|before| ![image before size (xl)](https://github.com/CoorpAcademy/components/assets/111736786/c241f4f8-4687-44db-83a4-3ae973eba204)|![image before size (m)](https://github.com/CoorpAcademy/components/assets/111736786/518d305b-6b98-4c39-8ebe-68663ead1035)|![image before size s](https://github.com/CoorpAcademy/components/assets/111736786/0c21ca21-eb31-4369-8224-681b2a408239)|
|**after**|![image after size xl](https://github.com/CoorpAcademy/components/assets/111736786/1d39c637-a418-489c-b43d-6980df75c507)|![image after size m](https://github.com/CoorpAcademy/components/assets/111736786/91725953-d22f-4c58-a68d-b661bee61446)|![image after size s](https://github.com/CoorpAcademy/components/assets/111736786/ec30ba7e-c2c0-4c07-a06b-a5556e3f373a)|
