### PR TITLE
Replace colorjs with css convert

### DIFF
--- a/packages/@coorpacademy-components/src/atom/chip/index.js
+++ b/packages/@coorpacademy-components/src/atom/chip/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import get from 'lodash/fp/get';
-import Color from 'colorjs.io';
+import {convert} from 'css-color-function';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import Provider from '../provider';
 import {COLORS} from '../../variables/colors';
@@ -16,12 +16,8 @@ const ICON_SIZE = '12px';
 export const calculateHoveredSelectedBgColor = (
   selectedBgColor,
   luminosityDelta = LUMINOSITY_DELTA
-) => {
-  return new Color(selectedBgColor)
-    .to('hsl')
-    .set({l: l => l * (1 - luminosityDelta)})
-    .toString();
-};
+) => convert(`hsl(from ${selectedBgColor} h s calc(l*(1 - ${luminosityDelta})))`);
+// note: luminosity decrease is relative to the selected color
 
 const Chip = (props, context) => {
   const {

--- a/packages/@coorpacademy-components/src/atom/chip/test/calculate-hovered-selected-color.js
+++ b/packages/@coorpacademy-components/src/atom/chip/test/calculate-hovered-selected-color.js
@@ -5,9 +5,11 @@ import {calculateHoveredSelectedBgColor} from '..';
 browserEnv();
 
 test('calculateHoveredSelectedBgColor with default luminosity delta', t => {
-  t.is(calculateHoveredSelectedBgColor('#0000FF'), 'hsl(240 100% 46%)');
+  t.is(calculateHoveredSelectedBgColor('#0000FF'), 'hsl(from #0000FF h s calc(l*(1 - 0.08)))');
+  // ≅ hsl(240 100% 46%)
 });
 
 test('calculateHoveredSelectedBgColor with custom luminosity delta', t => {
-  t.is(calculateHoveredSelectedBgColor('#0000FF', 0.2), 'hsl(240 100% 40%)');
+  t.is(calculateHoveredSelectedBgColor('#0000FF', 0.2), 'hsl(from #0000FF h s calc(l*(1 - 0.2)))');
+  // ≅  hsl(240 100% 40%)
 });

--- a/packages/@coorpacademy-components/src/atom/icon/index.js
+++ b/packages/@coorpacademy-components/src/atom/icon/index.js
@@ -6,7 +6,7 @@ import {library} from '@fortawesome/fontawesome-svg-core';
 import toLower from 'lodash/fp/toLower';
 import merge from 'lodash/fp/merge';
 import getOr from 'lodash/fp/getOr';
-import Color from 'colorjs.io';
+import {convert} from 'css-color-function';
 import style from './style.css';
 
 library.add(fas);
@@ -33,7 +33,8 @@ const SIZE_CONFIGS = {
 };
 
 export const getForegroundColor = backgroundColor =>
-  new Color(backgroundColor).to('hsl').set({l: ICON_LUMINOSITY}).toString();
+  convert(`color(${backgroundColor} lightness(${ICON_LUMINOSITY}%))`);
+// set lightness to 32%
 
 const Icon = React.memo(function Icon({
   iconName,

--- a/packages/@coorpacademy-components/src/atom/icon/test/get-foreground-color.test.js
+++ b/packages/@coorpacademy-components/src/atom/icon/test/get-foreground-color.test.js
@@ -5,15 +5,15 @@ import {getForegroundColor} from '..';
 browserEnv();
 
 test('getForegroundColor with a valid RGB background color', t => {
-  t.is(getForegroundColor('rgba(255, 220, 209, 1)'), 'hsl(14.348 100% 32%)');
+  t.is(getForegroundColor('rgba(255, 220, 209, 1)'), 'rgb(163, 38, 0)'); // hsl(14.348 100% 32%);
 });
 
 test('getForegroundColor with a valid HEX background color', t => {
-  t.is(getForegroundColor('#D9F4F7'), 'hsl(186 65.217% 32%)');
+  t.is(getForegroundColor('#D9F4F7'), 'rgb(29, 124, 135)'); // 'hsl(186 65.217% 32%)'
 });
 
 test('getForegroundColor with a valid HSL background color', t => {
-  t.is(getForegroundColor('hsla(52, 100%, 91%, 1)'), 'hsl(52 100% 32%)');
+  t.is(getForegroundColor('hsla(52, 100%, 91%, 1)'), 'rgb(163, 141, 0)'); // 'hsl(52 100% 32%)'
 });
 
 test('getForegroundColor throws an error with an invalid backgroundColor', t => {
@@ -21,6 +21,6 @@ test('getForegroundColor throws an error with an invalid backgroundColor', t => 
     () => {
       getForegroundColor('invalid color');
     },
-    {message: 'Could not parse invalid color as a color. Missing a plugin?'}
+    {message: 'Unable to parse color from string "invalid"'}
   );
 });


### PR DESCRIPTION
### Detailed purpose of the PR

Colorjs powered component is causing trouble on the Mooc/LXP in a es5 context. (Icon & Chip, #2837)
Replace it's usage by `css-color-function` that used in other part of the codebase to manipulate colors.
