### PR TITLE
CLXP-49 Radar/Skill chart enhancement with interactive feedbacks

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/index.tsx
@@ -478,17 +478,18 @@ export const LearningProfileRadarChart = (
     }
   }
 
-  function renderCustomLabel({
-    x,
-    y,
-    payload: {value: label},
-    index
-  }: {
+  function renderCustomLabel(props: {
     x: number;
     y: number;
     payload: {value: string};
     index: number;
   }) {
+    const {
+      x,
+      y,
+      payload: {value: label},
+      index
+    } = props;
     const currentData = formatedData.find(({subject}) => subject === label);
     const percentagesValues: number[] = pipe(
       omit('subject'),

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/style.css
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/style.css
@@ -65,3 +65,8 @@
   font-size: 14px;
   font-weight: 700;
 }
+
+.buttonWrapper {
+  width: 100%;
+  height: 36px;
+}

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/style.css
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/style.css
@@ -31,6 +31,7 @@
 .tickWrapper:hover,
 .tickWrapperHover {
   background-color: cm_grey_75;
+  border-radius: 12px;
 }
 
 

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/style.css
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/style.css
@@ -1,6 +1,7 @@
 @value colors: "../../variables/colors.css";
 @value cm_primary_blue from colors;
 @value cm_grey_50 from colors;
+@value cm_grey_75 from colors;
 @value lightDark from colors;
 
 .tickeForeignObject {
@@ -26,6 +27,13 @@
   border-radius: 12px;
   width: fit-content;
 }
+
+.tickWrapper:hover,
+.tickWrapperHover {
+  background-color: cm_grey_75;
+}
+
+
 
 .tickValue {
   padding: 4px;

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/dot-click.tsx
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/dot-click.tsx
@@ -1,12 +1,14 @@
 import test from 'ava';
 import browserEnv from 'browser-env';
 import React from 'react';
-import {render, fireEvent} from '@testing-library/react';
-import {noop} from 'lodash/fp';
+import {fireEvent} from '@testing-library/react';
+import {identity, noop} from 'lodash/fp';
+import {renderWithContext} from '../../../util/render-with-context';
 import {LearningProfileRadarChart} from '..';
 import fixture from './fixtures/hexagon';
 
 browserEnv();
+const translate = identity;
 
 global.ResizeObserver = class MockedResizeObserver {
   observe = () => noop(null);
@@ -19,7 +21,12 @@ global.ResizeObserver = class MockedResizeObserver {
 test('should get dot and trigger click', t => {
   t.plan(2);
   const props = {...fixture.props, onClick: (ref?: string) => t.is(ref, 'skillRef1')};
-  const {container} = render(<LearningProfileRadarChart {...props} width={100} height={100} />);
+  const {container} = renderWithContext(
+    <LearningProfileRadarChart {...props} width={100} height={100} />,
+    {
+      context: {translate}
+    }
+  );
   const dot1 = container.querySelector('[data-name="dot-dataset-1"]');
   t.truthy(dot1);
   fireEvent.click(dot1 as Element);

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/hexagon-with-2-dataset.ts
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/hexagon-with-2-dataset.ts
@@ -39,6 +39,7 @@ const fixture: Fixture = {
         }
       }
     ],
+    onExploreClick: skillRef => console.log(skillRef),
     onClick: skillref => console.log(`on dot click on ref: ${skillref}`)
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/hexagon-with-3-dataset.ts
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/hexagon-with-3-dataset.ts
@@ -58,6 +58,7 @@ const fixture: Fixture = {
         }
       }
     ],
+    onExploreClick: skillRef => console.log(skillRef),
     onClick: skillref => console.log(`on dot click on ref: ${skillref}`)
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/hexagon-with-default-style.ts
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/hexagon-with-default-style.ts
@@ -20,6 +20,7 @@ const fixture: Fixture = {
       skillRef5: 'Time management',
       skillRef6: 'Sustainable thinking'
     },
+    onExploreClick: skillRef => console.log(skillRef),
     onClick: skillref => console.log(`on dot click on ref: ${skillref}`)
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/hexagon.ts
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/hexagon.ts
@@ -31,6 +31,7 @@ const fixture: Fixture = {
         }
       }
     ],
+    onExploreClick: skillRef => console.log(skillRef),
     onClick: skillref => console.log(`on dot click on ref: ${skillref}`)
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/pentagon.ts
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/pentagon.ts
@@ -34,6 +34,7 @@ const fixture: Fixture = {
         }
       }
     ],
+    onExploreClick: skillRef => console.log(skillRef),
     onClick: skillref => console.log(`on dot click on ref: ${skillref}`)
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/quadrilateral.ts
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/quadrilateral.ts
@@ -32,6 +32,7 @@ const fixture: Fixture = {
         }
       }
     ],
+    onExploreClick: skillRef => console.log(skillRef),
     onClick: skillref => console.log(`on dot click on ref: ${skillref}`)
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/triangle.ts
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/fixtures/triangle.ts
@@ -30,6 +30,7 @@ const fixture: Fixture = {
         }
       }
     ],
