### PR TITLE
CLXP-50 update tooltip position to be more centered

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/discipline-associated-skills/index.js
+++ b/packages/@coorpacademy-components/src/molecule/discipline-associated-skills/index.js
@@ -51,6 +51,7 @@ const DisciplineAssociatedSkills = (props, context) => {
                   <ToolTip
                     AnchorElement={handleAnchorElement}
                     fontSize={12}
+                    delayHide={0}
                     iconContainerClassName={style.infoIconTooltip}
                     tooltipClassName={style.tooltip}
                     TooltipContent={translate('skill_focused_chip_tooltip')}

--- a/packages/@coorpacademy-components/src/molecule/discipline-associated-skills/style.css
+++ b/packages/@coorpacademy-components/src/molecule/discipline-associated-skills/style.css
@@ -55,7 +55,6 @@
   font-size: 12px;
   font-style: normal;
   line-height: 16px;
-  right: -28px;
   top: -48px;
 
   p {

--- a/packages/@coorpacademy-components/src/template/common/discipline/test/fixtures/with-associated-skills.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/test/fixtures/with-associated-skills.js
@@ -41,13 +41,13 @@ export default {
     skills: [
       {
         ref: 'skill-ref-1',
-        locale: 'Skill 1',
+        locale: 'Digital Dexterity',
         focused: true
       },
       {
         ref: 'skill-ref-2',
         locale: 'Skill 2',
-        focused: false
+        focused: true
       },
       {
         ref: 'skill-ref-3',


### PR DESCRIPTION
Purpose: update tooltip position to be more centered.
 Tweak on #2857 

 review app: https://6628d2e0fd4aa63f3be2e1ab-trywvwxcpi.chromatic.com/?path=/story/template-common-discipline--with-associated-skills

Before:
![image](https://github.com/CoorpAcademy/components/assets/160047673/39d07b8b-f628-4e6c-abc0-1463d157b34e)

After: 
![image](https://github.com/CoorpAcademy/components/assets/160047673/08f76d57-8199-45ed-86af-1e37bbff5531)

