### PR TITLE
CLXP-268: Create `ButtonMenuAction` component for the translation section

### DIFF
--- a/packages/@coorpacademy-components/src/atom/button-menu/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/button-menu/index.tsx
@@ -46,6 +46,7 @@ const Button = (props: ButtonProps) => {
       className={styleButton}
       onClick={handleOnClick}
       disabled={disabled}
+      style={customStyle}
     >
       <div className={style.buttonContent}>
         <span className={style.label}>{label}</span>

--- a/packages/@coorpacademy-components/src/atom/button-menu/style.css
+++ b/packages/@coorpacademy-components/src/atom/button-menu/style.css
@@ -29,7 +29,6 @@
 }
 
 .disabled {
-  opacity: 0.1;
   pointer-events: none;
 }
 

--- a/packages/@coorpacademy-components/src/atom/title/index.js
+++ b/packages/@coorpacademy-components/src/atom/title/index.js
@@ -12,10 +12,12 @@ const getTitleStyle = (type, size) => {
       return style.titlePage;
     case 'form-group':
       switch (size) {
-        case 'standard-light-weight':
-          return style.titleFormGroupLightWeight;
         case 'standard':
           return style.titleFormGroup;
+        case 'standard-light-weight':
+          return style.titleFormGroupLightWeight;
+        case 'xl-strong':
+          return style.XlStrongTitle;
         case 'medium':
           return style.mediumTitleFormGroup;
         case 'small':
@@ -34,6 +36,8 @@ const getSubtitleStyle = (type, size) => {
           return style.subtitleFormGroup;
         case 'standard-without-margin':
           return style.subtitleFormGroupWithoutMargin;
+        case 'medium':
+          return style.mediumSubtitleFormGroup;
         case 'small':
           return style.smallSubtitleFormGroup;
         case 'small-without-margin':
@@ -83,10 +87,11 @@ Title.propTypes = {
   subtitle: PropTypes.string,
   type: PropTypes.oneOf(['page', 'form-group']),
   'data-name': PropTypes.string,
-  titleSize: PropTypes.oneOf(['standard', 'standard-light-weight', 'medium', 'small']),
+  titleSize: PropTypes.oneOf(['xl-strong', 'standard', 'standard-light-weight', 'medium', 'small']),
   subtitleSize: PropTypes.oneOf([
     'standard',
     'standard-without-margin',
+    'medium',
     'small',
     'small-without-margin',
     'extra-small'

--- a/packages/@coorpacademy-components/src/atom/title/index.js
+++ b/packages/@coorpacademy-components/src/atom/title/index.js
@@ -17,7 +17,7 @@ const getTitleStyle = (type, size) => {
         case 'standard-light-weight':
           return style.titleFormGroupLightWeight;
         case 'xl-strong':
-          return style.XlStrongTitle;
+          return style.xlStrongTitle;
         case 'medium':
           return style.mediumTitleFormGroup;
         case 'small':

--- a/packages/@coorpacademy-components/src/atom/title/style.css
+++ b/packages/@coorpacademy-components/src/atom/title/style.css
@@ -1,59 +1,66 @@
 @value colors: "../../variables/colors.css";
-@value cm_grey_700 from colors;
 @value cm_grey_400 from colors;
+@value cm_grey_700 from colors;
 
 .container {
-    display: flex;
-    gap: 12px;
+  display: flex;
+  gap: 12px;
 }
 
 .title {
-    font-family: Gilroy;
-    font-style: normal;
-    font-weight: bold;
-    color: cm_grey_700;
+  font-family: Gilroy;
+  font-style: normal;
+  font-weight: bold;
+  color: cm_grey_700;
 }
 
 .titleContainer {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
 }
 
 .titlePage {
-    composes: title;
-    font-size: 32px;
-    line-height: 52px;
+  composes: title;
+  font-size: 32px;
+  line-height: 52px;
 }
 
 .titleFormGroup {
-    composes: title;
-    font-size: 18px;
-    display: flex;
-    align-items: center;
-    gap: 4px;
+  composes: title;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .titleFormGroupLightWeight {
-    composes: titleFormGroup;
-    font-weight: normal;
+  composes: titleFormGroup;
+  font-weight: normal;
+}
+
+.XlStrongTitle {
+  composes: title;
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 28px;
 }
 
 .mediumTitleFormGroup {
-    composes: title;
-    font-size: 16px;
+  composes: title;
+  font-size: 16px;
 }
 
 .smallTitleFormGroup {
-    composes: title;
-    font-size: 14px;
+  composes: title;
+  font-size: 14px;
 }
 
 .subtitle {
-    font-family: Gilroy;
-    font-style: normal;   
+  font-family: Gilroy;
+  font-style: normal;
 }
 
 .subtitleWithMargin {
@@ -62,47 +69,52 @@
 }
 
 .subtitlePage {
-    composes: subtitleWithMargin;
-    font-weight: normal;
-    font-size: 18px;
-    line-height: 24px;
-    color: cm_grey_700;
+  composes: subtitleWithMargin;
+  font-weight: normal;
+  font-size: 18px;
+  line-height: 24px;
+  color: cm_grey_700;
 }
 
 .subtitleFormGroup {
-    composes: subtitleWithMargin;
-    font-size: 14px;
-    font-weight: 400;
-    line-height: 20px;
-    color: cm_grey_400;
+  composes: subtitleWithMargin;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  color: cm_grey_400;
 }
 
 .subtitleFormGroupWithoutMargin {
-    composes: subtitleFormGroup;
-    font-weight: 500;
-    margin: 0;
+  composes: subtitleFormGroup;
+  font-weight: 500;
+  margin: 0;
 }
 
-.smallSubtitleFormGroup{
-    composes: subtitleFormGroup;
-    max-width: 455px;
+.mediumSubtitleFormGroup {
+  composes: subtitleFormGroup;
+  font-weight: 600;
+  margin: 0;
 }
 
-.smallSubtitleFormGroupWithoutMargin{
-    composes: smallSubtitleFormGroup;
-    margin: 0;  
+.smallSubtitleFormGroup {
+  composes: subtitleFormGroup;
+  max-width: 455px;
 }
 
-.extraSmallSubtitleFormGroup{
-    composes: subtitle;
-    font-size: 12px;
-    color: cm_grey_400;
-    line-height: 16px;
-    font-weight: normal;
+.smallSubtitleFormGroupWithoutMargin {
+  composes: smallSubtitleFormGroup;
+  margin: 0;
+}
+
+.extraSmallSubtitleFormGroup {
+  composes: subtitle;
+  font-size: 12px;
+  color: cm_grey_400;
+  line-height: 16px;
+  font-weight: normal;
 }
 
 .icon {
-    height: 24px;
-    width: 24px;
+  height: 24px;
+  width: 24px;
 }
-

--- a/packages/@coorpacademy-components/src/atom/title/style.css
+++ b/packages/@coorpacademy-components/src/atom/title/style.css
@@ -41,7 +41,7 @@
   font-weight: normal;
 }
 
-.XlStrongTitle {
+.xlStrongTitle {
   composes: title;
   font-size: 20px;
   font-weight: 700;

--- a/packages/@coorpacademy-components/src/molecule/button-menu-action/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/button-menu-action/index.tsx
@@ -1,0 +1,48 @@
+import React, {useCallback, useEffect, useState} from 'react';
+import classnames from 'classnames';
+import {noop} from 'lodash/fp';
+import ButtonLink from '../../atom/button-link';
+import ButtonMenu from '../../atom/button-menu';
+import propTypes, {ButtonMenuActionProps} from './types';
+import style from './style.css';
+
+const ButtonMenuAction = (props: ButtonMenuActionProps) => {
+  const {button, menu, menuWrapper} = props;
+  const {onClick = noop} = button;
+  const [visible, setVisible] = useState(false);
+
+  const toggleVisibility = useCallback(() => {
+    onClick();
+    setVisible(prevState => !prevState);
+  }, [onClick]);
+
+  useEffect(() => {
+    const handleMouseDown = () => setVisible(false);
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, []);
+
+  const _menu = (
+    <div
+      className={classnames(style.menuWrapper, visible && style.visible)}
+      data-name="menu-wrapper"
+      aria-label={menuWrapper?.ariaLabel}
+      style={menuWrapper?.customStyle}
+    >
+      <ButtonMenu {...menu} />
+    </div>
+  );
+
+  return (
+    <div className={style.container} data-name="button-menu-action-wrapper">
+      <ButtonLink {...button} onClick={toggleVisibility} />
+      {_menu}
+    </div>
+  );
+};
+
+ButtonMenuAction.propTypes = propTypes;
+
+export default ButtonMenuAction;

--- a/packages/@coorpacademy-components/src/molecule/button-menu-action/style.css
+++ b/packages/@coorpacademy-components/src/molecule/button-menu-action/style.css
@@ -1,4 +1,3 @@
-
 .container {
   display: flex;
   flex-direction: column;

--- a/packages/@coorpacademy-components/src/molecule/button-menu-action/style.css
+++ b/packages/@coorpacademy-components/src/molecule/button-menu-action/style.css
@@ -1,0 +1,34 @@
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  position: relative;
+}
+
+.menuWrapper {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 50px;
+  z-index: 99;
+  padding: 12px;
+  background: white;
+  box-shadow: 0px 2px 8px 0px rgba(0, 0, 0, 0.07);
+  border-radius: 12px;
+  transition: visibility 0.5s ease, opacity 0.3s ease, max-height 0.3s ease;
+  background-color: white;
+  visibility: hidden;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.menuWrapper > button {
+  cursor: pointer;
+}
+
+.visible {
+  visibility: visible;
+  opacity: 1;
+  overflow-y: auto;
+}

--- a/packages/@coorpacademy-components/src/molecule/button-menu-action/test/button-menu-action.tsx
+++ b/packages/@coorpacademy-components/src/molecule/button-menu-action/test/button-menu-action.tsx
@@ -1,0 +1,84 @@
+import test from 'ava';
+import browserEnv from 'browser-env';
+import React from 'react';
+import {fireEvent, render} from '@testing-library/react';
+import ButtonMenuAction from '..';
+import defaultFixture from './fixtures/default';
+
+browserEnv();
+
+test('should toggle visibility of the menu on button click', t => {
+  t.plan(6);
+
+  const props = {
+    ...defaultFixture.props,
+    button: {...defaultFixture.props.button, onClick: () => t.pass()}
+  };
+  const {container} = render(<ButtonMenuAction {...props} />);
+
+  const button = container.querySelector('[data-name="button-menu-action"]') as Element;
+  t.truthy(button, 'Button should be in the document');
+
+  fireEvent.click(button);
+
+  const menu = container.querySelector('[data-name="menu-wrapper"]') as Element;
+  t.truthy(menu, 'Menu should be in the document when the button is clicked');
+
+  fireEvent.click(button);
+
+  t.false(menu.classList.contains('visible'), 'Menu should be hidden after second click');
+
+  t.pass();
+});
+
+test('should close the menu when clicking outside', t => {
+  t.plan(5);
+
+  const props = {
+    ...defaultFixture.props,
+    button: {...defaultFixture.props.button, onClick: () => t.pass()}
+  };
+  const {container} = render(<ButtonMenuAction {...props} />);
+
+  const button = container.querySelector('[data-name="button-menu-action"]') as Element;
+  t.truthy(button);
+
+  fireEvent.click(button);
+
+  const menu = container.querySelector('[data-name="menu-wrapper"]') as Element;
+  t.truthy(menu, 'Menu should be visible after button click');
+
+  fireEvent.mouseDown(document.body);
+
+  t.false(menu.classList.contains('visible'), 'Menu should be hidden after clicking outside');
+
+  t.pass();
+});
+
+test('should find the button menu and have clickable buttons', t => {
+  t.plan(6);
+
+  const props = {
+    button: {...defaultFixture.props.button, onClick: () => t.pass()},
+    menu: {
+      ...defaultFixture.props.menu,
+      buttons: [{...defaultFixture.props.menu.buttons[0], onClick: () => t.pass()}]
+    }
+  };
+
+  const {container} = render(<ButtonMenuAction {...props} />);
+
+  const button = container.querySelector('[data-name="button-menu-action"]') as Element;
+  t.truthy(button);
+
+  fireEvent.click(button);
+
+  const menu = container.querySelector('[data-name="menu-wrapper"]') as Element;
+  t.truthy(menu, 'Menu should be visible after button click');
+
+  const labelFrenchButton = menu.querySelector('[data-name="label-french-button"]') as Element;
+  t.truthy(labelFrenchButton);
+
+  fireEvent.click(labelFrenchButton);
+  t.pass();
+});

--- a/packages/@coorpacademy-components/src/molecule/button-menu-action/test/button-menu-action.tsx
+++ b/packages/@coorpacademy-components/src/molecule/button-menu-action/test/button-menu-action.tsx
@@ -17,16 +17,16 @@ test('should toggle visibility of the menu on button click', t => {
   const {container} = render(<ButtonMenuAction {...props} />);
 
   const button = container.querySelector('[data-name="button-menu-action"]') as Element;
-  t.truthy(button, 'Button should be in the document');
+  t.truthy(button);
 
   fireEvent.click(button);
 
   const menu = container.querySelector('[data-name="menu-wrapper"]') as Element;
-  t.truthy(menu, 'Menu should be in the document when the button is clicked');
+  t.truthy(menu);
 
   fireEvent.click(button);
 
-  t.false(menu.classList.contains('visible'), 'Menu should be hidden after second click');
+  t.false(menu.classList.contains('visible'));
 
   t.pass();
 });
@@ -46,11 +46,11 @@ test('should close the menu when clicking outside', t => {
   fireEvent.click(button);
 
   const menu = container.querySelector('[data-name="menu-wrapper"]') as Element;
-  t.truthy(menu, 'Menu should be visible after button click');
+  t.truthy(menu);
 
   fireEvent.mouseDown(document.body);
 
-  t.false(menu.classList.contains('visible'), 'Menu should be hidden after clicking outside');
+  t.false(menu.classList.contains('visible'));
 
   t.pass();
 });
@@ -74,7 +74,7 @@ test('should find the button menu and have clickable buttons', t => {
   fireEvent.click(button);
 
   const menu = container.querySelector('[data-name="menu-wrapper"]') as Element;
-  t.truthy(menu, 'Menu should be visible after button click');
+  t.truthy(menu);
 
   const labelFrenchButton = menu.querySelector('[data-name="label-french-button"]') as Element;
   t.truthy(labelFrenchButton);

--- a/packages/@coorpacademy-components/src/molecule/button-menu-action/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/molecule/button-menu-action/test/fixtures/default.ts
@@ -17,21 +17,21 @@ const defaultFixture: ButtonMenuActionPropsFixture = {
       'aria-label': 'aria button',
       'data-name': 'button-menu-action',
       onClick: () => console.log('click on Add translations button'),
-      hoverBackgroundColor: COLORS.primary_weak_hover,
-      hoverColor: COLORS.primary_strong,
+      hoverBackgroundColor: COLORS.primary_100,
+      hoverColor: COLORS.cm_primary_blue,
       icon: {
         position: 'left',
         faIcon: {
           name: 'plus',
-          color: COLORS.primary_strong,
+          color: COLORS.cm_primary_blue,
           size: 14,
           customStyle: {padding: 0}
         }
       },
       customStyle: {
         width: 'fit-content',
-        backgroundColor: COLORS.primary_weak,
-        color: COLORS.primary_strong,
+        backgroundColor: COLORS.cm_blue_50,
+        color: COLORS.cm_primary_blue,
         borderRadius: '12px',
         paddingRight: '8px',
         paddingleft: '16px',

--- a/packages/@coorpacademy-components/src/molecule/button-menu-action/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/molecule/button-menu-action/test/fixtures/default.ts
@@ -1,0 +1,59 @@
+import {COLORS} from '../../../../variables/colors';
+import {ButtonMenuActionPropsFixture} from '../../types';
+import {ButtonProps} from '../../../../atom/button-menu/types';
+
+const buttonBase: ButtonProps = {
+  type: 'defaultLeft',
+  onClick: () => console.log('click'),
+  customStyle: {width: '238px'},
+  label: ''
+};
+
+const defaultFixture: ButtonMenuActionPropsFixture = {
+  props: {
+    button: {
+      type: 'primary',
+      label: 'Add translation',
+      'aria-label': 'aria button',
+      'data-name': 'button-menu-action',
+      onClick: () => console.log('click on Add translations button'),
+      hoverBackgroundColor: COLORS.primary_weak_hover,
+      hoverColor: COLORS.primary_strong,
+      icon: {
+        position: 'left',
+        faIcon: {
+          name: 'plus',
+          color: COLORS.primary_strong,
+          size: 14,
+          customStyle: {padding: 0}
+        }
+      },
+      customStyle: {
+        width: 'fit-content',
+        backgroundColor: COLORS.primary_weak,
+        color: COLORS.primary_strong,
+        borderRadius: '12px',
+        paddingRight: '8px',
+        paddingleft: '16px',
+        fontWeight: 600
+      }
+    },
+    menu: {
+      buttons: [
+        {...buttonBase, label: '🇫🇷 French', 'data-name': 'label-french-button', disabled: true},
+        {...buttonBase, label: '🇪🇸 Spanish'},
+        {...buttonBase, label: '🇮🇹 Italian'},
+        {...buttonBase, label: '🇩🇪 German'},
+        {...buttonBase, label: '🇷🇺 Russian'},
+        {...buttonBase, label: '🇵🇱 Polish'},
+        {...buttonBase, label: '🇹🇷 Turkish'}
+      ]
+    },
+
+    menuWrapper: {
+      customStyle: {maxHeight: '252px'}
+    }
+  }
+};
+
+export default defaultFixture;

--- a/packages/@coorpacademy-components/src/molecule/button-menu-action/types.ts
+++ b/packages/@coorpacademy-components/src/molecule/button-menu-action/types.ts
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import ButtonLinkPropTypes, {ButtonLinkProps} from '../../atom/button-link/types';
+import ButtonMenuPropTypes, {ButtonMenuProps} from '../../atom/button-menu/types';
+
+const ButtonMenuActionPropTypes = {
+  button: PropTypes.shape(ButtonLinkPropTypes).isRequired,
+  menu: PropTypes.shape(ButtonMenuPropTypes).isRequired,
+  menuWrapper: PropTypes.shape({
+    ariaLabel: PropTypes.string,
+    customStyle: PropTypes.objectOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object])
+    )
+  })
+};
+export default ButtonMenuActionPropTypes;
+
+export type ButtonMenuActionProps = {
+  button: ButtonLinkProps;
+  menu: ButtonMenuProps;
+  menuWrapper?: {
+    ariaLabel?: string;
+    customStyle?: Record<string, unknown>;
+  };
+};
+
+export type ButtonMenuActionPropsFixture = {props: ButtonMenuActionProps};

--- a/packages/@coorpacademy-components/src/organism/list-items/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/index.js
@@ -88,7 +88,9 @@ const buildEmptyResultView = emptyResult => {
     <div className={style.emptySearchResultContainer}>
       <div className={style.emptySearchResultTitle}>{title}</div>
       <div className={style.emptySearchResultDescription}>{description}</div>
-      <ButtonLink {...button} className={style.emptySearchResultButton} />
+      <div className={style.emptySearchResultButton}>
+        {button?.menu ? <ButtonMenuAction {...button} /> : <ButtonLink {...button} />}
+      </div>
     </div>
   );
 };
@@ -172,7 +174,7 @@ ListItems.propTypes = {
       emptyResult: PropTypes.shape({
         title: PropTypes.string,
         description: PropTypes.string,
-        button: PropTypes.shape(ButtonLink.propTypes)
+        button: PropTypes.oneOfType([ButtonLink.propTypes, ButtonMenuAction.propTypes])
       })
     }),
     PropTypes.shape({

--- a/packages/@coorpacademy-components/src/organism/list-items/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/index.js
@@ -12,7 +12,22 @@ import ExpandibleActionableTable from '../../molecule/expandible-actionable-tabl
 import Loader from '../../atom/loader';
 import Search from '../../atom/input-search';
 import CheckboxWithTitle from '../../atom/checkbox-with-title';
+import ButtonMenuAction from '../../molecule/button-menu-action';
 import style from './style.css';
+
+const buildTitleView = title => {
+  if (typeof title === 'string') {
+    return (
+      <Title
+        title={title}
+        type="form-group"
+        titleSize="standard-light-weight"
+        data-name="list-title"
+      />
+    );
+  }
+  return <Title {...title} />;
+};
 
 const buildListItemsView = (content, ariaLabel, selectMultiple) => {
   const {items, itemType, onDrop, isDraggable = false, tableHeader} = content;
@@ -73,12 +88,7 @@ const buildEmptyResultView = emptyResult => {
     <div className={style.emptySearchResultContainer}>
       <div className={style.emptySearchResultTitle}>{title}</div>
       <div className={style.emptySearchResultDescription}>{description}</div>
-      <ButtonLink
-        type="text"
-        label={button.label}
-        onClick={button.handleSearchReset}
-        className={style.emptySearchResultButton}
-      />
+      <ButtonLink {...button} className={style.emptySearchResultButton} />
     </div>
   );
 };
@@ -107,9 +117,11 @@ const ListItems = ({
   isFetching,
   search,
   checkboxWithTitle,
-  actionButtons
+  actionButtons,
+  buttonMenuAction
 }) => {
   const contentView = buildContentView(content, ariaLabel, selectMultiple);
+  const titleView = buildTitleView(title);
   return (
     <div>
       <div className={style.header}>
@@ -119,14 +131,7 @@ const ListItems = ({
             {actionButtons ? map(action => <ButtonLink {...action} />)(actionButtons) : null}
           </div>
         ) : (
-          <div className={style.title}>
-            <Title
-              title={title}
-              type="form-group"
-              titleSize="standard-light-weight"
-              data-name="list-title"
-            />
-          </div>
+          <div className={style.title}>{titleView}</div>
         )}
         <div className={style.inputWrapper}>
           {!isEmpty(search) ? <Search {...search} /> : null}
@@ -138,6 +143,7 @@ const ListItems = ({
             ) : null}
             {!isEmpty(buttonLink) ? <ButtonLink {...buttonLink} /> : null}
           </div>
+          {buttonMenuAction ? <ButtonMenuAction {...buttonMenuAction} /> : null}
         </div>
       </div>
       {isFetching ? (
@@ -174,11 +180,12 @@ ListItems.propTypes = {
       type: PropTypes.oneOf(['expandible-actionable-table'])
     })
   ]),
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.shape(Title.propTypes)]),
   isFetching: PropTypes.bool,
   search: PropTypes.shape(Search.propTypes),
   checkboxWithTitle: PropTypes.shape(CheckboxWithTitle.propTypes),
-  actionButtons: PropTypes.arrayOf(PropTypes.shape(ButtonLink.propTypes))
+  actionButtons: PropTypes.arrayOf(PropTypes.shape(ButtonLink.propTypes)),
+  buttonMenuAction: PropTypes.shape(ButtonMenuAction.propTypes)
 };
 
 export default ListItems;

--- a/packages/@coorpacademy-components/src/organism/list-items/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/index.js
@@ -174,7 +174,10 @@ ListItems.propTypes = {
       emptyResult: PropTypes.shape({
         title: PropTypes.string,
         description: PropTypes.string,
-        button: PropTypes.oneOfType([ButtonLink.propTypes, ButtonMenuAction.propTypes])
+        button: PropTypes.oneOfType([
+          PropTypes.shape(ButtonLink.propTypes),
+          PropTypes.shape(ButtonMenuAction.propTypes)
+        ])
       })
     }),
     PropTypes.shape({

--- a/packages/@coorpacademy-components/src/organism/list-items/style.css
+++ b/packages/@coorpacademy-components/src/organism/list-items/style.css
@@ -70,7 +70,6 @@
   padding: 8px 24px;
 }
 
-
 .tableHeaderItem {
   display: flex;
   flex: 1 0 0;

--- a/packages/@coorpacademy-components/src/organism/list-items/style.css
+++ b/packages/@coorpacademy-components/src/organism/list-items/style.css
@@ -124,7 +124,7 @@
   align-items: center;
   color: cm_grey_700;
   font-family: Gilroy;
-  margin-top: 40px;
+  margin-top: 64px;
 }
 
 .emptySearchResultTitle {

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill-empty.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/content-skill-empty.js
@@ -16,7 +16,11 @@ export default {
       emptyResult: {
         title: 'No results...',
         description: 'Try adjusting your search to find what you are looking for.',
-        button: {label: 'Clear search', handleSearchReset: () => console.log('clear search')}
+        button: {
+          type: 'text',
+          label: 'Clear search',
+          onClick: () => console.log('clear search')
+        }
       }
     },
     search: {...searchProps.props, value: 'qfqdf', placeholder: 'Search content'}

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/translations-empty.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/translations-empty.js
@@ -1,0 +1,25 @@
+import buttonMenuAction from '../../../../molecule/button-menu-action/test/fixtures/default';
+
+export default {
+  props: {
+    title: {
+      title: 'Translations',
+      type: 'form-group',
+      'data-name': 'list-title',
+      subtitle: 'Manage your translation to reach more learners',
+      titleSize: 'xl-strong',
+      subtitleSize: 'medium'
+    },
+    'aria-label': 'aria list',
+    content: {
+      items: [],
+      type: 'list',
+      emptyResult: {
+        title: 'No translations for this skill yet',
+        description: 'No translations for this skill yet. Click ‘Add translation’ to get started.',
+        button: buttonMenuAction.props
+      }
+    },
+    buttonMenuAction: buttonMenuAction.props
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/translations-empty.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/translations-empty.js
@@ -1,16 +1,9 @@
 import buttonMenuAction from '../../../../molecule/button-menu-action/test/fixtures/default';
+import translations from './translations';
 
 export default {
   props: {
-    title: {
-      title: 'Translations',
-      type: 'form-group',
-      'data-name': 'list-title',
-      subtitle: 'Manage your translation to reach more learners',
-      titleSize: 'xl-strong',
-      subtitleSize: 'medium'
-    },
-    'aria-label': 'aria list',
+    ...translations.props,
     content: {
       items: [],
       type: 'list',
@@ -19,7 +12,6 @@ export default {
         description: 'No translations for this skill yet. Click ‘Add translation’ to get started.',
         button: buttonMenuAction.props
       }
-    },
-    buttonMenuAction: buttonMenuAction.props
+    }
   }
 };

--- a/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/translations.js
+++ b/packages/@coorpacademy-components/src/organism/list-items/test/fixtures/translations.js
@@ -1,0 +1,21 @@
+import translation from '../../../list-item/test/fixtures/translation';
+import buttonMenuAction from '../../../../molecule/button-menu-action/test/fixtures/default';
+
+export default {
+  props: {
+    title: {
+      title: 'Translations',
+      type: 'form-group',
+      'data-name': 'list-title',
+      subtitle: 'Manage your translation to reach more learners',
+      titleSize: 'xl-strong',
+      subtitleSize: 'medium'
+    },
+    'aria-label': 'aria list',
+    content: {
+      items: [{...translation.props}],
+      type: 'list'
+    },
+    buttonMenuAction: buttonMenuAction.props
+  }
+};

--- a/packages/@coorpacademy-components/src/variables/colors.css
+++ b/packages/@coorpacademy-components/src/variables/colors.css
@@ -77,7 +77,7 @@
 @value box_shadow_light_dark: rgba(0, 0, 0, 0.12);
 @value box_shadow_medium_dark: rgba(0, 0, 0, 0.2);
 @value box_shadow_orange_700: rgba(255, 84, 31, 0.15);
-@value box_shadow_blue_700: rgba(0, 66, 173, 0.15); ;
+@value box_shadow_blue_700: rgba(0, 66, 173, 0.15);
 
 @value light_blue: #ADC9F5;
 @value negative_100: #FCDADA;

--- a/packages/@coorpacademy-components/src/variables/colors.ts
+++ b/packages/@coorpacademy-components/src/variables/colors.ts
@@ -7,11 +7,15 @@ export const COLORS = {
   white: '#ffffff',
   cm_grey_400: '#9999A8',
   cm_grey_800: '#171721',
+  cm_blue_50: '#f1f6fe',
   cm_primary_blue: '#0061FF',
   cm_grey_500: '#515161',
   cm_grey_700: '#1D1D2B',
   cm_yellow_400: '#bd7e00',
-  brand: '#00B0FF'
+  brand: '#00B0FF',
+  primary_weak: '#F1F6FE',
+  primary_weak_hover: '#D6E6FF',
+  primary_strong: '#0061FF'
 } as const;
 
 export type Colors = typeof COLORS;

--- a/packages/@coorpacademy-components/src/variables/colors.ts
+++ b/packages/@coorpacademy-components/src/variables/colors.ts
@@ -5,16 +5,15 @@ export const COLORS = {
   positive: '#35CC7F',
   cm_positive_200: '#05944F',
   white: '#ffffff',
+  cm_blue_50: '#f1f6fe',
   cm_grey_400: '#9999A8',
   cm_grey_800: '#171721',
   cm_primary_blue: '#0061FF',
+  primary_100: '#D6E6FF',
   cm_grey_500: '#515161',
   cm_grey_700: '#1D1D2B',
   cm_yellow_400: '#bd7e00',
-  brand: '#00B0FF',
-  primary_weak: '#F1F6FE',
-  primary_weak_hover: '#D6E6FF',
-  primary_strong: '#0061FF'
+  brand: '#00B0FF'
 } as const;
 
 export type Colors = typeof COLORS;

--- a/packages/@coorpacademy-components/src/variables/colors.ts
+++ b/packages/@coorpacademy-components/src/variables/colors.ts
@@ -7,7 +7,6 @@ export const COLORS = {
   white: '#ffffff',
   cm_grey_400: '#9999A8',
   cm_grey_800: '#171721',
-  cm_blue_50: '#f1f6fe',
   cm_primary_blue: '#0061FF',
   cm_grey_500: '#515161',
   cm_grey_700: '#1D1D2B',


### PR DESCRIPTION
**Detailed purpose of the PR**
Jira [ticket](https://go1web.atlassian.net/browse/CLXP-268) linked to the ticket [[SE Template] Skill edition page](https://go1web.atlassian.net/jira/software/projects/CLXP/boards/626?selectedIssue=CLXP-248)

- Create ButtonMenuAction component.
- Add new styles for Translation fixture in `Title` component.
- Update component organism `ListItems` to add `ButtonMenuAction `and to add a fixture for translation list.

**Result and observation**
-> https://6622682e70ecd8ecf5027fa1-zjizlujhex.chromatic.com/?path=/story/organism-listitems--translations

**`ButtonMenuAction`** 
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/23ca848b-e062-4ea2-ac8c-fd13d6032e5a" />

**`ListItems` - Translation fixture** 
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/dc8f25b4-53ea-4e91-a411-afcd587a8dc8" />

<img width="1503" alt="image" src="https://github.com/user-attachments/assets/b40b614c-704a-4e26-a746-d53a78fbce52" />


**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [x] Unit testing