+    onExploreClick: skillRef => console.log(skillRef),
     onClick: skillref => console.log(`on dot click on ref: ${skillref}`)
   }
 };

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/label-click.tsx
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/test/label-click.tsx
@@ -1,12 +1,14 @@
 import test from 'ava';
 import browserEnv from 'browser-env';
 import React from 'react';
-import {render, fireEvent} from '@testing-library/react';
-import {noop} from 'lodash/fp';
+import {fireEvent} from '@testing-library/react';
+import {identity, noop} from 'lodash/fp';
+import {renderWithContext} from '../../../util/render-with-context';
 import {LearningProfileRadarChart} from '..';
 import fixture from './fixtures/hexagon';
 
 browserEnv();
+const translate = identity;
 
 global.ResizeObserver = class MockedResizeObserver {
   observe = () => noop(null);
@@ -19,7 +21,12 @@ global.ResizeObserver = class MockedResizeObserver {
 test('should get label and trigger click', t => {
   t.plan(2);
   const props = {...fixture.props, onClick: (ref?: string) => t.is(ref, 'skillRef3')};
-  const {container} = render(<LearningProfileRadarChart {...props} width={100} height={100} />);
+  const {container} = renderWithContext(
+    <LearningProfileRadarChart {...props} width={100} height={100} />,
+    {
+      context: {translate}
+    }
+  );
   const label = container.querySelector('[data-name="Problem solving"]');
   t.truthy(label);
   fireEvent.click(label as Element);

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/types.ts
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/types.ts
@@ -87,7 +87,7 @@ export type LearningProfileRadarChartPropTypes = {
   };
   totalDataset: number;
   onClick: (skillRef?: string) => void;
-  onExploreClick?: () => void;
+  onExploreClick: (label?: string) => void;
   colors?: ColorType[];
   width?: number;
   height?: number;

--- a/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/types.ts
+++ b/packages/@coorpacademy-components/src/molecule/learning-profile-radar-chart/types.ts
@@ -23,7 +23,8 @@ export const learningProfileRadarChartPropTypes = {
     })
   ),
   width: PropTypes.number,
-  height: PropTypes.number
+  height: PropTypes.number,
+  onExploreClick: PropTypes.func
 };
 
 export const customDotPropTypes = {
@@ -86,6 +87,7 @@ export type LearningProfileRadarChartPropTypes = {
   };
   totalDataset: number;
   onClick: (skillRef?: string) => void;
+  onExploreClick?: () => void;
   colors?: ColorType[];
   width?: number;
   height?: number;

--- a/packages/@coorpacademy-components/src/template/my-learning/index.js
+++ b/packages/@coorpacademy-components/src/template/my-learning/index.js
@@ -316,6 +316,7 @@ const MyLearning = (props, context) => {
                     data={graphDatas}
                     legend={graphLegends}
                     onClick={handleOnDotClick}
+                    onExploreClick={onExploreSkill}
                     colors={[
                       {
                         gradient: {

--- a/packages/@coorpacademy-components/src/template/my-learning/style.css
+++ b/packages/@coorpacademy-components/src/template/my-learning/style.css
@@ -120,6 +120,10 @@
 .radarContainer {
   width: 700px;
   height: 444px;
+
+  svg {
+    overflow: initial;
+  }
 }
 
 .toolBarContainer {

--- a/packages/@coorpacademy-components/src/template/my-learning/test/fixtures/default.js
+++ b/packages/@coorpacademy-components/src/template/my-learning/test/fixtures/default.js
@@ -113,7 +113,7 @@ export const defaultProps = {
   isLoadng: false,
   onSkillFocusConfirm: () => console.log('confirm'),
   onReviewSkill: () => console.log('review'),
-  onExploreSkill: () => console.log('explore')
+  onExploreSkill: skillRef => console.log(skillRef)
 };
 
 export default {


### PR DESCRIPTION
purpose: 
- Add the ability to unselect the skill by clicking again on the dot or its label card

- Add a “Explore” button (brand color + full container width) into the skill label card when selected ([figma link](https://www.figma.com/design/FoegQZuRfm9NHnSUEWuoui/Learner-profile%2C-skills%2C-progression?node-id=1726-7336&t=72qFzOKshz13GQdP-11))

- Add hover effect to label skill card when it is selected ([figma link](https://www.figma.com/design/FoegQZuRfm9NHnSUEWuoui/Learner-profile%2C-skills%2C-progression?node-id=1726-7336&t=72qFzOKshz13GQdP-11)) when hovering it or its dot

- Add hover effect on unselected label skill card ([figma link](https://www.figma.com/design/FoegQZuRfm9NHnSUEWuoui/Learner-profile%2C-skills%2C-progression?node-id=1742-33003&t=72qFzOKshz13GQdP-11)) when hovering it or its dot

Review app: https://6628d2e0fd4aa63f3be2e1ab-xnagvdbqoc.chromatic.com/?path=/story/template-mylearning--default