### PR TITLE
Rename a leftover default reference in css (post #2930) :memo:

### DIFF
--- a/packages/@coorpacademy-components/src/atom/input-color/style.css
+++ b/packages/@coorpacademy-components/src/atom/input-color/style.css
@@ -2,7 +2,7 @@
 @value grey from colors;
 
 .defaultStyle {
-  composes: default from '../input-text/style.css';
+  composes: defaultStyle from '../input-text/style.css';
 }
 
 .input {


### PR DESCRIPTION
## Detailed purpose of the PR-

Glitch on IconColor induced in the #2922 series (#2930)
Identified by @youssefezzahi96
I performed a check all across the css to make sure there was not similar situation
