### PR TITLE
Add locales

### DIFF
--- a/packages/@coorpacademy-components/locales/bs/global.json
+++ b/packages/@coorpacademy-components/locales/bs/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "fokusirane vještine",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Ocijenite ovaj kurs"
+      "comment_aria_label": "Ocijenite ovaj kurs",
+      "diploma": "Validirani put"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Nagrada"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certificate"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/cs/global.json
+++ b/packages/@coorpacademy-components/locales/cs/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "zaměřených dovedností",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Ohodnoťte tento kurz"
+      "comment_aria_label": "Ohodnoťte tento kurz",
+      "diploma": "Ověřená cesta"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Cena"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certifikát"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/de/global.json
+++ b/packages/@coorpacademy-components/locales/de/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "fokussierte Fähigkeiten\n",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Bewerten Sie diesen Kurs"
+      "comment_aria_label": "Bewerten Sie diesen Kurs",
+      "diploma": "Validierter Weg"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Award"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Zertifikat"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "focused skills",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Rate this course"
+      "comment_aria_label": "Rate this course",
+      "diploma": "Validated pathway"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "givaudan": {
+      "diploma": "Award"
+    },
+    "learning-lab": {
+      "diploma": "Certificat"
+    },
+    "onboarding": {
+      "diploma": "Certificat"
+    },
+    "mylcl-learning": {
+       "diploma": "learning path"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/es/global.json
+++ b/packages/@coorpacademy-components/locales/es/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "habilidades interesadas",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Califica este curso"
+      "comment_aria_label": "Califica este curso",
+      "diploma": "Vía validada"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Award"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certificado"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/et/global.json
+++ b/packages/@coorpacademy-components/locales/et/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "fookusoskused",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Hinda seda kursust"
+      "comment_aria_label": "Hinda seda kursust",
+      "diploma": "Valideeritud rada"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Auhind"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Tunnistus"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/fi/global.json
+++ b/packages/@coorpacademy-components/locales/fi/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "osaamisen painopisteet",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Arvioi tämä kurssi"
+      "comment_aria_label": "Arvioi tämä kurssi",
+      "diploma": "Vahvistettu reitti"
+    },
+    "ehc-vd": {
+      "diploma": "todistus"
+    },
+    "esante-formation": {
+      "diploma": "Oppimispolku"
+    },
+    "givaudan": {
+      "diploma": "Diplomi"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "oppimispolku"
+    },
+    "onboarding": {
+      "diploma": "Todistus"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/fr/global.json
+++ b/packages/@coorpacademy-components/locales/fr/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "compétences ciblées",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Notez ce cours"
+      "comment_aria_label": "Notez ce cours",
+      "diploma": "Parcours validé"
+    },
+    "esante-formation": {
+      "diploma": "Attestation"
+    },
+    "ehc-vd": {
+      "diploma": "attestation"
+    },
+    "givaudan": {
+      "diploma": "Award"
+    },
+    "learning-lab": {
+      "diploma": "Certificat"
+    },
+    "onboarding": {
+      "diploma": "Certificat"
+    },
+    "mylcl-learning": {
+       "diploma": "parcours"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/hr/global.json
+++ b/packages/@coorpacademy-components/locales/hr/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "fokusirane vještine",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Ocijenite ovaj tečaj"
+      "comment_aria_label": "Ocijenite ovaj tečaj",
+      "diploma": "Validirani put"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Dodijeliti"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Potvrda"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/hu/global.json
+++ b/packages/@coorpacademy-components/locales/hu/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "célzott képességek",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Értékelje ezt a tanfolyamot"
+      "comment_aria_label": "Értékelje ezt a tanfolyamot",
+      "diploma": "Ellenőrzött útvonal"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Díj"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Bizonyítvány"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/hy/global.json
+++ b/packages/@coorpacademy-components/locales/hy/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "կենտրոնացված հմտություններ",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Գնահատեք այս դասընթացը"
+      "comment_aria_label": "Գնահատեք այս դասընթացը",
+      "diploma": "Վավերացված ուղի"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Մրցանակ"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certificate"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/it/global.json
+++ b/packages/@coorpacademy-components/locales/it/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "competenze messe a fuoco",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Vota questo corso"
+      "comment_aria_label": "Vota questo corso",
+      "diploma": "Percorso convalidato"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Award"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certificato"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/ja/global.json
+++ b/packages/@coorpacademy-components/locales/ja/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "フォーカスしたスキル",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "このコースを評価する"
+      "comment_aria_label": "このコースを評価する",
+      "diploma": "検証済みの経路"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "アワード"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "証明書"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/ko/global.json
+++ b/packages/@coorpacademy-components/locales/ko/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "집중한 기술",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "이 강좌를 평가해 주세요"
+      "comment_aria_label": "이 강좌를 평가해 주세요",
+      "diploma": "검증된 경로"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "상"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "인증서"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/nl/global.json
+++ b/packages/@coorpacademy-components/locales/nl/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "gefocuste vaardigheden",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Beoordeel deze cursus"
+      "comment_aria_label": "Beoordeel deze cursus",
+      "diploma": "Gevalideerd traject"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Prijs"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certificaat"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/pl/global.json
+++ b/packages/@coorpacademy-components/locales/pl/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "wybrane umiejętności",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Oceń ten kurs"
+      "comment_aria_label": "Oceń ten kurs",
+      "diploma": "Sprawdzona ścieżka"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Award"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certyfikat"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/pt/global.json
+++ b/packages/@coorpacademy-components/locales/pt/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "competências com foco",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Avalie este curso"
+      "comment_aria_label": "Avalie este curso",
+      "diploma": "Caminho validado"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Award"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certificado"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/ro/global.json
+++ b/packages/@coorpacademy-components/locales/ro/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "abilități focalizate",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Evaluează acest curs"
+      "comment_aria_label": "Evaluează acest curs",
+      "diploma": "Calea validată"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Adjudecare"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certificat"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/ru/global.json
+++ b/packages/@coorpacademy-components/locales/ru/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "выбранные навыки",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Оцените этот курс"
+      "comment_aria_label": "Оцените этот курс",
+      "diploma": "Проверенный путь"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Награда"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Сертификат"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/sk/global.json
+++ b/packages/@coorpacademy-components/locales/sk/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "zručnosti, na ktoré sa zameriavate",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Ohodnoťte tento kurz"
+      "comment_aria_label": "Ohodnoťte tento kurz",
+      "diploma": "Overená cesta"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "givaudan": {
+      "diploma": "Cena"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certifikát"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/sl/global.json
+++ b/packages/@coorpacademy-components/locales/sl/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "osredotočene veščine",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Ocenite ta tečaj"
+      "comment_aria_label": "Ocenite ta tečaj",
+      "diploma": "Potrjena pot"
+    },
+    "ehc-vd": {
+      "diploma": "potrdilo"
+    },
+    "esante-formation": {
+      "diploma": "Učna pot"
+    },
+    "givaudan": {
+      "diploma": "Nagrada"
+    },
+    "learning-lab": {
+      "diploma": "Certifikat"
+    },
+    "mylcl-learning": {
+      "diploma": "learning path"
+    },
+    "onboarding": {
+      "diploma": "Certifikat"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/sv/global.json
+++ b/packages/@coorpacademy-components/locales/sv/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "färdighet i fokus",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Betygsätt denna kurs"
+      "comment_aria_label": "Betygsätt denna kurs",
+      "diploma": "Validerad väg"
+    },
+    "ehc-vd": {
+      "diploma": "certifikat"
+    },
+    "esante-formation": {
+      "diploma": "Inlärningsväg"
+    },
+    "givaudan": {
+      "diploma": "Utmärkelse"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+      "diploma": "inlärningsväg"
+    },
+    "onboarding": {
+      "diploma": "Certifikat"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/th/global.json
+++ b/packages/@coorpacademy-components/locales/th/global.json
@@ -94,5 +94,29 @@
   "close_button_ariaLabel": "ปิดสไลด์รีวิว",
   "post_comment_aria_label": "โพสต์ความคิดเห็นของคุณ",
   "validate_aria_label": "ตรวจสอบคำตอบของคุณแล้วไปยังขั้นตอนถัดไป",
-  "stars": "ดาว"
+  "stars": "ดาว",
+  "custom":{
+    "digitlearning": {
+      "comment_aria_label": "Rate this course",
+      "diploma": "Validated pathway"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "givaudan": {
+      "diploma": "Award"
+    },
+    "learning-lab": {
+      "diploma": "Certificat"
+    },
+    "onboarding": {
+      "diploma": "Certificat"
+    },
+    "mylcl-learning": {
+       "diploma": "learning path"
+    }
+  }
 }

--- a/packages/@coorpacademy-components/locales/tl/global.json
+++ b/packages/@coorpacademy-components/locales/tl/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "mga kasanayang pinagtuunan ng pansin",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "I-rate ang kursong ito"
+      "comment_aria_label": "I-rate ang kursong ito",
+      "diploma": "Napatunayang landas"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "givaudan": {
+      "diploma": "parangal"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "onboarding": {
+      "diploma": "Sertipiko"
+    },
+    "mylcl-learning": {
+       "diploma": "learning path"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/tr/global.json
+++ b/packages/@coorpacademy-components/locales/tr/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "odaklanan beceriler",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Bu kursu değerlendirin"
+      "comment_aria_label": "Bu kursu değerlendirin",
+      "diploma": "Doğrulanmış yol"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "givaudan": {
+      "diploma": "Ödül"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "onboarding": {
+      "diploma": "Sertifika"
+    },
+    "mylcl-learning": {
+       "diploma": "learning path"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/uk/global.json
+++ b/packages/@coorpacademy-components/locales/uk/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "навички розвитку",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Оцініть цей курс"
+      "comment_aria_label": "Оцініть цей курс",
+      "diploma": "Перевірений шлях"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "givaudan": {
+      "diploma": "Нагорода"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "onboarding": {
+      "diploma": "Сертифікат"
+    },
+    "mylcl-learning": {
+       "diploma": "learning path"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/vi/global.json
+++ b/packages/@coorpacademy-components/locales/vi/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "kỹ năng được chú trọng",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "Đánh giá khóa học này"
+      "comment_aria_label": "Đánh giá khóa học này",
+      "diploma": "Lộ trình đã được xác thực"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "givaudan": {
+      "diploma": "Phần thưởng"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "onboarding": {
+      "diploma": "Chứng chỉ"
+    },
+    "mylcl-learning": {
+       "diploma": "learning path"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/zh/global.json
+++ b/packages/@coorpacademy-components/locales/zh/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "已重点关注的技能",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "评价此课程"
+      "comment_aria_label": "评价此课程",
+      "diploma": "经过验证的途径"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "givaudan": {
+      "diploma": "奖"
+    },
+    "learning-lab": {
+      "diploma": "Certificate"
+    },
+    "onboarding": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+       "diploma": "learning path"
     }
   }
 }

--- a/packages/@coorpacademy-components/locales/zh_TW/global.json
+++ b/packages/@coorpacademy-components/locales/zh_TW/global.json
@@ -180,7 +180,26 @@
   "focused_skills": "聚焦技能",
   "custom":{
     "digitlearning": {
-      "comment_aria_label": "評量本課程"
+      "comment_aria_label": "評量本課程",
+      "diploma": "驗證途徑"
+    },
+    "esante-formation": {
+      "diploma": "Learning path"
+    },
+    "ehc-vd": {
+      "diploma": "certificate"
+    },
+    "givaudan": {
+      "diploma": "獎"
+    },
+    "learning-lab": {
+      "diploma": "證書"
+    },
+    "onboarding": {
+      "diploma": "Certificate"
+    },
+    "mylcl-learning": {
+       "diploma": "learning path"
     }
   }
 }


### PR DESCRIPTION
[IDEA 6107 - Esante-formation - modification wording sur la page Certification](https://app.prodpad.com/ideas/6107/canvas)
Hello,
Le client a remplacé le mot "Diplôme" par "Attestation". Pouvez-vous svp rectifier la trad sur la page dans les détails des certificats ? 
https://ans-formation.coorpacademy.com/certifications

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
