### PR TITLE
add hover tooltip to button link  & fix hover sizes

### DIFF
--- a/packages/@coorpacademy-components/src/atom/button-link/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.tsx
@@ -119,7 +119,8 @@ const ButtonLink = (props: ButtonLinkProps) => {
         toolTipIsVisible={hovered}
         placement={tooltipPlacement}
         TooltipContent={TooltipContent}
-        closeToolTipInformationTextAriaLabel={tooltipText || ariaLabel || ''}
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        closeToolTipInformationTextAriaLabel={(tooltipText || ariaLabel)!}
       />
     );
   };

--- a/packages/@coorpacademy-components/src/atom/button-link/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.tsx
@@ -110,8 +110,8 @@ const ButtonLink = (props: ButtonLinkProps) => {
   );
 
   const renderToolTip = () => {
-    if (!tooltipText && !ariaLabel) return null;
-
+    const closeToolTipInformationTextAriaLabel = tooltipText || ariaLabel;
+    if (!closeToolTipInformationTextAriaLabel) return null;
     return (
       <ToolTip
         fontSize={12}
@@ -119,8 +119,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
         toolTipIsVisible={hovered}
         placement={tooltipPlacement}
         TooltipContent={TooltipContent}
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        closeToolTipInformationTextAriaLabel={(tooltipText || ariaLabel)!}
+        closeToolTipInformationTextAriaLabel={closeToolTipInformationTextAriaLabel}
       />
     );
   };

--- a/packages/@coorpacademy-components/src/atom/button-link/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.tsx
@@ -6,6 +6,7 @@ import FaIcon from '../icon';
 import {ICONS} from '../../util/button-icons';
 import propTypes, {ButtonLinkProps, IconType} from './types';
 import style from './style.css';
+import ToolTip from '../tooltip';
 
 const getButtonContent = (
   icon?: IconType,
@@ -56,6 +57,25 @@ const getButtonContent = (
   );
 };
 
