### PR TITLE
CLXP-127 Technical: Missing translation shouldn't break the UX on CM

### DIFF
--- a/packages/@coorpacademy-translate/src/test/translate.js
+++ b/packages/@coorpacademy-translate/src/test/translate.js
@@ -118,7 +118,7 @@ test("should throw error if nested template couldn't be found", t => {
   t.throws(() => translate('foo.foo_none'), {message: 'Key foo.foo_none not found!'});
 });
 
-test("should not throw error if template couldn't be found and isAllowFalsy === true", t => {
+test("should not throw error if template couldn't be found and throwIfMissing === true", t => {
   const translate = createTranslate(
     {
       foo: 'Foo'

--- a/packages/@coorpacademy-translate/src/test/translate.js
+++ b/packages/@coorpacademy-translate/src/test/translate.js
@@ -119,9 +119,12 @@ test("should throw error if nested template couldn't be found", t => {
 });
 
 test("should not throw error if template couldn't be found and isAllowFalsy === true", t => {
-  const translate = createTranslate({
-    foo: 'Foo'
-  }, true);
+  const translate = createTranslate(
+    {
+      foo: 'Foo'
+    },
+    true
+  );
 
   t.is(translate('bar'), 'bar');
 });

--- a/packages/@coorpacademy-translate/src/test/translate.js
+++ b/packages/@coorpacademy-translate/src/test/translate.js
@@ -117,3 +117,11 @@ test("should throw error if nested template couldn't be found", t => {
 
   t.throws(() => translate('foo.foo_none'), {message: 'Key foo.foo_none not found!'});
 });
+
+test("should not throw error if template couldn't be found and isAllowFalsy === true", t => {
+  const translate = createTranslate({
+    foo: 'Foo'
+  }, true);
+
+  t.is(translate('bar'), 'bar');
+});

--- a/packages/@coorpacademy-translate/src/test/translate.js
+++ b/packages/@coorpacademy-translate/src/test/translate.js
@@ -118,12 +118,12 @@ test("should throw error if nested template couldn't be found", t => {
   t.throws(() => translate('foo.foo_none'), {message: 'Key foo.foo_none not found!'});
 });
 
-test("should not throw error if template couldn't be found and throwIfMissing === true", t => {
+test("should not throw error if template couldn't be found and throwIfMissing === false", t => {
   const translate = createTranslate(
     {
       foo: 'Foo'
     },
-    true
+    false
   );
 
   t.is(translate('bar'), 'bar');

--- a/packages/@coorpacademy-translate/src/translate.js
+++ b/packages/@coorpacademy-translate/src/translate.js
@@ -16,21 +16,25 @@ function getTemplate(locales, key, count) {
   return getOr(regularTemplate, `${key}_plural`, locales);
 }
 
-const createTranslate = (locales, isAllowFalsy = false) => (key, data) => {
-  const template = getTemplate(locales, key, get('count', data));
-  if (!isString(template) && !isAllowFalsy) {
-    throw new Error(`Key ${key} not found!`);
-  }
+const createTranslate =
+  (locales, isAllowFalsy = false) =>
+  (key, data) => {
+    const template = getTemplate(locales, key, get('count', data));
+    if (!isString(template) && !isAllowFalsy) {
+      throw new Error(`Key ${key} not found!`);
+    }
 
-  return !isString(template) ? key : replace(
-    interpolation,
-    (token, value) => {
-      const _value = trim(value);
-      return has(_value, data) ? get(_value, data) : token;
-    },
-    template
-  );
-};
+    return !isString(template)
+      ? key
+      : replace(
+          interpolation,
+          (token, value) => {
+            const _value = trim(value);
+            return has(_value, data) ? get(_value, data) : token;
+          },
+          template
+        );
+  };
 
 export function mockTranslate(key, data) {
   if (data) {

--- a/packages/@coorpacademy-translate/src/translate.js
+++ b/packages/@coorpacademy-translate/src/translate.js
@@ -17,11 +17,11 @@ function getTemplate(locales, key, count) {
 }
 
 const createTranslate =
-  (locales, throwIfMissing = false) =>
+  (locales, throwIfMissing = true) =>
   (key, data) => {
     const template = getTemplate(locales, key, get('count', data));
     if (!isString(template)) {
-      if (!throwIfMissing) throw new Error(`Key ${key} not found!`);
+      if (throwIfMissing) throw new Error(`Key ${key} not found!`);
       return key;
     }
 

--- a/packages/@coorpacademy-translate/src/translate.js
+++ b/packages/@coorpacademy-translate/src/translate.js
@@ -16,13 +16,13 @@ function getTemplate(locales, key, count) {
   return getOr(regularTemplate, `${key}_plural`, locales);
 }
 
-const createTranslate = locales => (key, data) => {
+const createTranslate = (locales, isAllowFalsy = false) => (key, data) => {
   const template = getTemplate(locales, key, get('count', data));
-  if (!isString(template)) {
+  if (!isString(template) && !isAllowFalsy) {
     throw new Error(`Key ${key} not found!`);
   }
 
-  return replace(
+  return !isString(template) ? key : replace(
     interpolation,
     (token, value) => {
       const _value = trim(value);

--- a/packages/@coorpacademy-translate/src/translate.js
+++ b/packages/@coorpacademy-translate/src/translate.js
@@ -17,23 +17,22 @@ function getTemplate(locales, key, count) {
 }
 
 const createTranslate =
-  (locales, isAllowFalsy = false) =>
+  (locales, throwIfMissing = false) =>
   (key, data) => {
     const template = getTemplate(locales, key, get('count', data));
-    if (!isString(template) && !isAllowFalsy) {
-      throw new Error(`Key ${key} not found!`);
+    if (!isString(template)) {
+      if (!throwIfMissing) throw new Error(`Key ${key} not found!`);
+      return key;
     }
 
-    return !isString(template)
-      ? key
-      : replace(
-          interpolation,
-          (token, value) => {
-            const _value = trim(value);
-            return has(_value, data) ? get(_value, data) : token;
-          },
-          template
-        );
+    return replace(
+      interpolation,
+      (token, value) => {
+        const _value = trim(value);
+        return has(_value, data) ? get(_value, data) : token;
+      },
+      template
+    );
   };
 
 export function mockTranslate(key, data) {


### PR DESCRIPTION
Add a flag `isAllowFalsy` to `createTranslate` so that error is not throw if locale key is missing if  `isAllowFalsy === true`

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [x] Unit testing
