### PR TITLE
CLXP-254: List items search

### DIFF
--- a/packages/@coorpacademy-components/src/organism/list-item/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/index.js
@@ -13,7 +13,6 @@ import CardImagePreview from '../../atom/card-image-preview';
 import CheckboxWithTitle from '../../atom/checkbox-with-title';
 import style from './style.css';
 
-const BACKGROUND_COLOR = COLORS.white;
 const ListItem = (
   {
     buttonLink,
@@ -135,11 +134,11 @@ const ListItem = (
 
       <div className={style.settings}>
         {tagsView}
-        {selected && !checkable ? (
+        {selected ? (
           <FaIcon
             iconName="circle-check"
             iconColor={primarySelectedColor}
-            backgroundColor={BACKGROUND_COLOR}
+            backgroundColor={COLORS.white}
             size={{faSize: 16, wrapperSize: 16}}
           />
         ) : null}

--- a/packages/@coorpacademy-components/src/organism/list-item/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/index.js
@@ -13,6 +13,7 @@ import CardImagePreview from '../../atom/card-image-preview';
 import CheckboxWithTitle from '../../atom/checkbox-with-title';
 import style from './style.css';
 
+const BACKGROUND_COLOR = COLORS.white;
 const ListItem = (
   {
     buttonLink,
@@ -134,11 +135,11 @@ const ListItem = (
 
       <div className={style.settings}>
         {tagsView}
-        {selected ? (
+        {selected && !checkable ? (
           <FaIcon
             iconName="circle-check"
             iconColor={primarySelectedColor}
-            backgroundColor={COLORS.white}
+            backgroundColor={BACKGROUND_COLOR}
             size={{faSize: 16, wrapperSize: 16}}
           />
         ) : null}

--- a/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/checkbox-deletable.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/test/fixtures/checkbox-deletable.js
@@ -1,0 +1,31 @@
+import {defaultsDeep} from 'lodash/fp';
+import CheckboxSelected from './checkbox-selected';
+
+const {props} = CheckboxSelected;
+
+export default {
+  props: defaultsDeep(props, {
+    checkbox: {
+      checked: true,
+      onChange: value => console.log(value)
+    },
+    secondButtonLink: {
+      'aria-label': 'Delete',
+      type: 'primary',
+      customStyle: {
+        width: 'fit-content',
+        backgroundColor: 'transparent'
+      },
+      hoverBackgroundColor: '#EAEAEB',
+      icon: {
+        position: 'left',
+        faIcon: {
+          name: 'trash',
+          color: '#515161',
+          size: 16
+        }
+      },
+      onClick: () => console.log('Click on delete icon')
+    }
+  })
+};

--- a/packages/@coorpacademy-components/src/organism/list-items/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/index.js
@@ -85,7 +85,7 @@ const buildEmptyResultView = emptyResult => {
 const buildContentView = (content, ariaLabel, selectMultiple) => {
   const {type} = content;
 
-  if (type === 'list' && isEmpty(content.items)) {
+  if (type === 'list' && isEmpty(content.items) && content.emptyResult) {
     return buildEmptyResultView(content.emptyResult);
   }
 

--- a/packages/@coorpacademy-components/src/organism/list-items/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/index.js
@@ -10,6 +10,7 @@ import SelectMultiple from '../../molecule/select-multiple';
 import ExpandibleActionableTable from '../../molecule/expandible-actionable-table';
 import Loader from '../../atom/loader';
 import Search from '../../atom/input-search';
+import CheckboxWithTitle from '../../atom/checkbox-with-title';
 import style from './style.css';
 
 const buildListItemsView = (content, ariaLabel, selectMultiple) => {
@@ -64,8 +65,30 @@ const buildListItemsView = (content, ariaLabel, selectMultiple) => {
   );
 };
 
+const buildEmptyResultView = emptyResult => {
+  const {title, description, button} = emptyResult;
+
+  return (
+    <div className={style.emptySearchResultContainer}>
+      <div className={style.emptySearchResultTitle}>{title}</div>
+      <div className={style.emptySearchResultDescription}>{description}</div>
+      <ButtonLink
+        type="text"
+        label={button.label}
+        onClick={button.handleSearchReset}
+        className={style.emptySearchResultButton}
+      />
+    </div>
+  );
+};
+
 const buildContentView = (content, ariaLabel, selectMultiple) => {
   const {type} = content;
+
+  if (type === 'list' && isEmpty(content.items)) {
+    return buildEmptyResultView(content.emptyResult);
+  }
+
   switch (type) {
     case 'list':
       return buildListItemsView(content, ariaLabel, selectMultiple);
@@ -81,20 +104,25 @@ const ListItems = ({
   content,
   'aria-label': ariaLabel,
   isFetching,
-  search
+  search,
+  checkboxWithTitle
 }) => {
   const contentView = buildContentView(content, ariaLabel, selectMultiple);
   return (
     <div>
       <div className={style.header}>
-        <div className={style.title}>
-          <Title
-            title={title}
-            type="form-group"
-            titleSize="standard-light-weight"
-            data-name="list-title"
-          />
-        </div>
+        {checkboxWithTitle ? (
+          <CheckboxWithTitle {...checkboxWithTitle} title={checkboxWithTitle.title} />
+        ) : (
+          <div className={style.title}>
+            <Title
+              title={title}
+              type="form-group"
+              titleSize="standard-light-weight"
+              data-name="list-title"
+            />
+          </div>
+        )}
         <div className={style.inputWrapper}>
           {!isEmpty(search) ? <Search {...search} /> : null}
           <div className={style.actionsWrapper}>
@@ -129,7 +157,12 @@ ListItems.propTypes = {
       itemType: PropTypes.string,
       onDrop: PropTypes.func,
       isDraggable: PropTypes.bool,
-      tableHeader: PropTypes.arrayOf(PropTypes.string)
+      tableHeader: PropTypes.arrayOf(PropTypes.string),
+      emptyResult: PropTypes.shape({
+        title: PropTypes.string,
+        description: PropTypes.string,
+        button: PropTypes.shape(ButtonLink.propTypes)
+      })
     }),
     PropTypes.shape({
       ...ExpandibleActionableTable.propTypes,
@@ -138,7 +171,8 @@ ListItems.propTypes = {
   ]),
   title: PropTypes.string,
   isFetching: PropTypes.bool,
-  search: PropTypes.shape(Search.propTypes)
+  search: PropTypes.shape(Search.propTypes),
+  checkboxWithTitle: PropTypes.shape(CheckboxWithTitle.propTypes)
 };
 
 export default ListItems;

--- a/packages/@coorpacademy-components/src/organism/list-items/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isNil from 'lodash/fp/isNil';
 import isEmpty from 'lodash/fp/isEmpty';
+import map from 'lodash/fp/map';
 import ListItem from '../list-item';
 import DraggableList from '../../molecule/draggable-list';
 import Title from '../../atom/title';
@@ -105,14 +106,18 @@ const ListItems = ({
   'aria-label': ariaLabel,
   isFetching,
   search,
-  checkboxWithTitle
+  checkboxWithTitle,
+  actionButtons
 }) => {
   const contentView = buildContentView(content, ariaLabel, selectMultiple);
   return (
     <div>
       <div className={style.header}>
         {checkboxWithTitle ? (
-          <CheckboxWithTitle {...checkboxWithTitle} title={checkboxWithTitle.title} />
+          <div className={style.checkboxAndActionsWrapper}>
+            <CheckboxWithTitle {...checkboxWithTitle} title={checkboxWithTitle.title} />
+            {actionButtons ? map(action => <ButtonLink {...action} />)(actionButtons) : null}
+          </div>
         ) : (
           <div className={style.title}>
             <Title
@@ -172,7 +177,8 @@ ListItems.propTypes = {
   title: PropTypes.string,
   isFetching: PropTypes.bool,
   search: PropTypes.shape(Search.propTypes),
-  checkboxWithTitle: PropTypes.shape(CheckboxWithTitle.propTypes)
+  checkboxWithTitle: PropTypes.shape(CheckboxWithTitle.propTypes),
+  actionButtons: PropTypes.arrayOf(PropTypes.shape(ButtonLink.propTypes))
 };
 
 export default ListItems;

--- a/packages/@coorpacademy-components/src/organism/list-items/style.css
+++ b/packages/@coorpacademy-components/src/organism/list-items/style.css
@@ -36,6 +36,11 @@
   text-align: left;
 }
 
+.checkboxAndActionsWrapper {
+  display: flex;
+  gap: 24px; 
+}
+
 .selectMultiple {
   width: 291px;
 }

--- a/packages/@coorpacademy-components/src/organism/list-items/style.css
+++ b/packages/@coorpacademy-components/src/organism/list-items/style.css
@@ -4,13 +4,17 @@
 @value medium from colors;
 @value xtraLightGrey from colors;
 @value cm_grey_400 from colors;
+@value cm_grey_500 from colors;
+@value cm_grey_700 from colors;
 @value dark from colors;
+@value cm_primary_blue from colors;
+@value cm_blue_600 from colors;
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 24px;
+  padding: 0;
   margin-bottom: 24px;
 }
 
@@ -108,4 +112,41 @@
   display: flex;
   gap: 8px;
   align-items: center;
+}
+
+.emptySearchResultContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: cm_grey_700;
+  font-family: Gilroy;
+  margin-top: 40px;
+}
+
+.emptySearchResultTitle {
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 28px;
+  margin-bottom: 8px;
+}
+
+.emptySearchResultDescription {
+  color: cm_grey_500;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.emptySearchResultButton {
+  color: cm_primary_blue;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+  cursor: pointer;
+  margin-top: 32px;
+  width: auto;
+}
+
+.emptySearchResultButton:hover {
+  color: cm_blue_600;
 }

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill-delete.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill-delete.js
@@ -1,0 +1,96 @@
+import checkbox from '../../../list-item/test/fixtures/checkbox';
+import checkboxSelected from '../../../list-item/test/fixtures/checkbox-selected';
+import searchProps from '../../../../atom/input-search/test/fixtures/coorpmanager';
+import checkboxWithTitleProps from '../../../../atom/checkbox-with-title/test/fixtures/with-custom-icon';
+import {COLORS} from '../../../../variables/colors';
+
+const secondButtonLink = {
+  'aria-label': 'Delete',
+  type: 'primary',
+  customStyle: {
+    width: 'fit-content',
+    backgroundColor: 'transparent'
+  },
+  hoverBackgroundColor: '#EAEAEB',
+  icon: {
+    position: 'left',
+    faIcon: {
+      name: 'trash',
+      color: '#515161',
+      size: 16
+    }
+  },
+  onClick: () => console.log('Click on delete icon')
+};
+
+const items = [
+  {...checkboxSelected.props, secondButtonLink, id: '1'},
+  {
+    id: '2',
+    title: 'Ensuring team cohesion ',
+    subtitle: 'Coorpacademy',
+    image:
+      'https://api.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/partner-wedemain/fr/medias/img/cover/shutterstock_248741149-1470302136299.jpg&h=500&w=500&q=90',
+    tags: [
+      {
+        label: 'Course',
+        type: 'default',
+        icon: {
+          iconName: 'book-open',
+          preset: 's',
+          customStyle: {
+            padding: 0
+          },
+          position: 'left'
+        }
+      }
+    ],
+    checkbox: {
+      checked: true,
+      onChange: value => console.log(value)
+    },
+    secondButtonLink
+  },
+  {
+    ...checkbox.props,
+    secondButtonLink,
+    id: '3'
+  }
+];
+
+export default {
+  props: {
+    checkboxWithTitle: {
+      ...checkboxWithTitleProps.props,
+      title: `<span style="color: #1D1D2B;">${
+        items.length - 1
+      }</span><span>&nbsp;</span>items selected`,
+      customStyle: {...checkboxWithTitleProps.props.customStyle, paddingLeft: '16px'}
+    },
+    'aria-label': 'aria list',
+    content: {items, type: 'list'},
+    search: {...searchProps.props, placeholder: 'Search...'},
+    actionButtons: [
+      {
+        label: 'Delete',
+        type: 'secondary',
+        onClick: () => console.log('click Save changes'),
+        icon: {
+          position: 'left',
+          faIcon: {
+            name: 'trash',
+            color: COLORS.cm_grey_700,
+            size: 14,
+            customStyle: {padding: 0}
+          }
+        },
+        customStyle: {
+          fontWeight: '600',
+          borderRadius: '12px',
+          width: 'auto',
+          paddingRight: '8px'
+        }
+      }
+    ]
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill-delete.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill-delete.js
@@ -1,30 +1,14 @@
 import checkbox from '../../../list-item/test/fixtures/checkbox';
-import checkboxSelected from '../../../list-item/test/fixtures/checkbox-selected';
+import checkboxDeletable from '../../../list-item/test/fixtures/checkbox-deletable';
 import searchProps from '../../../../atom/input-search/test/fixtures/coorpmanager';
 import checkboxWithTitleProps from '../../../../atom/checkbox-with-title/test/fixtures/with-custom-icon';
 import {COLORS} from '../../../../variables/colors';
 
-const secondButtonLink = {
-  'aria-label': 'Delete',
-  type: 'primary',
-  customStyle: {
-    width: 'fit-content',
-    backgroundColor: 'transparent'
-  },
-  hoverBackgroundColor: '#EAEAEB',
-  icon: {
-    position: 'left',
-    faIcon: {
-      name: 'trash',
-      color: '#515161',
-      size: 16
-    }
-  },
-  onClick: () => console.log('Click on delete icon')
-};
-
 const items = [
-  {...checkboxSelected.props, secondButtonLink, id: '1'},
+  {
+    ...checkboxDeletable.props,
+    id: '1'
+  },
   {
     id: '2',
     title: 'Ensuring team cohesion ',
@@ -49,12 +33,12 @@ const items = [
       checked: true,
       onChange: value => console.log(value)
     },
-    secondButtonLink
+    secondButtonLink: checkboxDeletable.props.secondButtonLink
   },
   {
     ...checkbox.props,
-    secondButtonLink,
-    id: '3'
+    id: '3',
+    secondButtonLink: checkboxDeletable.props.secondButtonLink
   }
 ];
 

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill-empty.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill-empty.js
@@ -1,0 +1,24 @@
+import searchProps from '../../../../atom/input-search/test/fixtures/coorpmanager';
+import checkboxWithTitleProps from '../../../../atom/checkbox-with-title/test/fixtures/with-custom-icon';
+
+export default {
+  props: {
+    checkboxWithTitle: {
+      ...checkboxWithTitleProps.props,
+      title: `<span style="color: #1D1D2B;">0</span><span>&nbsp;</span>items`,
+
+      customStyle: {...checkboxWithTitleProps.props.customStyle, paddingLeft: '16px'}
+    },
+    'aria-label': 'aria list',
+    content: {
+      items: [],
+      type: 'list',
+      emptyResult: {
+        title: 'No results...',
+        description: 'Try adjusting your search to find what you are looking for.',
+        button: {label: 'Clear search', handleSearchReset: () => console.log('clear search')}
+      }
+    },
+    search: {...searchProps.props, value: 'qfqdf', placeholder: 'Search content'}
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill.js
@@ -1,0 +1,25 @@
+import checkbox from '../../../list-item/test/fixtures/checkbox';
+import checkboxSelected from '../../../list-item/test/fixtures/checkbox-selected';
+import searchProps from '../../../../atom/input-search/test/fixtures/coorpmanager';
+import checkboxWithTitleProps from '../../../../atom/checkbox-with-title/test/fixtures/with-custom-icon';
+
+const items = [
+  {...checkboxSelected.props, id: '1'},
+  {...checkboxSelected.props, id: '2'},
+  {...checkbox.props, id: '3'}
+];
+
+export default {
+  props: {
+    checkboxWithTitle: {
+      ...checkboxWithTitleProps.props,
+      title: `<span style="color: #1D1D2B;">${
+        items.length - 1
+      }</span><span>&nbsp;</span>items selected`,
+      customStyle: {...checkboxWithTitleProps.props.customStyle, paddingLeft: '16px'}
+    },
+    'aria-label': 'aria list',
+    content: {items, type: 'list'},
+    search: {...searchProps.props, placeholder: 'Search...'}
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill.js
@@ -5,7 +5,31 @@ import checkboxWithTitleProps from '../../../../atom/checkbox-with-title/test/fi
 
 const items = [
   {...checkboxSelected.props, id: '1'},
-  {...checkboxSelected.props, id: '2'},
+  {
+    id: '2',
+    title: 'Ensuring team cohesion ',
+    subtitle: 'Coorpacademy',
+    image:
+      'https://api.coorpacademy.com/api-service/medias?url=https://static.coorpacademy.com/content/partner-wedemain/fr/medias/img/cover/shutterstock_248741149-1470302136299.jpg&h=500&w=500&q=90',
+    tags: [
+      {
+        label: 'Course',
+        type: 'default',
+        icon: {
+          iconName: 'book-open',
+          preset: 's',
+          customStyle: {
+            padding: 0
+          },
+          position: 'left'
+        }
+      }
+    ],
+    checkbox: {
+      checked: true,
+      onChange: value => console.log(value)
+    }
+  },
   {...checkbox.props, id: '3'}
 ];
 


### PR DESCRIPTION
**Detailed purpose of the PR**
Jira [ticket](https://go1web.atlassian.net/jira/software/projects/CLXP/boards/626?selectedIssue=CLXP-254).

- Update component organism `ListItems` to add a checkbox and an empty view.

**Result and observation**
-> https://6622682e70ecd8ecf5027fa1-pykcecechn.chromatic.com/?path=/story/organism-listitems--content-skill


<img width="1504" alt="image" src="https://github.com/user-attachments/assets/2c8e5a92-ea51-4263-bbdc-beaa82c8ecdb" />


<img width="760" alt="Screenshot 2025-03-17 at 09 49 45" src="https://github.com/user-attachments/assets/6dcf8d78-68d1-4c2e-96a3-1b32574ae2a1" />

<img width="1509" alt="Screenshot 2025-03-18 at 13 49 11" src="https://github.com/user-attachments/assets/7660f786-cc61-4153-aca6-61e0a7916e74" />

**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