+const TooltipContent = ({ ariaLabel }: { ariaLabel: string }) => (
+  <span className={style.tooltipContentWrapper}>{ariaLabel}</span>
+);
+
+const renderToolTip = (hovered: boolean,tooltipPlacement: string, ariaLabel?: string) => {
+  if (!ariaLabel) return null;
+
+  return (
+    <ToolTip
+      fontSize={12}
+      anchorId="button-icon"
+      toolTipIsVisible={hovered}
+      placement={tooltipPlacement}
+      TooltipContent={() => <TooltipContent ariaLabel={ariaLabel} />}
+      closeToolTipInformationTextAriaLabel={ariaLabel}
+    />
+  );
+};
+
 const ButtonLink = (props: ButtonLinkProps) => {
   const {
     type,
@@ -69,6 +89,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
     'data-name': dataName,
     'data-testid': dataTestId = 'button-link',
     'aria-label': ariaLabel,
+    tooltipPlacement = 'left',
     link,
     onClick = noop,
     onKeyDown = noop,
@@ -79,6 +100,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
   const styleButton = classnames(
     className,
     style.button,
+    !label && style.iconButton,
     type === 'primary' && style.primary,
     type === 'secondary' && style.secondary,
     type === 'tertiary' && style.tertiary,
@@ -119,6 +141,12 @@ const ButtonLink = (props: ButtonLinkProps) => {
         {...(useTitle && {
           title: ariaLabel || label
         })}
+        {...(ariaLabel && !label
+          ? {
+              'data-for': 'button-icon',
+              'data-tip': hovered
+            }
+          : {})}
         style={customStyle}
         className={styleButton}
         data-name={dataName}
@@ -130,6 +158,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
         onMouseLeave={handleMouseLeave}
       >
         {getButtonContent(icon, content ?? label, hovered, hoverBackgroundColor, hoverColor)}
+        {renderToolTip(hovered, tooltipPlacement, ariaLabel)}
       </Link>
     );
   }
@@ -137,8 +166,14 @@ const ButtonLink = (props: ButtonLinkProps) => {
   return (
     <button
       {...(useTitle && {
-        title: ariaLabel || label
+        title: ariaLabel
       })}
+      {...(ariaLabel && !label
+        ? {
+            'data-for': 'button-icon',
+            'data-tip': hovered
+          }
+        : {})}
       // eslint-disable-next-line react/button-has-type
       type={usage}
       aria-label={ariaLabel || label}
@@ -154,6 +189,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
       disabled={disabled}
     >
       {getButtonContent(icon, content ?? label, hovered, hoverBackgroundColor, hoverColor)}
+      {renderToolTip(hovered, tooltipPlacement, ariaLabel)}
     </button>
   );
 };

--- a/packages/@coorpacademy-components/src/atom/button-link/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.tsx
@@ -4,9 +4,9 @@ import classnames from 'classnames';
 import Link from '../link';
 import FaIcon from '../icon';
 import {ICONS} from '../../util/button-icons';
+import ToolTip from '../tooltip';
 import propTypes, {ButtonLinkProps, IconType} from './types';
 import style from './style.css';
-import ToolTip from '../tooltip';
 
 const getButtonContent = (
   icon?: IconType,
@@ -57,25 +57,6 @@ const getButtonContent = (
   );
 };
 
-const TooltipContent = ({ ariaLabel }: { ariaLabel: string }) => (
-  <span className={style.tooltipContentWrapper}>{ariaLabel}</span>
-);
-
-const renderToolTip = (hovered: boolean,tooltipPlacement: string, ariaLabel?: string) => {
-  if (!ariaLabel) return null;
-
-  return (
-    <ToolTip
-      fontSize={12}
-      anchorId="button-icon"
-      toolTipIsVisible={hovered}
-      placement={tooltipPlacement}
-      TooltipContent={() => <TooltipContent ariaLabel={ariaLabel} />}
-      closeToolTipInformationTextAriaLabel={ariaLabel}
-    />
-  );
-};
-
 const ButtonLink = (props: ButtonLinkProps) => {
   const {
     type,
@@ -122,6 +103,26 @@ const ButtonLink = (props: ButtonLinkProps) => {
 
   const handleMouseLeave = useCallback(() => setHovered(false), [setHovered]);
 
+  const TooltipContent = useCallback(
+    () => <span className={style.tooltipContentWrapper}>{ariaLabel}</span>,
+    [ariaLabel]
+  );
+
+  const renderToolTip = () => {
+    if (!ariaLabel) return null;
+
+    return (
+      <ToolTip
+        fontSize={12}
+        anchorId="button-icon"
+        toolTipIsVisible={hovered}
+        placement={tooltipPlacement}
+        TooltipContent={TooltipContent}
+        closeToolTipInformationTextAriaLabel={ariaLabel}
+      />
+    );
+  };
+
   const _customStyle = useMemo(() => {
     return {
       ...customStyle,
@@ -158,7 +159,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
         onMouseLeave={handleMouseLeave}
       >
         {getButtonContent(icon, content ?? label, hovered, hoverBackgroundColor, hoverColor)}
-        {renderToolTip(hovered, tooltipPlacement, ariaLabel)}
+        {renderToolTip()}
       </Link>
     );
   }
@@ -189,7 +190,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
       disabled={disabled}
     >
       {getButtonContent(icon, content ?? label, hovered, hoverBackgroundColor, hoverColor)}
-      {renderToolTip(hovered, tooltipPlacement, ariaLabel)}
+      {renderToolTip()}
     </button>
   );
 };

--- a/packages/@coorpacademy-components/src/atom/button-link/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.tsx
@@ -168,7 +168,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
   return (
     <button
       {...(useTitle && {
-        title: ariaLabel
+        title: ariaLabel || label
       })}
       {...(ariaLabel && !label
         ? {

--- a/packages/@coorpacademy-components/src/atom/button-link/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.tsx
@@ -143,12 +143,6 @@ const ButtonLink = (props: ButtonLinkProps) => {
         {...(useTitle && {
           title: ariaLabel || label
         })}
-        {...(ariaLabel && !label
-          ? {
-              'data-for': 'button-icon',
-              'data-tip': hovered
-            }
-          : {})}
         style={customStyle}
         className={styleButton}
         data-name={dataName}

--- a/packages/@coorpacademy-components/src/atom/button-link/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-link/index.tsx
@@ -70,6 +70,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
     'data-name': dataName,
     'data-testid': dataTestId = 'button-link',
     'aria-label': ariaLabel,
+    tooltipText,
     tooltipPlacement = 'left',
     link,
     onClick = noop,
@@ -104,12 +105,12 @@ const ButtonLink = (props: ButtonLinkProps) => {
   const handleMouseLeave = useCallback(() => setHovered(false), [setHovered]);
 
   const TooltipContent = useCallback(
-    () => <span className={style.tooltipContentWrapper}>{ariaLabel}</span>,
-    [ariaLabel]
+    () => <span className={style.tooltipContentWrapper}>{tooltipText || ariaLabel}</span>,
+    [tooltipText, ariaLabel]
   );
 
   const renderToolTip = () => {
-    if (!ariaLabel) return null;
+    if (!tooltipText && !ariaLabel) return null;
 
     return (
       <ToolTip
@@ -118,7 +119,7 @@ const ButtonLink = (props: ButtonLinkProps) => {
         toolTipIsVisible={hovered}
         placement={tooltipPlacement}
         TooltipContent={TooltipContent}
-        closeToolTipInformationTextAriaLabel={ariaLabel}
+        closeToolTipInformationTextAriaLabel={tooltipText || ariaLabel || ''}
       />
     );
   };

--- a/packages/@coorpacademy-components/src/atom/button-link/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-link/style.css
@@ -27,6 +27,11 @@
   user-select: none;
 }
 
+.iconButton {
+  composes: button;
+  padding: 0px 14px;
+}
+
 .disabled {
   opacity: 0.4;
   pointer-events: none;
@@ -95,4 +100,13 @@
   color: inherit;
   border-radius: 0px;
   height: auto;
+}
+
+.tooltipContentWrapper {
+  text-align: left;
+  width: max-content;
+  font-family: Gilroy;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
 }

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-icon-no-label-no-tootltip-text-no-arialabel.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-icon-no-label-no-tootltip-text-no-arialabel.ts
@@ -1,0 +1,22 @@
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
+  props: {
+    type: 'primary',
+    customStyle: {
+      width: 'fit-content',
+      backgroundColor: 'transparent'
+    },
+    hoverBackgroundColor: '#EAEAEB',
+    icon: {
+      position: 'left',
+      faIcon: {
+        name: 'edit',
+        color: '#515161',
+        size: 16
+      }
+    },
+    onClick: () => console.log('click')
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-icon-no-label-no-tootltip-text.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-icon-no-label-no-tootltip-text.ts
@@ -1,0 +1,23 @@
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
+  props: {
+    'aria-label': 'Edit',
+    type: 'primary',
+    customStyle: {
+      width: 'fit-content',
+      backgroundColor: 'transparent'
+    },
+    hoverBackgroundColor: '#EAEAEB',
+    icon: {
+      position: 'left',
+      faIcon: {
+        name: 'edit',
+        color: '#515161',
+        size: 16
+      }
+    },
+    onClick: () => console.log('click')
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-icon-no-label-no-tootltip-text.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-icon-no-label-no-tootltip-text.ts
@@ -4,6 +4,7 @@ const fixture: Fixture = {
   props: {
     'aria-label': 'Edit',
     type: 'primary',
+    useTitle: false,
     customStyle: {
       width: 'fit-content',
       backgroundColor: 'transparent'

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-icon-no-label.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-icon-no-label.ts
@@ -1,0 +1,24 @@
+import {Fixture} from '../../types';
+
+const fixture: Fixture = {
+  props: {
+    'aria-label': 'Edit',
+    tooltipText: 'Edit',
+    type: 'primary',
+    customStyle: {
+      width: 'fit-content',
+      backgroundColor: 'transparent'
+    },
+    hoverBackgroundColor: '#EAEAEB',
+    icon: {
+      position: 'left',
+      faIcon: {
+        name: 'edit',
+        color: '#515161',
+        size: 16
+      }
+    },
+    onClick: () => console.log('click')
+  }
+};
+export default fixture;

--- a/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-icon-no-label.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/test/fixtures/button-icon-no-label.ts
@@ -4,6 +4,7 @@ const fixture: Fixture = {
   props: {
     'aria-label': 'Edit',
     tooltipText: 'Edit',
+    useTitle: false,
     type: 'primary',
     customStyle: {
       width: 'fit-content',

--- a/packages/@coorpacademy-components/src/atom/button-link/types.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/types.ts
@@ -8,6 +8,7 @@ const propTypes = {
   label: PropTypes.string,
   content: PropTypes.node,
   'aria-label': PropTypes.string,
+  tooltipText: PropTypes.string,
   tooltipPlacement: PropTypes.oneOf(['left', 'right', 'top', 'bottom']),
   'data-name': PropTypes.string,
   'data-testid': PropTypes.string,
@@ -47,6 +48,7 @@ export type ButtonLinkProps = {
   label?: string;
   content?: React.ReactNode;
   'aria-label'?: string;
+  tooltipText?: string;
   tooltipPlacement?: 'left' | 'right' | 'top' | 'bottom';
   'data-name'?: string;
   'data-testid'?: string;

--- a/packages/@coorpacademy-components/src/atom/button-link/types.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/types.ts
@@ -8,6 +8,7 @@ const propTypes = {
   label: PropTypes.string,
   content: PropTypes.node,
   'aria-label': PropTypes.string,
+  tooltipPlacement: PropTypes.oneOf(['left', 'right', 'top', 'bottom']),
   'data-name': PropTypes.string,
   'data-testid': PropTypes.string,
   icon: PropTypes.shape({
@@ -46,6 +47,7 @@ export type ButtonLinkProps = {
   label?: string;
   content?: React.ReactNode;
   'aria-label'?: string;
+  tooltipPlacement: 'left' | 'right' | 'top' | 'bottom';
   'data-name'?: string;
   'data-testid'?: string;
   icon?: IconType;

--- a/packages/@coorpacademy-components/src/atom/button-link/types.ts
+++ b/packages/@coorpacademy-components/src/atom/button-link/types.ts
@@ -47,7 +47,7 @@ export type ButtonLinkProps = {
   label?: string;
   content?: React.ReactNode;
   'aria-label'?: string;
-  tooltipPlacement: 'left' | 'right' | 'top' | 'bottom';
+  tooltipPlacement?: 'left' | 'right' | 'top' | 'bottom';
   'data-name'?: string;
   'data-testid'?: string;
   icon?: IconType;

--- a/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/new-design-published-coorp-provider.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/new-design-published-coorp-provider.js
@@ -18,11 +18,13 @@ export default {
       preset: 'xl'
     },
     buttonLink: {
+      'aria-label': 'Edit',
       type: 'primary',
       customStyle: {
         width: 'fit-content',
         backgroundColor: 'transparent'
       },
+      hoverBackgroundColor: "#EAEAEB",
       icon: {
         position: 'left',
         faIcon: {

--- a/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/new-design-published-coorp-provider.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/new-design-published-coorp-provider.js
@@ -24,7 +24,7 @@ export default {
         width: 'fit-content',
         backgroundColor: 'transparent'
       },
-      hoverBackgroundColor: "#EAEAEB",
+      hoverBackgroundColor: '#EAEAEB',
       icon: {
         position: 'left',
         faIcon: {

--- a/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/translation-readonly.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/translation-readonly.js
@@ -9,7 +9,7 @@ export default {
         width: 'fit-content',
         backgroundColor: 'transparent'
       },
-      hoverBackgroundColor: "#EAEAEB",
+      hoverBackgroundColor: '#EAEAEB',
       icon: {
         position: 'left',
         faIcon: {

--- a/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/translation-readonly.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/translation-readonly.js
@@ -3,11 +3,13 @@ export default {
     id: 'default',
     title: '🇫🇷 French',
     buttonLink: {
+      'aria-label': 'See',
       type: 'primary',
       customStyle: {
         width: 'fit-content',
-        backgroundColor: '#EAEAEB'
+        backgroundColor: 'transparent'
       },
+      hoverBackgroundColor: "#EAEAEB",
       icon: {
         position: 'left',
         faIcon: {

--- a/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/translation.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/translation.js
@@ -9,7 +9,7 @@ export default {
         width: 'fit-content',
         backgroundColor: 'transparent'
       },
-      hoverBackgroundColor: "#EAEAEB",
+      hoverBackgroundColor: '#EAEAEB',
       icon: {
         position: 'left',
         faIcon: {
@@ -27,7 +27,7 @@ export default {
         width: 'fit-content',
         backgroundColor: 'transparent'
       },
-      hoverBackgroundColor: "#EAEAEB",
+      hoverBackgroundColor: '#EAEAEB',
       icon: {
         position: 'left',
         faIcon: {

--- a/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/translation.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/translation.js
@@ -3,11 +3,13 @@ export default {
     id: 'default',
     title: '🇫🇷 French',
     buttonLink: {
+      'aria-label': 'Edit',
       type: 'primary',
       customStyle: {
         width: 'fit-content',
         backgroundColor: 'transparent'
       },
+      hoverBackgroundColor: "#EAEAEB",
       icon: {
         position: 'left',
         faIcon: {
@@ -19,11 +21,13 @@ export default {
       onClick: () => console.log('click')
     },
     secondButtonLink: {
+      'aria-label': 'Delete',
       type: 'primary',
       customStyle: {
         width: 'fit-content',
         backgroundColor: 'transparent'
       },
+      hoverBackgroundColor: "#EAEAEB",
       icon: {
         position: 'left',
         faIcon: {


### PR DESCRIPTION
[ticket](https://go1web.atlassian.net/jira/software/projects/CLXP/boards/626?selectedIssue=CLXP-202)
fixed: 
add hover tooltip to button links components
fix size of buttons on hover (reduce to 14px square)
result:
https://6622682e70ecd8ecf5027fa1-dqgllstenp.chromatic.com/?path=/story/organism-listitem--translation
https://6622682e70ecd8ecf5027fa1-dqgllstenp.chromatic.com/?path=/story/organism-listitem--translation-readonly