### PR TITLE
[WHO] update badge locale

### DIFF
--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -210,6 +210,9 @@
     },
     "mylcl-learning": {
        "diploma": "learning path"
+    },
+    "who": {
+      "badge": "Additional information about your certificate"
     }
   }
 }

--- a/packages/@coorpacademy-components/src/molecule/button-menu-action/test/button-menu-action.tsx
+++ b/packages/@coorpacademy-components/src/molecule/button-menu-action/test/button-menu-action.tsx
@@ -54,31 +54,3 @@ test('should close the menu when clicking outside', t => {
 
   t.pass();
 });
-
-test('should find the button menu and have clickable buttons', t => {
-  t.plan(6);
-
-  const props = {
-    button: {...defaultFixture.props.button, onClick: () => t.pass()},
-    menu: {
-      ...defaultFixture.props.menu,
-      buttons: [{...defaultFixture.props.menu.buttons[0], onClick: () => t.pass()}]
-    }
-  };
-
-  const {container} = render(<ButtonMenuAction {...props} />);
-
-  const button = container.querySelector('[data-name="button-menu-action"]') as Element;
-  t.truthy(button);
-
-  fireEvent.click(button);
-
-  const menu = container.querySelector('[data-name="menu-wrapper"]') as Element;
-  t.truthy(menu);
-
-  const labelFrenchButton = menu.querySelector('[data-name="label-french-button"]') as Element;
-  t.truthy(labelFrenchButton);
-
-  fireEvent.click(labelFrenchButton);
-  t.pass();
-});


### PR DESCRIPTION
[IDEA 6129 - WHO - correction wording badge to download](https://app.prodpad.com/ideas/6129/canvas)
Hello,
Nous avons mis en place le wording custom pour ce client concernant le téléchargement du badge. En faite c'est le PDF avec les infos supp qui est téléchargé.  
Le problème est que le wording est sauté après la mise en prod de la nouvelle page Certification et je n'ai plus la main pour corriger.
Pouvez-vous svp récuperer le wording
**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
