### PR TITLE
Stop the tweaking with casing of class :no_good:

### DIFF
--- a/packages/@coorpacademy-webpack-config/src/index.js
+++ b/packages/@coorpacademy-webpack-config/src/index.js
@@ -78,7 +78,8 @@ const createConfig = (NODE_ENV = 'development', {additionalPlugins = [], esModul
                 esModule,
                 modules: {
                   namedExport: esModule,
-                  getLocalIdent
+                  getLocalIdent,
+                  exportLocalsConvention: 'as-is'
                 }
               }
             },


### PR DESCRIPTION
## Detailed purpose of the PR
<!-- fatigue-->
As there was other glitched, I found a way to tell the css-loader to stop messing around with class names 😏 

https://webpack.js.org/loaders/css-loader/#modules

exportLocalsConvention, with ~`touche pas`~ `as-is` convention.

Tested via canary