### PR TITLE
Tweak access to style kebab cased classname

### DIFF
--- a/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/index.tsx
@@ -26,7 +26,7 @@ const BattleOpponent = (
 ) => {
   const translate: Required<WebContextValues>['translate'] = GetTranslateFromContext(legacyContext);
   const wrapperClassnames = useMemo(
-    () => classnames(style.card, style['opponent-card'], isRandom ? style.random : null),
+    () => classnames(style.card, style.opponentCard, isRandom ? style.random : null),
     [isRandom]
   );
 

--- a/packages/@coorpacademy-components/src/atom/battle-opponent/style.css
+++ b/packages/@coorpacademy-components/src/atom/battle-opponent/style.css
@@ -23,7 +23,7 @@
   margin: 5px;
 }
 
-.opponent-card {
+.opponentCard {
   flex: 1 1 350px;
   height: 80px;
   background-color: white;
@@ -37,7 +37,7 @@
   cursor: pointer;
 }
 
-.opponent-card .name {
+.opponentCard .name {
   font-family: 'Gilroy';
   font-size: 15px;
   font-weight: 700;
@@ -46,7 +46,7 @@
 }
 
 
-.opponent-card .rightArrow {
+.opponentCard .rightArrow {
   margin-left: 20px;
 }
 
@@ -95,7 +95,7 @@
   display: none;
 }
 
-.opponent-card:hover {
+.opponentCard:hover {
   background-color: cm_grey_75;
 }
 
@@ -125,16 +125,16 @@
 }
 
 @media mobile {
-  .opponent-card {
+  .opponentCard {
     width: 100%;
     padding: 10px;
   }
 
-  .opponent-card .avatar {
+  .opponentCard .avatar {
     margin-right: 10px;
   }
 
-  .opponent-card .rightArrow {
+  .opponentCard .rightArrow {
     margin-left: 10px;
   }
 


### PR DESCRIPTION
### Detailed purpose of the PR

#2922 seems to have unintended side effect on case conversion, removing dual kebab/camel case access.
As a result, convert all `style[kebab-class-name]` to style.camelClassName (which seems to only concern one component)


cf original e2E test (https://app.travis-ci.com/github/CoorpAcademy/coorpacademy/jobs/630949028#L2365), reproduced locally:
![Capture d’écran 2025-02-27 à 18 02 53](https://github.com/user-attachments/assets/da4365f2-67a7-407c-b092-151e7adbe376)
