### PR TITLE
fix course title rendering in popin-end

### DIFF
--- a/packages/@coorpacademy-components/src/template/app-player/popin-header/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-header/style.css
@@ -119,7 +119,7 @@
 .title {
   composes: titleElement;
   font-size: 17px;
-  display: inline-flex;
+  display: block;
 }
 
 .fullAnswer {


### PR DESCRIPTION
with the course `"To be or <i>bot</i> to be ? L'intelligence artificielle dans votre quotidien"`

## before
<img width="1473" alt="Capture d’écran 2024-05-21 à 18 16 36" src="https://github.com/CoorpAcademy/components/assets/15608581/39fc376c-02d4-4b16-9197-b685cfcddfed">

## after
<img width="1480" alt="Capture d’écran 2024-05-21 à 18 15 47" src="https://github.com/CoorpAcademy/components/assets/15608581/0be6c41d-4f12-402f-86d1-39c8c4f8d39f">


**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
