### PR TITLE
Fx default named class in bumbed babel/webpack config

### DIFF
--- a/packages/@coorpacademy-components/src/atom/autocomplete/index.js
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/index.js
@@ -12,7 +12,7 @@ import style from './style.css';
 
 const THEME_STYLE = {
   coorpmanager: style.coorpmanager,
-  default: style.default
+  default: style.defaultStyle
 };
 
 const renderSuggestion = suggestion => <span>{suggestion.name}</span>;
@@ -39,7 +39,7 @@ const Autocomplete = props => {
   const mainClass = THEME_STYLE[theme];
   const title = useMemo(() => `${propsTitle}${required ? '*' : ''}`, [propsTitle, required]);
   const className = useMemo(
-    () => getClassState(style.default, style.modified, style.error, modified, error),
+    () => getClassState(style.defaultStyle, style.modified, style.error, modified, error),
     [modified, error]
   );
 

--- a/packages/@coorpacademy-components/src/atom/autocomplete/style.css
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/style.css
@@ -13,14 +13,14 @@
 @value cm_grey_500 from colors;
 @value cm_grey_700 from colors;
 
-.default {
+.defaultStyle {
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
     align-content: center;
 }
 
-.default label {
+.defaultStyle label {
     display: flex;
     align-items: center;
     height: 50px;

--- a/packages/@coorpacademy-components/src/atom/autocomplete/style.css
+++ b/packages/@coorpacademy-components/src/atom/autocomplete/style.css
@@ -30,11 +30,11 @@
 }
 
 .error {
-    composes: default;
+    composes: defaultStyle;
 }
 
 .modified {
-    composes: default;
+    composes: defaultStyle;
 }
 
 .title {

--- a/packages/@coorpacademy-components/src/atom/button-link-icon/index.js
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon/index.js
@@ -30,7 +30,7 @@ const getSizeStyle = size => {
     case 'responsive':
       return style.responsive;
     default:
-      return style.default;
+      return style.defaultStyle;
   }
 };
 

--- a/packages/@coorpacademy-components/src/atom/button-link-icon/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-link-icon/style.css
@@ -42,7 +42,7 @@
   text-decoration: none;
 }
 
-.default {
+.defaultStyle {
   composes: button;
   width: 44px;
   height: 44px;
@@ -91,7 +91,7 @@
   }
 }
 
-.default .icon {
+.defaultStyle .icon {
   width: 14px;
   height: 14px;
 }

--- a/packages/@coorpacademy-components/src/atom/button-menu/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-menu/index.tsx
@@ -8,7 +8,7 @@ const Button = (props: ButtonProps) => {
   const {'data-name': dataName, disabled, label, onClick, type = 'default'} = props;
   const styleButton = classnames(
     style.button,
-    type === 'default' && style.default,
+    type === 'default' && style.defaultStyle,
     type === 'defaultLeft' && style.defaultLeft,
     type === 'dangerous' && style.dangerous,
     type === 'dangerousLeft' && style.dangerousLeft,

--- a/packages/@coorpacademy-components/src/atom/button-menu/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-menu/style.css
@@ -42,7 +42,7 @@
 }
 
 .defaultLeft {
-  composes: default;
+  composes: defaultStyle;
   justify-content: flex-start;
 }
 
@@ -51,7 +51,7 @@
 }
 
 .dangerous {
-  composes: default;
+  composes: defaultStyle;
   color: cm_negative_100;
 }
 

--- a/packages/@coorpacademy-components/src/atom/button-menu/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-menu/style.css
@@ -36,7 +36,7 @@
   display: block;
 }
 
-.default {
+.defaultStyle {
   background-color: cm_grey_100;
   color: cm_grey_900;
 }
@@ -46,7 +46,7 @@
   justify-content: flex-start;
 }
 
-.default:hover {
+.defaultStyle:hover {
   background-color: cm_grey_200;
 }
 

--- a/packages/@coorpacademy-components/src/atom/input-checkbox/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-checkbox/index.js
@@ -35,7 +35,8 @@ const InputCheckbox = props => {
   const modifiedClassName =
     theme === 'coorpmanager' ? style.coorpManagerModified : style.defaultModified;
   const errorClassName = theme === 'coorpmanager' ? style.coorpManagerError : style.defaultError;
-  const defaultContainerClassName = theme === 'coorpmanager' ? style.coorpManager : style.defaultStyle;
+  const defaultContainerClassName =
+    theme === 'coorpmanager' ? style.coorpManager : style.defaultStyle;
 
   const className = getClassState(
     defaultContainerClassName,

--- a/packages/@coorpacademy-components/src/atom/input-checkbox/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-checkbox/index.js
@@ -35,7 +35,7 @@ const InputCheckbox = props => {
   const modifiedClassName =
     theme === 'coorpmanager' ? style.coorpManagerModified : style.defaultModified;
   const errorClassName = theme === 'coorpmanager' ? style.coorpManagerError : style.defaultError;
-  const defaultContainerClassName = theme === 'coorpmanager' ? style.coorpManager : style.default;
+  const defaultContainerClassName = theme === 'coorpmanager' ? style.coorpManager : style.defaultStyle;
 
   const className = getClassState(
     defaultContainerClassName,

--- a/packages/@coorpacademy-components/src/atom/input-checkbox/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-checkbox/style.css
@@ -16,7 +16,7 @@
 @value cm_green_50 from colors;
 @value cm_primary_blue from colors;
 
-.default {
+.defaultStyle {
   display: flex;
   flex-direction: row-reverse;
   justify-content: flex-end;
@@ -43,7 +43,7 @@
   composes: default;
 }
 
-.default input,
+.defaultStyle input,
 .coorpManager input {
   display: none;
 }
@@ -55,7 +55,7 @@
   color: white;
 }
 
-.default .title {
+.defaultStyle .title {
   font-family: Gilroy;
   font-size: 15px;
   text-transform: none;
@@ -63,9 +63,9 @@
   width: 180px;
 }
 
-.default .tertiary,
-.default .primary,
-.default .secondary {
+.defaultStyle .tertiary,
+.defaultStyle .primary,
+.defaultStyle .secondary {
   color: dark;
   background-color: unset;
 }
@@ -97,7 +97,7 @@
   background-color: cm_blue_50;
 }
 
-.default .label,
+.defaultStyle .label,
 .coorpManager .label {
   border: solid 1px cm_grey_200;
   background-color: cm_grey_100;
@@ -113,7 +113,7 @@
   position: relative;
 }
 
-.default .label {
+.defaultStyle .label {
   margin-left: 20px;
 }
 
@@ -144,7 +144,7 @@
   outline: 2px solid battle;
 }
 
-.default .inherit,
+.defaultStyle .inherit,
 .coorpManager .inherit {
   color: inherit;
   text-overflow: ellipsis;
@@ -154,7 +154,7 @@
 }
 
 .coorpManager .noLabelMargins,
-.default .noLabelMargins {
+.defaultStyle .noLabelMargins {
   margin-right: 0;
   margin-left: 0;
 }

--- a/packages/@coorpacademy-components/src/atom/input-checkbox/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-checkbox/style.css
@@ -36,11 +36,11 @@
 }
 
 .defaultError {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .defaultModified {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .defaultStyle input,

--- a/packages/@coorpacademy-components/src/atom/input-color/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-color/index.js
@@ -21,7 +21,7 @@ const InputColor = props => {
     backgroundColor: value
   };
   const handleChange = useMemo(() => e => onChange(e.target.value), [onChange]);
-  const className = getClassState(style.default, style.modified, style.error, modified, error);
+  const className = getClassState(style.defaultStyle, style.modified, style.error, modified, error);
 
   return (
     <div className={className}>

--- a/packages/@coorpacademy-components/src/atom/input-color/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-color/style.css
@@ -11,12 +11,12 @@
 
 .error {
   composes: error from '../input-text/style.css';
-  composes: default;
+  composes: defaultStyle;
 }
 
 .modified {
   composes: modified from '../input-text/style.css';
-  composes: default;
+  composes: defaultStyle;
 }
 
 .title {

--- a/packages/@coorpacademy-components/src/atom/input-color/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-color/style.css
@@ -1,7 +1,7 @@
 @value colors: "../../variables/colors.css";
 @value grey from colors;
 
-.default {
+.defaultStyle {
   composes: default from '../input-text/style.css';
 }
 

--- a/packages/@coorpacademy-components/src/atom/input-html/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-html/index.js
@@ -36,7 +36,7 @@ const InputHtml = (props, legacyContext) => {
 
   const {title, placeholder, error, description, disabled} = props;
 
-  const className = error ? style.error : style.default;
+  const className = error ? style.error : style.defaultStyle;
   const iconContent = !preview ? (
     <PreviewIcon style={{color: mediumColor}} height={16} />
   ) : (

--- a/packages/@coorpacademy-components/src/atom/input-html/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-html/style.css
@@ -4,7 +4,7 @@
 @value light from colors;
 @value negative from colors;
 
-.default {
+.defaultStyle {
   display: flex;
 }
 
@@ -12,7 +12,7 @@
   composes: default;
 }
 
-.default label {
+.defaultStyle label {
   display: flex;
   align-items: center;
   position: relative;

--- a/packages/@coorpacademy-components/src/atom/input-html/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-html/style.css
@@ -9,7 +9,7 @@
 }
 
 .error {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .defaultStyle label {

--- a/packages/@coorpacademy-components/src/atom/input-switch/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-switch/index.js
@@ -50,7 +50,7 @@ const InputSwitch = props => {
           modifiedClass: style.coorpmanagerModified
         };
       default:
-        return {defaultClass: style.default, modifiedClass: style.modified};
+        return {defaultClass: style.defaultStyle, modifiedClass: style.modified};
     }
   };
   const {defaultClass, modifiedClass} = getClass();

--- a/packages/@coorpacademy-components/src/atom/input-switch/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-switch/style.css
@@ -10,7 +10,7 @@
 @value cm_primary_blue from colors;
 @value light_blue from colors;
 
-.default {
+.defaultStyle {
   display: flex;
 }
 
@@ -30,7 +30,7 @@
   composes: coorpmanager;
 }
 
-.default label {
+.defaultStyle label {
   height: 24px;
   position: relative;
   flex-grow: 0;
@@ -42,7 +42,7 @@
   transition: all 0.3s ease;
 }
 
-.default label::after {
+.defaultStyle label::after {
   position: absolute;
   left: 2px;
   top: 2px;
@@ -82,7 +82,7 @@
   background: positive;
 }
 
-.default input:checked ~ label::after {
+.defaultStyle input:checked ~ label::after {
   left: 30px;
 }
 

--- a/packages/@coorpacademy-components/src/atom/input-switch/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-switch/style.css
@@ -15,11 +15,11 @@
 }
 
 .modified {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .coorpmanager {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .coorpmanagerModified {

--- a/packages/@coorpacademy-components/src/atom/input-text/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-text/index.js
@@ -14,7 +14,7 @@ const themeStyle = {
   setup: style.setup,
   coorpmanager: style.coorpmanager,
   cockpit: style.cockpit,
-  default: style.default
+  default: style.defaultStyle
 };
 const InputText = props => {
   const {
@@ -39,7 +39,7 @@ const InputText = props => {
   const isCMTheme = theme === 'coorpmanager';
   const handleChange = useMemo(() => e => onChange(e.target.value), [onChange]);
   const mainClass = themeStyle[theme];
-  const className = getClassState(style.default, style.modified, style.error, modified, error);
+  const className = getClassState(style.defaultStyle, style.modified, style.error, modified, error);
   const descriptionView =
     description && theme !== 'coorpmanager' ? (
       <div className={style.description}>{description}</div>

--- a/packages/@coorpacademy-components/src/atom/input-text/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-text/style.css
@@ -23,11 +23,11 @@
 }
 
 .error {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .modified {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .setup {

--- a/packages/@coorpacademy-components/src/atom/input-text/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-text/style.css
@@ -15,7 +15,7 @@
 @value cm_grey_500 from colors;
 @value cm_grey_700 from colors;
 
-.default {
+.defaultStyle {
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
@@ -120,7 +120,7 @@
   align-self: flex-start;
   padding-left: 13px;
 }
-.default label {
+.defaultStyle label {
   display: flex;
   align-items: center;
   height: 50px;

--- a/packages/@coorpacademy-components/src/atom/input-textarea/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-textarea/index.js
@@ -14,7 +14,7 @@ const themeStyle = {
   setup: style.setup,
   coorpmanager: style.coorpmanager,
   cockpit: style.cockpit,
-  default: style.default
+  default: style.defaultStyle
 };
 const InputTextarea = props => {
   const {
@@ -33,7 +33,7 @@ const InputTextarea = props => {
   } = props;
 
   const mainClass = themeStyle[theme];
-  const className = getClassState(style.default, style.modified, style.error, modified, error);
+  const className = getClassState(style.defaultStyle, style.modified, style.error, modified, error);
   const handleChange = useMemo(() => e => onChange(e.target.value), [onChange]);
 
   const descriptionView =

--- a/packages/@coorpacademy-components/src/atom/input-textarea/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-textarea/style.css
@@ -13,7 +13,7 @@
 @value cm_grey_500 from colors;
 @value cm_grey_700 from colors;
 
-.default {
+.defaultStyle {
   display: flex;
 }
 
@@ -25,7 +25,7 @@
   composes: default;
 }
 
-.default label {
+.defaultStyle label {
   display: flex;
   align-items: center;
   height: 130px;
@@ -42,7 +42,7 @@
   width: 180px;
 }
 
-.default textarea {
+.defaultStyle textarea {
   font-family: "Gilroy";
   text-transform: none;
   padding: 10px 15px;

--- a/packages/@coorpacademy-components/src/atom/input-textarea/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-textarea/style.css
@@ -18,11 +18,11 @@
 }
 
 .error {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .modified {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .defaultStyle label {

--- a/packages/@coorpacademy-components/src/atom/label/index.js
+++ b/packages/@coorpacademy-components/src/atom/label/index.js
@@ -6,7 +6,7 @@ import style from './style.css';
 
 const Label = ({children, innerHtml = false}) => {
   return (
-    <span className={classnames(style.default, innerHtml ? style.innerHTML : null)}>
+    <span className={classnames(style.defaultStyle, innerHtml ? style.innerHTML : null)}>
       {children}
     </span>
   );

--- a/packages/@coorpacademy-components/src/atom/label/style.css
+++ b/packages/@coorpacademy-components/src/atom/label/style.css
@@ -1,7 +1,7 @@
 @value colors: "../../variables/colors.css";
 @value black from colors;
 
-.default {
+.defaultStyle {
   color: black;
 }
 

--- a/packages/@coorpacademy-components/src/atom/life/index.js
+++ b/packages/@coorpacademy-components/src/atom/life/index.js
@@ -11,7 +11,7 @@ import Provider from '../provider';
 import cssStyle from './style.css';
 
 const MODES = {
-  default: cssStyle.default,
+  default: cssStyle.defaultStyle,
   small: cssStyle.small
 };
 

--- a/packages/@coorpacademy-components/src/atom/life/style.css
+++ b/packages/@coorpacademy-components/src/atom/life/style.css
@@ -7,7 +7,7 @@
  * Default
  */
 
-.default {
+.defaultStyle {
   position: relative;
   width: 90px;
   height: 67px;

--- a/packages/@coorpacademy-components/src/atom/picture-background/index.js
+++ b/packages/@coorpacademy-components/src/atom/picture-background/index.js
@@ -25,7 +25,7 @@ const PictureBackground = props => {
       </div>
     </div>
   ) : (
-    <img className={classnames(cssStyle.default, bgStyle)} src={src} alt={alt} />
+    <img className={classnames(cssStyle.defaultStyle, bgStyle)} src={src} alt={alt} />
   );
 
   return (

--- a/packages/@coorpacademy-components/src/atom/picture-background/style.css
+++ b/packages/@coorpacademy-components/src/atom/picture-background/style.css
@@ -11,7 +11,7 @@
 }
 
 .picture,
-.default {
+.defaultStyle {
   display: block;
   background-repeat: no-repeat;
   background-position: 50% 50%;

--- a/packages/@coorpacademy-components/src/atom/range/handle.css
+++ b/packages/@coorpacademy-components/src/atom/range/handle.css
@@ -16,7 +16,7 @@
   overflow: visible;
 }
 
-.default {
+.defaultStyle {
   border-radius: 100%;
   border: 4px solid white;
   box-sizing: border-box;

--- a/packages/@coorpacademy-components/src/atom/range/handle.js
+++ b/packages/@coorpacademy-components/src/atom/range/handle.js
@@ -61,7 +61,7 @@ const Handle = (props, legacyContext) => {
           backgroundColor,
           boxShadow: `0px 0px 20px ${getShadowBoxColorFromPrimary(primaryColor)}`
         }}
-        className={style.default}
+        className={style.defaultStyle}
         ref={handle}
         data-name={'handle'}
       />

--- a/packages/@coorpacademy-components/src/atom/select-icon/index.js
+++ b/packages/@coorpacademy-components/src/atom/select-icon/index.js
@@ -52,7 +52,7 @@ const SelectIcon = props => {
   const {isSelected = false} = options;
 
   const contentView = getButtonContent(faIcon, options);
-  const styleButton = classnames(style.default, isSelected && style.selected);
+  const styleButton = classnames(style.defaultStyle, isSelected && style.selected);
   const handleOnClick = useCallback(() => onClick(), [onClick]);
 
   const IconButton = useCallback(

--- a/packages/@coorpacademy-components/src/atom/select-icon/style.css
+++ b/packages/@coorpacademy-components/src/atom/select-icon/style.css
@@ -36,7 +36,7 @@
   color: cm_grey_500;
 }
 
-.default {
+.defaultStyle {
   composes: button;
   width: 144px;
   height: 120px;

--- a/packages/@coorpacademy-components/src/atom/select/index.js
+++ b/packages/@coorpacademy-components/src/atom/select/index.js
@@ -154,7 +154,7 @@ const Select = (props, legacyContext) => {
   const arrowColor = selected ? color : undefined;
 
   const behaviorClassName = useMemo(
-    () => getClassState(style.default, style.modified, style.error, modified, error),
+    () => getClassState(style.defaultStyle, style.modified, style.error, modified, error),
     [error, modified]
   );
   const composedClassName = useMemo(

--- a/packages/@coorpacademy-components/src/atom/select/style.css
+++ b/packages/@coorpacademy-components/src/atom/select/style.css
@@ -17,7 +17,7 @@
 @value cm_blue_900 from colors;
 @value cm_grey_450 from colors;
 
-.default {
+.defaultStyle {
   display: flex;
 }
 
@@ -62,7 +62,7 @@ div.coorpmanager label.selectWrapper {
   position: relative;
 }
 
-.default .selectWrapper {
+.defaultStyle .selectWrapper {
   display: flex;
   align-items: center;
   height: 50px;
@@ -94,7 +94,7 @@ div.coorpmanager label.selectWrapper {
   text-overflow: ellipsis;
 }
 
-.default .selectBox {
+.defaultStyle .selectBox {
   font-family: "Gilroy";
   text-transform: none;
   padding: 0 15px;
@@ -155,7 +155,7 @@ div.coorpmanager label.selectWrapper {
   margin: auto 0;
 }
 
-.default select:focus::-ms-value {
+.defaultStyle select:focus::-ms-value {
   background-color: transparent;  /* make the select background transparent in ie */
   color: dark;
 }
@@ -194,7 +194,7 @@ div.coorpmanager label.selectWrapper {
   }
 }
 
-.default .selectBox[multiple] {
+.defaultStyle .selectBox[multiple] {
   padding: 0;
   height: 80px;
 }
@@ -278,7 +278,7 @@ div.coorpmanager label.selectWrapper {
   box-sizing: border-box;
 }
 
-div.default label.selectWrapper span.longLabel {
+div.defaultStyle label.selectWrapper span.longLabel {
     min-width: 230px;
     max-width: 280px;
     white-space: pre-wrap;
@@ -367,7 +367,7 @@ div.player:hover span.selectSpan {
     height: 100%;
   }
 
-  .player.default .selectBox {
+  .player.defaultStyle .selectBox {
     position: absolute;
     top: 0px;
     left: 0px;
@@ -552,7 +552,7 @@ div.player:hover span.selectSpan {
   margin-left: 0;
 }
 
-.default .selectWrapper select.selectBox {
+.defaultStyle .selectWrapper select.selectBox {
   width: inherit;
   border-radius: 8px;
   padding: 0;

--- a/packages/@coorpacademy-components/src/atom/select/style.css
+++ b/packages/@coorpacademy-components/src/atom/select/style.css
@@ -22,7 +22,7 @@
 }
 
 .coorpmanager {
-  composes: default;
+  composes: defaultStyle;
 }
 
 div.coorpmanager label.selectWrapper {
@@ -51,11 +51,11 @@ div.coorpmanager label.selectWrapper {
   }
 }
 .error {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .modified {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .selectWrapper {
@@ -257,7 +257,7 @@ div.coorpmanager label.selectWrapper {
 */
 
 .no-label {
-  composes: default;
+  composes: defaultStyle;
   position: relative;
 }
 
@@ -407,7 +407,7 @@ div.player:hover span.selectSpan {
 */
 
 .mooc {
-  composes: default;
+  composes: defaultStyle;
   width: 150px;
 }
 

--- a/packages/@coorpacademy-components/src/atom/status-item/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/status-item/index.tsx
@@ -97,7 +97,7 @@ const StatusItem = (props: StatusItemProps) => {
   return (
     <div
       className={classnames(
-        style.default,
+        style.defaultStyle,
         icon === 'right' && style.right,
         icon === 'wrong' && style.wrong,
         current && style.current,

--- a/packages/@coorpacademy-components/src/atom/status-item/style.css
+++ b/packages/@coorpacademy-components/src/atom/status-item/style.css
@@ -11,7 +11,7 @@
 @value cm_pink_50 from colors;
 @value cm_primary_blue from colors;
 
-.default {
+.defaultStyle {
   width: 100%;
   height: 100%;
   opacity: 0.5;

--- a/packages/@coorpacademy-components/src/atom/tag/index.js
+++ b/packages/@coorpacademy-components/src/atom/tag/index.js
@@ -6,7 +6,7 @@ import Icon from '../icon';
 import style from './style.css';
 
 const TAG_STYLES = {
-  default: style.default,
+  default: style.defaultStyle,
   success: style.success,
   failure: style.failure,
   warning: style.warning,

--- a/packages/@coorpacademy-components/src/atom/tag/style.css
+++ b/packages/@coorpacademy-components/src/atom/tag/style.css
@@ -35,7 +35,7 @@
   padding: 8px 16px;
 }
 
-.default {
+.defaultStyle {
   composes: tag;
   background-color: cm_grey_100;
   color: cm_grey_500;

--- a/packages/@coorpacademy-components/src/molecule/brand-create-form/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-create-form/index.js
@@ -12,7 +12,7 @@ const BrandCreateForm = (props, context) => {
 
   const wrapperClass =
     isModified || isPending || field.error ? style.modifiedWrapper : style.wrapper;
-  const fieldClass = field.error ? style.error : style.default;
+  const fieldClass = field.error ? style.error : style.defaultStyle;
   const disabled = isPending || !isModified;
   const {onChange} = field;
   const handleChange = useMemo(() => e => onChange(e.target.value), [onChange]);

--- a/packages/@coorpacademy-components/src/molecule/brand-create-form/style.css
+++ b/packages/@coorpacademy-components/src/molecule/brand-create-form/style.css
@@ -73,7 +73,7 @@
   margin-bottom: 20px;
 }
 
-.default {
+.defaultStyle {
   margin-bottom: 70px;
 }
 
@@ -81,14 +81,14 @@
   composes: default;
 }
 
-.default label {
+.defaultStyle label {
   font-family: 'Gilroy';
   font-weight: 600;
   font-size: 18px;
   color: medium;
 }
 
-.default input {
+.defaultStyle input {
   font-family: "Gilroy";
   text-transform: none;
   padding: 0 15px;

--- a/packages/@coorpacademy-components/src/molecule/brand-create-form/style.css
+++ b/packages/@coorpacademy-components/src/molecule/brand-create-form/style.css
@@ -78,7 +78,7 @@
 }
 
 .error {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .defaultStyle label {

--- a/packages/@coorpacademy-components/src/molecule/brand-upload-box/index.js
+++ b/packages/@coorpacademy-components/src/molecule/brand-upload-box/index.js
@@ -60,7 +60,7 @@ class BrandUploadBox extends React.Component {
       default:
         content = (
           <div className={style.wrapper}>
-            <div id={idBox} className={dragging ? style.dropping : style.default}>
+            <div id={idBox} className={dragging ? style.dropping : style.defaultStyle}>
               <div className={style.cont}>
                 <UploadIcon style={{color: brandColor}} className={style.arrow} />
                 <div className={style.desc}>{description}</div>

--- a/packages/@coorpacademy-components/src/molecule/brand-upload-box/style.css
+++ b/packages/@coorpacademy-components/src/molecule/brand-upload-box/style.css
@@ -34,14 +34,14 @@
 }
 
 .loading {
-  composes: default;
+  composes: defaultStyle;
   height: 80px;
   border: none;
   position: relative;
 }
 
 .dropping {
-  composes: default;
+  composes: defaultStyle;
   border: 3px dashed brand;
 }
 

--- a/packages/@coorpacademy-components/src/molecule/brand-upload-box/style.css
+++ b/packages/@coorpacademy-components/src/molecule/brand-upload-box/style.css
@@ -24,7 +24,7 @@
   transform: scale(1.2);
 }
 
-.default {
+.defaultStyle {
   border: 2px dashed xtraLightGrey;
   border-radius: 4px;
   overflow: hidden;

--- a/packages/@coorpacademy-components/src/molecule/card/customer.css
+++ b/packages/@coorpacademy-components/src/molecule/card/customer.css
@@ -3,7 +3,7 @@
 @value colors: "../../variables/colors.css";
 @value white from colors;
 
-.default {
+.defaultStyle {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;

--- a/packages/@coorpacademy-components/src/molecule/card/customer.css
+++ b/packages/@coorpacademy-components/src/molecule/card/customer.css
@@ -22,7 +22,7 @@
 }
 
 .content {
-  composes: default;
+  composes: defaultStyle;
   padding: 12px 12px 0;
   font-size: 12px;
 }

--- a/packages/@coorpacademy-components/src/molecule/card/customer.js
+++ b/packages/@coorpacademy-components/src/molecule/card/customer.js
@@ -5,7 +5,7 @@ import {keys} from 'lodash/fp';
 import style from './customer.css';
 
 export const THEMES = {
-  default: null,
+  default: style.defaultStyle,
   coorpmanager: style.coorpmanager
 };
 

--- a/packages/@coorpacademy-components/src/molecule/card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/card/index.js
@@ -16,7 +16,7 @@ import Notification from './notification';
 import style from './style.css';
 
 export const THEMES = {
-  default: null,
+  default: style.defaultStyle,
   coorpmanager: style.coorpmanager
 };
 

--- a/packages/@coorpacademy-components/src/molecule/card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/card/style.css
@@ -11,11 +11,11 @@
 @value cm_negative_200 from colors;
 @value negative_100 from colors;
 
-.default[disabled] {
+.defaultStyle[disabled] {
   cursor: inherit;
 }
 
-.default {
+.defaultStyle {
   display: inline-block;
   box-sizing: border-box;
   vertical-align: top;
@@ -33,7 +33,7 @@
   box-shadow: 0 0 13px 0 rgba(0, 0, 0, 0.11);
 }
 
-.default[disabled] .favorite {
+.defaultStyle[disabled] .favorite {
   z-index: 0;
 }
 
@@ -88,7 +88,7 @@
   max-height: 52px;
 }
 
-.default .image {
+.defaultStyle .image {
   overflow: hidden;
   background-position: 50%;
   background-size: cover;
@@ -99,18 +99,18 @@
   line-height: 125px;
 }
 
-.default .image::after {
+.defaultStyle .image::after {
   opacity: 0;
   transition: opacity 0.25s ease-in-out;
 }
 
-.default:hover .image {
+.defaultStyle:hover .image {
   transform-origin: center;
   transform: scale(1.1);
   transition: all 1s ease-in-out;
 }
 
-.default .image::after {
+.defaultStyle .image::after {
   position: absolute;
   content: '';
   width: 100%;
@@ -125,7 +125,7 @@
   );
 }
 
-.default .image::before {
+.defaultStyle .image::before {
   position: absolute;
   content: '';
   width: 100%;
@@ -137,7 +137,7 @@
   background: black;
 }
 
-.default:hover .image::before {
+.defaultStyle:hover .image::before {
   opacity: 0.3;
   transition: opacity 0.5s ease-in-out;
 }
@@ -156,14 +156,14 @@
   }
 }
 
-.course .default:hover,
-.chapter .default:hover {
+.course .defaultStyle:hover,
+.chapter .defaultStyle:hover {
   background: light;
   cursor: pointer;
   transition: background 0.25s ease-in-out;
 }
 
-.default[disabled] .imageWrapper {
+.defaultStyle[disabled] .imageWrapper {
   opacity: 0.8;
 }
 
@@ -382,8 +382,8 @@
   animation-play-state: paused;
 }
 
-.default:hover .externalIconCircleWrapper::after,
-.default:hover .externalIconCircleWrapper::before {
+.defaultStyle:hover .externalIconCircleWrapper::after,
+.defaultStyle:hover .externalIconCircleWrapper::before {
   animation-play-state: running;
   box-shadow: inset 0 0 7px 0 rgba(255, 255, 255, 0.37);
 }
@@ -494,13 +494,13 @@
 }
 
 @media (hover: none) {
-  .default:hover .image {
+  .defaultStyle:hover .image {
     transform: scale(1);
   }
-  .default:hover .image::before {
+  .defaultStyle:hover .image::before {
     opacity: 0;
   }
-  .default:hover .externalIconCircleWrapper {
+  .defaultStyle:hover .externalIconCircleWrapper {
     transform: scale(1);
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/card/style.css
@@ -43,14 +43,14 @@
 }
 
 .course {
-  composes: default;
+  composes: defaultStyle;
   border-radius: 8px;
   width: 256px;
   height: 297px;
 }
 
 .chapter {
-  composes: default;
+  composes: defaultStyle;
   border-radius: 8px;
   width: 203px;
   height: 297px;

--- a/packages/@coorpacademy-components/src/molecule/filters/index.js
+++ b/packages/@coorpacademy-components/src/molecule/filters/index.js
@@ -113,7 +113,7 @@ class Filters extends React.Component {
         <div
           data-name="filter"
           data-open={filtersActive}
-          className={filtersActive ? style.activeDefault : style.default}
+          className={filtersActive ? style.activeDefault : style.defaultStyle}
         >
           <div className={style.title} data-name="filterButton" onClick={this.handleOpenFilter}>
             {filterTabLabel}

--- a/packages/@coorpacademy-components/src/molecule/filters/style.css
+++ b/packages/@coorpacademy-components/src/molecule/filters/style.css
@@ -21,7 +21,7 @@
   border-bottom: 1px solid light;
 }
 
-.default {
+.defaultStyle {
   display: none;
   padding: 25px 0;
   width: 100%;
@@ -78,7 +78,7 @@
   transition: transform 0.4s ease-out;
 }
 
-.default .arrow,
+.defaultStyle .arrow,
 .wrapperSortBy .arrow {
   transform: rotate(0deg);
   transition: transform 0.4s ease-out;
@@ -112,7 +112,7 @@
   display: none;
 }
 
-.default,
+.defaultStyle,
 .wrapperSortBy,
 .activeDefault,
 .activeWrapperSortBy {
@@ -124,7 +124,7 @@
   background: xtraLightGrey;
 }
 
-.default {
+.defaultStyle {
   border-right: solid 1px light;
   border-bottom: solid 1px light;
 }

--- a/packages/@coorpacademy-components/src/molecule/hero/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/hero/index.tsx
@@ -22,7 +22,7 @@ const Hero = (props: Props, context: WebContextValues) => {
   } = props;
 
   const primaryColor = get('common.primary', skin);
-  const cardStyle = classnames(style.hero, title ? null : style.lazy);
+  const cardStyle = classnames(style.hero, title ? style.defaultStyle : style.lazy);
 
   return (
     <div className={cardStyle} data-name="hero">

--- a/packages/@coorpacademy-components/src/molecule/hero/style.css
+++ b/packages/@coorpacademy-components/src/molecule/hero/style.css
@@ -31,7 +31,7 @@
 }
 
 .hero {
-  composes: default;
+  composes: defaultStyle;
   border-radius: 0;
   width: 100%;
   height: 100%;

--- a/packages/@coorpacademy-components/src/molecule/hero/style.css
+++ b/packages/@coorpacademy-components/src/molecule/hero/style.css
@@ -9,11 +9,11 @@
 @value xtraLightGrey from colors;
 @value white from colors;
 
-.default[disabled] {
+.defaultStyle[disabled] {
   pointer-events: none;
 }
 
-.default {
+.defaultStyle {
   display: inline-block;
   box-sizing: border-box;
   vertical-align: top;
@@ -48,7 +48,7 @@
   left: 0;
 }
 
-.default .image {
+.defaultStyle .image {
   overflow: hidden;
   background-position: 50%;
   background-size: cover;
@@ -59,12 +59,12 @@
   line-height: 125px;
 }
 
-.default .image::after {
+.defaultStyle .image::after {
   opacity: 0;
   transition: opacity 0.25s ease-in-out;
 }
 
-.default .image::after {
+.defaultStyle .image::after {
   position: absolute;
   content: '';
   width: 100%;
@@ -80,7 +80,7 @@
   );
 }
 
-.default .image::before {
+.defaultStyle .image::before {
   position: absolute;
   content: '';
   width: 100%;
@@ -92,7 +92,7 @@
   background: black;
 }
 
-.default:hover .image::before {
+.defaultStyle:hover .image::before {
   opacity: 0.3;
   transition: opacity 0.5s ease-in-out;
 }
@@ -125,7 +125,7 @@
   }
 }
 
-.default[disabled] .imageWrapper {
+.defaultStyle[disabled] .imageWrapper {
   opacity: 0.4;
 }
 
@@ -152,7 +152,7 @@
 }
 
 @media (hover: none) {
-  .default:hover .image::before {
+  .defaultStyle:hover .image::before {
     opacity: 0;
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/module-card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/module-card/index.js
@@ -12,7 +12,7 @@ function ModuleCard(props, context) {
 
   const iconColor = getOr('#00B0FF', ['common', 'primary'], skin);
   return (
-    <div className={style.default} data-name="module-card" onClick={onClick}>
+    <div className={style.defaultStyle} data-name="module-card" onClick={onClick}>
       <div
         className={classnames(style.title, style.innerHTML)}
         // eslint-disable-next-line react/no-danger

--- a/packages/@coorpacademy-components/src/molecule/module-card/style.css
+++ b/packages/@coorpacademy-components/src/molecule/module-card/style.css
@@ -6,7 +6,7 @@
 @value xtraLightGrey from colors;
 @value dark from colors;
 
-.default {
+.defaultStyle {
   width: 350px;
   margin: 5px;
   height: 80px;
@@ -21,7 +21,7 @@
   cursor: pointer;
 }
 
-.default:hover {
+.defaultStyle:hover {
   background-color: xtraLightGrey;
 }
 
@@ -49,7 +49,7 @@
 }
 
 @media mobile {
-  .default {
+  .defaultStyle {
     padding: 10px;
     margin: 5px 0;
     width: 100%;

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/index.js
@@ -179,10 +179,10 @@ const SelectMultiple = (
     />
   ) : null;
 
-  const mainClass = theme ? themeStyle[theme] : style.default;
+  const mainClass = theme ? themeStyle[theme] : style.defaultStyle;
   const showPlaceholder = isCMTheme && isActive;
   const behaviourClassName = getClassState(
-    style.default,
+    style.defaultStyle,
     style.modified,
     style.error,
     modified,

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/style.css
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/style.css
@@ -27,11 +27,11 @@
 }
 
 .error {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .modified {
-  composes: default;
+  composes: defaultStyle;
 }
 
 .select {
@@ -148,7 +148,7 @@
   setup theme
 */
 .setup {
-  composes: default;
+  composes: defaultStyle;
   display: flex;
   align-items: center;
   height: 50px;
@@ -197,7 +197,7 @@
 */
 
 .cockpit {
-  composes: default;
+  composes: defaultStyle;
   display: flex;
   align-items: center;
   margin-left: 20px;

--- a/packages/@coorpacademy-components/src/molecule/select-multiple/style.css
+++ b/packages/@coorpacademy-components/src/molecule/select-multiple/style.css
@@ -19,7 +19,7 @@
 /*
   default theme
 */
-.default {
+.defaultStyle {
   display: block;
   position: relative;
   user-select: none;

--- a/packages/@coorpacademy-components/src/molecule/theme-image/index.js
+++ b/packages/@coorpacademy-components/src/molecule/theme-image/index.js
@@ -15,7 +15,7 @@ function ThemeImage({image}, {skin}) {
 
   return (
     <div className={style.wrapper}>
-      <div className={style.default}>
+      <div className={style.defaultStyle}>
         <div className={style.background} style={defaultStyle} />
       </div>
       <div className={style.desktopContainer}>

--- a/packages/@coorpacademy-components/src/molecule/theme-image/style.css
+++ b/packages/@coorpacademy-components/src/molecule/theme-image/style.css
@@ -21,7 +21,7 @@
   height: 100%;
 }
 
-.default {
+.defaultStyle {
   display: block;
   width: 100%;
   height: 100%;
@@ -40,7 +40,7 @@
     display: block;
   }
 
-  .default,
+  .defaultStyle,
   .tabletContainer,
   .mobileContainer {
     display: none;
@@ -52,7 +52,7 @@
     display: block;
   }
 
-  .default,
+  .defaultStyle,
   .desktopContainer,
   .mobileContainer {
     display: none;
@@ -64,7 +64,7 @@
     display: block;
   }
 
-  .default,
+  .defaultStyle,
   .desktopContainer,
   .tabletContainer {
     display: none;

--- a/packages/@coorpacademy-components/src/molecule/titled-checkbox/index.js
+++ b/packages/@coorpacademy-components/src/molecule/titled-checkbox/index.js
@@ -11,7 +11,7 @@ const TitledCheckbox = props => {
   const handleChange = useMemo(() => () => onToggle(choice), [onToggle, choice]);
 
   return (
-    <label className={style.default}>
+    <label className={style.defaultStyle}>
       <div
         className={style.box}
         style={{

--- a/packages/@coorpacademy-components/src/molecule/titled-checkbox/style.css
+++ b/packages/@coorpacademy-components/src/molecule/titled-checkbox/style.css
@@ -1,4 +1,4 @@
-.default {
+.defaultStyle {
   line-height: 25px;
   font-family: Gilroy;
   display: flex;

--- a/packages/@coorpacademy-components/src/organism/brand-analytics/analytics-popin.css
+++ b/packages/@coorpacademy-components/src/organism/brand-analytics/analytics-popin.css
@@ -6,7 +6,7 @@
 @value grey from colors;
 @value white from colors;
 
-.default {
+.defaultStyle {
   z-index: 20;
   top: 0;
   display: flex;

--- a/packages/@coorpacademy-components/src/organism/brand-analytics/analytics-popin.js
+++ b/packages/@coorpacademy-components/src/organism/brand-analytics/analytics-popin.js
@@ -23,7 +23,7 @@ const AnalyticsPopin = (props, context) => {
   }
 
   return (
-    <div className={style.default} onClick={onCloseClick}>
+    <div className={style.defaultStyle} onClick={onCloseClick}>
       <div className={style.popin}>
         <div className={style.header} onClick={onCloseClick} data-name="popin-header">
           {header}

--- a/packages/@coorpacademy-components/src/organism/cards-grid/index.js
+++ b/packages/@coorpacademy-components/src/organism/cards-grid/index.js
@@ -23,7 +23,7 @@ function CardsGrid(props) {
   }, list);
 
   return (
-    <div className={style.default} style={customStyle}>
+    <div className={style.defaultStyle} style={customStyle}>
       {cards}
       {loader}
     </div>

--- a/packages/@coorpacademy-components/src/organism/cards-grid/style.css
+++ b/packages/@coorpacademy-components/src/organism/cards-grid/style.css
@@ -5,7 +5,7 @@
 @value tablet from breakpoints;
 @value mobile from breakpoints;
 
-.default {
+.defaultStyle {
   box-sizing: border-box;
   width: 100%;
   margin: auto;

--- a/packages/@coorpacademy-components/src/organism/popin/index.js
+++ b/packages/@coorpacademy-components/src/organism/popin/index.js
@@ -18,7 +18,7 @@ const Popin = (props, context) => {
   const primary = getOr('#00B0FF', ['common', 'primary'], skin);
 
   return (
-    <div className={style.default} onClick={closeOnClick}>
+    <div className={style.defaultStyle} onClick={closeOnClick}>
       <div className={style.popin} onClick={stopPropagation}>
         <div className={style.header} onClick={closeOnClick} data-name="popin-header">
           {header}

--- a/packages/@coorpacademy-components/src/organism/popin/style.css
+++ b/packages/@coorpacademy-components/src/organism/popin/style.css
@@ -6,7 +6,7 @@
 @value grey from colors;
 @value white from colors;
 
-.default {
+.defaultStyle {
   font-family: Gilroy;
   position: fixed;
   z-index: 20;

--- a/packages/@coorpacademy-components/src/organism/resource-browser/index.js
+++ b/packages/@coorpacademy-components/src/organism/resource-browser/index.js
@@ -31,7 +31,7 @@ const ResourceBrowser = props => {
   const {resources, className, overlay} = props;
   const selectedResource = find(({selected}) => selected, resources);
   return (
-    <div data-name="resourceBrowser" className={classnames(style.default, className)}>
+    <div data-name="resourceBrowser" className={classnames(style.defaultStyle, className)}>
       <div className={style.resourcePlayerWrapper}>
         {selectedResource ? (
           <ResourcePlayer

--- a/packages/@coorpacademy-components/src/organism/resource-browser/style.css
+++ b/packages/@coorpacademy-components/src/organism/resource-browser/style.css
@@ -1,6 +1,6 @@
 @value mobile, tablet from "../../variables/breakpoints.css";
 
-.default {
+.defaultStyle {
   display: flex;
   flex-flow: row;
   justify-content: center;
@@ -29,7 +29,7 @@
 }
 
 @media tablet {
-  .default {
+  .defaultStyle {
     flex-flow: column;
     height: auto;
     width: 100%;

--- a/packages/@coorpacademy-components/src/template/activity/index.js
+++ b/packages/@coorpacademy-components/src/template/activity/index.js
@@ -107,7 +107,7 @@ const Progression = (props, legacyContext) => {
   ) : null;
 
   return (
-    <div className={style.default}>
+    <div className={style.defaultStyle}>
       <div data-name="activity-header" tabIndex={0}>
         <div className={style.mainTitle} tabIndex={0}>
           <span>{mainTitle}</span> {mainSubtitle}

--- a/packages/@coorpacademy-components/src/template/activity/style.css
+++ b/packages/@coorpacademy-components/src/template/activity/style.css
@@ -9,7 +9,7 @@
 @value white from colors;
 @value xtraLightGrey from colors;
 
-.default {
+.defaultStyle {
   margin: 16px auto 0;
   box-sizing: border-box;
   max-width: 1080px;
@@ -104,7 +104,7 @@
 }
 
 @media tablet, mobile {
-  .default {
+  .defaultStyle {
     margin: 0;
     padding: 0;
   }

--- a/packages/@coorpacademy-components/src/template/back-office/dashboard-preview/dashboard-popin.css
+++ b/packages/@coorpacademy-components/src/template/back-office/dashboard-preview/dashboard-popin.css
@@ -6,7 +6,7 @@
 @value grey from colors;
 @value white from colors;
 
-.default {
+.defaultStyle {
   font-family: Gilroy;
   z-index: 20;
   top: 0;

--- a/packages/@coorpacademy-components/src/template/back-office/dashboard-preview/dashboard-popin.js
+++ b/packages/@coorpacademy-components/src/template/back-office/dashboard-preview/dashboard-popin.js
@@ -18,7 +18,7 @@ const DashboardPopin = (props, context) => {
   const primary = getOr('#00B0FF', ['common', 'primary'], skin);
 
   return (
-    <div className={style.default} onClick={closeOnClick}>
+    <div className={style.defaultStyle} onClick={closeOnClick}>
       <div className={style.popin} onClick={stopPropagation}>
         <div className={style.header} onClick={closeOnClick} data-name="popin-header">
           {header}

--- a/packages/@coorpacademy-components/src/template/external-course/index.js
+++ b/packages/@coorpacademy-components/src/template/external-course/index.js
@@ -13,9 +13,9 @@ import CmPopin from '../../molecule/cm-popin';
 import style from './style.css';
 
 const defaultWrapperStyle = {
-  default: style.default,
+  default: style.defaultStyle,
   cockpit: style.defaultCockpit,
-  mobile: style.default
+  mobile: style.defaultStyle
 };
 
 const ExternalCourse = (props, context) => {

--- a/packages/@coorpacademy-components/src/template/external-course/style.css
+++ b/packages/@coorpacademy-components/src/template/external-course/style.css
@@ -7,7 +7,7 @@
 @value dark from colors;
 @value warn from colors;
 
-.default{
+.defaultStyle{
   font-family: 'Gilroy';
   font-size: 14px;
   font-weight: bold;

--- a/packages/@coorpacademy-components/src/template/external-course/style.css
+++ b/packages/@coorpacademy-components/src/template/external-course/style.css
@@ -25,7 +25,7 @@
 }
 
 .defaultCockpit{
-  composes: default;
+  composes: defaultStyle;
   height: 100%;
 }
 


### PR DESCRIPTION
## Detailed purpose of the PR

Fix for #2922, the `default` css class were not handled correctly (conflict with `default` module concept) since babel and webpack bump (and adjustements).
That caused the switch disappearing glitch on CM.

This PR rename all that classes to `defaultStyle`.
Beta deployed on uberstaging
