### PR TITLE
CLXP-110 Skill picker modal footer is hidden when zoom in on browser

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/base-modal/style.css
+++ b/packages/@coorpacademy-components/src/molecule/base-modal/style.css
@@ -24,12 +24,15 @@
 }
 
 .modal {
-  max-width: 660px;
+  max-width: 71vw;
+  max-height: 86vh;
   min-width: 450px;
   min-height: 165px;
   overflow: hidden;
   border-radius: 16px;
   background-color: white;
+  display: flex;
+  flex-direction: column;
 }
 
 .header {
@@ -68,6 +71,7 @@
 }
 
 .body {
+  overflow: auto;
   background-color: xtraLightGrey;
   padding: 32px 32px 16px 32px;
   min-height: 100px;


### PR DESCRIPTION
Purpose: fix Skill picker modal footer is hidden when zoom in on browser

review app: https://6628d2e0fd4aa63f3be2e1ab-ywbzvisqli.chromatic.com/

125%: 
![image](https://github.com/user-attachments/assets/bb088553-c369-41d4-b648-4b8ed54bdd06)

150%:

![image](https://github.com/user-attachments/assets/d65afd53-9e62-4304-8cba-282c74aa09a0)
