### PR TITLE
 add cleanup observable and use it in generate stories

### DIFF
--- a/packages/@coorpacademy-components/scripts/observables/cleanup.js
+++ b/packages/@coorpacademy-components/scripts/observables/cleanup.js
@@ -1,0 +1,74 @@
+const {Observable} = require('rxjs');
+const {filter} = require('rxjs/operators');
+const {walkDirectory$} = require('./walk-directory'); // your existing directory walker
+const {readdir,unlink, rmdir, stat} = require('fs');
+const {dirname} = require('path');
+const {rm} = require('fs/promises'); 
+
+
+const readAllStoryFiles$ = (cwd) =>
+  walkDirectory$(cwd).pipe(
+    filter((filePath) => filePath.endsWith('.stories.tsx'))
+  );
+
+
+
+function removeEmptyFolders$(folderPath, removeParents = false) {
+  return new Observable((observer) => {
+    stat(folderPath, (statErr, stats) => {
+      if (statErr || !stats.isDirectory()) {
+        observer.complete();
+        return;
+      }
+      readdir(folderPath, (readErr, files) => {
+        if (readErr) {
+          observer.error(readErr);
+          return;
+        }
+        // Filter out system files if needed
+        files = files.filter((file) => file !== '.DS_Store');
+
+        if (files.length === 0) {
+          rmdir(folderPath, (rmdirErr) => {
+            if (rmdirErr) {
+              observer.error(rmdirErr);
+              return;
+            }
+            observer.next(folderPath);
+            if (removeParents && dirname(folderPath) !== folderPath) {
+              removeEmptyFolders$(dirname(folderPath), true).subscribe(
+                (val) => observer.next(val),
+                (err) => observer.error(err),
+                () => observer.complete()
+              );
+            } else {
+              observer.complete();
+            }
+          });
+        } else {
+          // Not empty
+          observer.complete();
+        }
+      });
+    });
+  });
+}
+
+
+/**
+ * Recursively deletes a folder (rm -rf).
+ */
+function deleteFolder$(folderPath) {
+  return new Observable((observer) => {
+    rm(folderPath, {recursive: true, force: true})
+      .then(() => {
+        observer.next(folderPath);
+        observer.complete();
+      })
+      .catch((err) => observer.error(err));
+  });
+}
+
+
+
+module.exports = {readAllStoryFiles$, deleteFolder$, removeEmptyFolders$};

--- a/packages/@coorpacademy-components/scripts/observables/cleanup.js
+++ b/packages/@coorpacademy-components/scripts/observables/cleanup.js
@@ -1,19 +1,16 @@
 const {Observable} = require('rxjs');
 const {filter} = require('rxjs/operators');
 const {walkDirectory$} = require('./walk-directory'); // your existing directory walker
-const {readdir,unlink, rmdir, stat} = require('fs');
+const {readdir, rmdir, stat} = require('fs');
 const {dirname} = require('path');
 const {rm} = require('fs/promises'); 
-
 
 const readAllStoryFiles$ = (cwd) =>
   walkDirectory$(cwd).pipe(
     filter((filePath) => filePath.endsWith('.stories.tsx'))
   );
 
