### PR TITLE
Introduce a webpack option esModule to support no modules 

### DIFF
--- a/packages/@coorpacademy-webpack-config/src/index.js
+++ b/packages/@coorpacademy-webpack-config/src/index.js
@@ -11,7 +11,7 @@ export const getLocalIdent = (context, localIdentName, localName) => {
   return `${localName}-${hash.digest('base64').slice(0, 5)}`;
 };
 
-const createConfig = (NODE_ENV = 'development', additionalPlugins = []) => {
+const createConfig = (NODE_ENV = 'development', {additionalPlugins = [], esModule = true} = {}) => {
   const isProduction = NODE_ENV === 'production';
   return {
     mode: isProduction ? 'production' : 'development',
@@ -75,9 +75,9 @@ const createConfig = (NODE_ENV = 'development', additionalPlugins = []) => {
             {
               loader: 'css-loader',
               options: {
-                esModule: true,
+                esModule,
                 modules: {
-                  namedExport: true,
+                  namedExport: esModule,
                   getLocalIdent
                 }
               }

--- a/packages/@coorpacademy-webpack-config/src/test/index.js
+++ b/packages/@coorpacademy-webpack-config/src/test/index.js
@@ -31,6 +31,9 @@ test('should include lodash babel plugin by default', t => {
 test('should be validate by webpack schema', t => {
   t.notThrows(() => webpack.validate(generateConfig('development')));
   t.notThrows(() => webpack.validate(generateConfig('production')));
+  t.notThrows(() => webpack.validate(generateConfig('development'), {esModules: true}));
+  t.notThrows(() => webpack.validate(generateConfig('development'), {esModules: false}));
+  t.notThrows(() => webpack.validate(generateConfig('development'), {additionalPlugins: []}));
 });
 
 test('should hash className', t => {


### PR DESCRIPTION
## Detailed purpose of the PR

This tweak is necessary as current webpack version (from #2922+#2923) does not work on the LXP, not using esModules

To have a more self documented interface, rework the optional argument to an optional option object.
Would need to update existing implementation provide additionalPlugins (notably cm)