### PR TITLE
Update babel and webpack plugin hotfixes

### DIFF
--- a/packages/@coorpacademy-components/src/variables/colors.css
+++ b/packages/@coorpacademy-components/src/variables/colors.css
@@ -30,6 +30,7 @@
 @value cm_blue_50: #f1f6fe;
 @value cm_blue_200: #74A5F6;
 @value cm_blue_600: #0051d6;
+@value cm_blue_700 #0042AD;
 @value cm_blue_900: #06265B;
 @value cm_bleu_article: #365FCD;
 @value cm_grey_50: #FAFAFA;
@@ -72,6 +73,8 @@
 @value box_shadow_light_dark: rgba(0, 0, 0, 0.12);
 @value box_shadow_medium_dark: rgba(0, 0, 0, 0.2);
 @value box_shadow_orange_700: rgba(255, 84, 31, 0.15);
+@value box_shadow_blue_700: rgba(0, 66, 173, 0.15); ;
+
 @value light_blue: #ADC9F5;
 @value negative_100: #FCDADA;
 @value go1_backgound: #144953;

--- a/packages/@coorpacademy-webpack-config/src/index.js
+++ b/packages/@coorpacademy-webpack-config/src/index.js
@@ -66,11 +66,18 @@ const createConfig = (NODE_ENV = 'development', additionalPlugins = []) => {
         {
           test: /\.css$/,
           use: [
-            isProduction ? MiniCssExtractPlugin.loader : 'style-loader',
+            isProduction
+              ? {
+                  loader: MiniCssExtractPlugin.loader,
+                  options: {defaultExport: true}
+                }
+              : 'style-loader',
             {
               loader: 'css-loader',
               options: {
+                esModule: true,
                 modules: {
+                  namedExport: true,
                   getLocalIdent
                 }
               }


### PR DESCRIPTION
## Detailed purpose of the PR

Fixes to #2922 

Address two concern:
- Bumped `mini-css-extract-plugin` need config changes to support the import default we mainly use to import the css
- Webpack was complaining about two missing variables `cm_blue_700` and `box_shadow_blue_700 `


:link: https://app.travis-ci.com/github/CoorpAcademy/coorpacademy/jobs/630559152#L947

![Capture d’écran 2025-02-13 à 16 24 51](https://github.com/user-attachments/assets/0c6abe05-942e-4dc8-8f39-8b39363bb96c)
![Capture d’écran 2025-02-13 à 16 26 47](https://github.com/user-attachments/assets/1dece298-49b7-47c1-bd57-76911c6aeff2)