-
-
-function removeEmptyFolders$(folderPath, removeParents = false) {
+const removeEmptyFolders$ = (folderPath, removeParents = false) => {
   return new Observable((observer) => {
     stat(folderPath, (statErr, stats) => {
       if (statErr || !stats.isDirectory()) {
@@ -54,11 +51,10 @@ function removeEmptyFolders$(folderPath, removeParents = false) {
   });
 }
 
-
 /**
  * Recursively deletes a folder (rm -rf).
  */
-function deleteFolder$(folderPath) {
+const  deleteFolder$ = (folderPath) => {
   return new Observable((observer) => {
     rm(folderPath, {recursive: true, force: true})
       .then(() => {
@@ -68,7 +64,5 @@ function deleteFolder$(folderPath) {
       .catch((err) => observer.error(err));
   });
 }
-
-
 
 module.exports = {readAllStoryFiles$, deleteFolder$, removeEmptyFolders$};

--- a/packages/@coorpacademy-components/scripts/observables/cleanup.js
+++ b/packages/@coorpacademy-components/scripts/observables/cleanup.js
@@ -21,9 +21,9 @@ const removeEmptyFolders$ = (folderPath, removeParents = false) => {
           return;
         }
         // Filter out system files if needed
-        files = files.filter(file => file !== '.DS_Store');
+        const files_ = files.filter(file => file !== '.DS_Store');
 
-        if (files.length === 0) {
+        if (files_.length === 0) {
           rmdir(folderPath, rmdirErr => {
             if (rmdirErr) {
               observer.error(rmdirErr);
@@ -58,6 +58,7 @@ const deleteFolder$ = folderPath => {
       .then(() => {
         observer.next(folderPath);
         observer.complete();
+        return null;
       })
       .catch(err => observer.error(err));
   });

--- a/packages/@coorpacademy-components/scripts/observables/cleanup.js
+++ b/packages/@coorpacademy-components/scripts/observables/cleanup.js
@@ -1,17 +1,15 @@
+const {readdir, rmdir, stat} = require('fs');
+const {dirname} = require('path');
+const {rm} = require('fs/promises');
 const {Observable} = require('rxjs');
 const {filter} = require('rxjs/operators');
 const {walkDirectory$} = require('./walk-directory'); // your existing directory walker
-const {readdir, rmdir, stat} = require('fs');
-const {dirname} = require('path');
-const {rm} = require('fs/promises'); 
 
-const readAllStoryFiles$ = (cwd) =>
-  walkDirectory$(cwd).pipe(
-    filter((filePath) => filePath.endsWith('.stories.tsx'))
-  );
+const readAllStoryFiles$ = cwd =>
+  walkDirectory$(cwd).pipe(filter(filePath => filePath.endsWith('.stories.tsx')));
 
 const removeEmptyFolders$ = (folderPath, removeParents = false) => {
-  return new Observable((observer) => {
+  return new Observable(observer => {
     stat(folderPath, (statErr, stats) => {
       if (statErr || !stats.isDirectory()) {
         observer.complete();
@@ -23,10 +21,10 @@ const removeEmptyFolders$ = (folderPath, removeParents = false) => {
           return;
         }
         // Filter out system files if needed
-        files = files.filter((file) => file !== '.DS_Store');
+        files = files.filter(file => file !== '.DS_Store');
 
         if (files.length === 0) {
-          rmdir(folderPath, (rmdirErr) => {
+          rmdir(folderPath, rmdirErr => {
             if (rmdirErr) {
               observer.error(rmdirErr);
               return;
@@ -34,8 +32,8 @@ const removeEmptyFolders$ = (folderPath, removeParents = false) => {
             observer.next(folderPath);
             if (removeParents && dirname(folderPath) !== folderPath) {
               removeEmptyFolders$(dirname(folderPath), true).subscribe(
-                (val) => observer.next(val),
-                (err) => observer.error(err),
+                val => observer.next(val),
+                err => observer.error(err),
                 () => observer.complete()
               );
             } else {
@@ -49,20 +47,20 @@ const removeEmptyFolders$ = (folderPath, removeParents = false) => {
       });
     });
   });
-}
+};
 
 /**
  * Recursively deletes a folder (rm -rf).
  */
-const  deleteFolder$ = (folderPath) => {
-  return new Observable((observer) => {
+const deleteFolder$ = folderPath => {
+  return new Observable(observer => {
     rm(folderPath, {recursive: true, force: true})
       .then(() => {
         observer.next(folderPath);
         observer.complete();
       })
-      .catch((err) => observer.error(err));
+      .catch(err => observer.error(err));
   });
-}
+};
 
 module.exports = {readAllStoryFiles$, deleteFolder$, removeEmptyFolders$};

--- a/packages/@coorpacademy-components/scripts/observables/generate-stories.js
+++ b/packages/@coorpacademy-components/scripts/observables/generate-stories.js
@@ -4,16 +4,12 @@ const {map, toArray, mergeMap} = require('rxjs/operators');
 const {readComponentFixtures$} = require('./component-fixtures');
 const {pascalCase} = require('./string');
 const {readComponents$} = require('./components');
-const {
-  readAllStoryFiles$,
-  deleteFolder$,
-  removeEmptyFolders$
-} = require('./cleanup');
+const {readAllStoryFiles$, deleteFolder$, removeEmptyFolders$} = require('./cleanup');
 
 /**
  * Generate story files for all current components.
  */
-const generateStories$ = (cwd) => {
+const generateStories$ = cwd => {
   // 1) Build [storiesPath, lines$] pairs for each component
   const generation$ = readComponents$(cwd).pipe(
     map(({title, path, type, titleRaw, levels}) => {
@@ -59,11 +55,11 @@ export default {
 
   // 2) Remove stale story folders, then emit the new generation array
   return generation$.pipe(
-    mergeMap((storyEntries) => {
+    mergeMap(storyEntries => {
       const desiredStoryPaths = new Set(storyEntries.map(([p]) => p));
 
       return readAllStoryFiles$(cwd).pipe(
-        mergeMap((existingStoryPath) => {
+        mergeMap(existingStoryPath => {
           if (!desiredStoryPaths.has(existingStoryPath)) {
             // This story is stale
             const testFolder = dirname(existingStoryPath);

--- a/packages/@coorpacademy-components/scripts/observables/generate-stories.js
+++ b/packages/@coorpacademy-components/scripts/observables/generate-stories.js
@@ -18,7 +18,8 @@ const generateStories$ = cwd => {
 
       // 1) Read the fixtures once, share the results
       const fixtures$ = readComponentFixtures$({title, path, type}).pipe(
-        shareReplay(1) // caches and replays the emitted fixtures
+        shareReplay({bufferSize: Infinity, refCount: true})
+        // caches and replays the emitted fixtures
       );
 
       const fixtureImports$ = fixtures$.pipe(

--- a/packages/@coorpacademy-components/scripts/observables/generate-stories.js
+++ b/packages/@coorpacademy-components/scripts/observables/generate-stories.js
@@ -1,43 +1,87 @@
-const {join, relative} = require('path');
-const {map} = require('rxjs/operators');
-const {concat, of} = require('rxjs');
+// generate-stories.js
+const {join, dirname, relative} = require('path');
+const {of, from, concat} = require('rxjs');
+const {map, toArray, mergeMap} = require('rxjs/operators');
 const {readComponentFixtures$} = require('./component-fixtures');
 const {pascalCase} = require('./string');
 const {readComponents$} = require('./components');
+const {
+  readAllStoryFiles$,
+  deleteFolder$,
+  removeEmptyFolders$
+} = require('./cleanup');
 
-const generateStories$ = cwd =>
-  readComponents$(cwd).pipe(
+/**
+ * Generate story files for all current components.
+ */
+const generateStories$ = (cwd) => {
+  // 1) Build [storiesPath, lines$] pairs for each component
+  const generation$ = readComponents$(cwd).pipe(
     map(({title, path, type, titleRaw, levels}) => {
       const testPath = join(path, 'test');
       const storiesPath = join(testPath, 'index.stories.tsx');
-      return [
-        storiesPath,
-        concat(
-          of(`import React from 'react';`, `import ${title} from '..';`),
-          readComponentFixtures$({title, path, type}).pipe(
-            map(
-              ({fixture, fixturePath}) =>
-                `import fixture${fixture} from './${relative(testPath, fixturePath)}';`
-            )
-          ),
-          of(
-            `
+
+      // Observable that emits lines for fixture imports
+      const fixtureImports$ = readComponentFixtures$({title, path, type}).pipe(
+        map(
+          ({fixture, fixturePath}) =>
+            `import fixture${fixture} from './${relative(testPath, fixturePath)}';`
+        )
+      );
+
+      // Observable that emits lines for fixture exports
+      const fixtureExports$ = readComponentFixtures$({title, path, type}).pipe(
+        map(
+          ({fixture}) => `
+export const ${pascalCase(fixture)} = (args: any) => <${title} {...args} />;
+${pascalCase(fixture)}.args = fixture${fixture}.props;`
+        )
+      );
+
+      // Combine all lines in a single stream with concat()
+      const content$ = concat(
+        // 1) Basic imports
+        of(`import React from 'react';`, `import ${title} from '..';`),
+        // 2) Fixture imports
+        fixtureImports$,
+        // 3) Default export
+        of(`
 export default {
   title: '${[...levels.map(pascalCase), titleRaw].join('/')}',
   component: ${title}
-};`
-          ),
-          readComponentFixtures$({title, path, type}).pipe(
-            map(
-              ({fixture}) =>
-                `
-export const ${pascalCase(fixture)} = (args: any) => <${title} {...args} />;
-${pascalCase(fixture)}.args = fixture${fixture}.props;`
-            )
-          )
-        )
-      ];
-    })
+};`),
+        // 4) Fixture exports
+        fixtureExports$
+      );
+
+      return [storiesPath, content$];
+    }),
+    toArray() // gather all story definitions into an array
   );
 
-module.exports.generateStories$ = generateStories$;
+  // 2) Remove stale story folders, then emit the new generation array
+  return generation$.pipe(
+    mergeMap((storyEntries) => {
+      const desiredStoryPaths = new Set(storyEntries.map(([p]) => p));
+
+      return readAllStoryFiles$(cwd).pipe(
+        mergeMap((existingStoryPath) => {
+          if (!desiredStoryPaths.has(existingStoryPath)) {
+            // This story is stale
+            const testFolder = dirname(existingStoryPath);
+            const parentFolder = dirname(testFolder);
+            return deleteFolder$(testFolder).pipe(
+              mergeMap(() => removeEmptyFolders$(parentFolder, true))
+            );
+          }
+          return of(null);
+        }),
+        toArray(),
+        // 3) Finally, emit the storyEntries array for the rest of the pipeline (writing files, etc.)
+        mergeMap(() => from(storyEntries))
+      );
+    })
+  );
+};
+
+module.exports = {generateStories$};

--- a/packages/@coorpacademy-components/scripts/observables/generate-stories.js
+++ b/packages/@coorpacademy-components/scripts/observables/generate-stories.js
@@ -1,4 +1,3 @@
-// generate-stories.js
 const {join, dirname, relative} = require('path');
 const {of, from, concat} = require('rxjs');
 const {map, toArray, mergeMap} = require('rxjs/operators');
@@ -29,7 +28,6 @@ const generateStories$ = (cwd) => {
         )
       );
 
-      // Observable that emits lines for fixture exports
       const fixtureExports$ = readComponentFixtures$({title, path, type}).pipe(
         map(
           ({fixture}) => `


### PR DESCRIPTION
 <!-- Before creating your PR :
 - Have you added a Modification Type Label ?
 - Did you use the trello power up to link your PR and the trello ticket ?
-->

**Detailed purpose of the PR**

- Update the generate storybook script and specifly the generated stories to support the removal of stale folder & stories files for stale components ( often the case when having multiple PR to review and switching back and forth to use the storybook
<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [x] Manual testing
- [ ] Unit testing
