### PR TITLE
CLXP-163 remove default button title

### DIFF
--- a/packages/@coorpacademy-components/src/atom/button-link-icon/index.js
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon/index.js
@@ -92,7 +92,6 @@ const ButtonLinkIcon = props => {
           className={styleButton}
           data-name={dataName}
           aria-label={ariaLabel}
-          title={ariaLabel}
           onMouseLeave={handleMouseLeave}
           onMouseOver={handleMouseOver}
         >
@@ -110,7 +109,6 @@ const ButtonLinkIcon = props => {
           aria-label={ariaLabel}
           data-name={dataName}
           data-testid={`button-${dataName}-${className}`}
-          title={ariaLabel}
           className={styleButton}
           onClick={handleOnClick}
           onMouseLeave={handleMouseLeave}


### PR DESCRIPTION
Purpose: remove the default tooltip of ButtonLinkIcon:

Before:

![image](https://github.com/user-attachments/assets/f1a73bdb-4abb-4c71-a5b5-cccbcb83c550)

After:

![image](https://github.com/user-attachments/assets/b3b40bdd-0532-44ad-b427-8f4fe56ece70)
