### PR TITLE
singular support in certification detail page

### DIFF
--- a/packages/@coorpacademy-components/locales/en/global.json
+++ b/packages/@coorpacademy-components/locales/en/global.json
@@ -78,9 +78,10 @@
   "learning_priorities_brand_description": "Define learning priorities for your company with skills, playlists or certifications. They will appear on the My Learning page.",
   "media_stars_to_win_plural": "Win {{count}} additional stars in this chapter the first time you view a lesson!",
   "media_stars_to_win": "Win {{count}} additional star in this chapter the first time you view a lesson!",
-  "modules": "Modules",
-  "modules_completed": "modules completed",
-  "modules_completed_mandatory": "mandatory modules completed",
+  "modules": "{{count}} module",
+  "modules_plural": "{{count}} modules",
+  "modules_completed_mandatory": "<span data-name=\"progress-stats\" style=\"color=#515161;padding-right: 4px;\">{{count}}/{{total}}</span> mandatory module completed",
+  "modules_completed_mandatory_plural": "<span data-name=\"progress-stats\" style=\"color=#515161;padding-right: 4px;\">{{count}}/{{total}}</span> mandatory modules completed",
   "More": "More",
   "More details": "More details",
   "New media": "New lesson",
@@ -215,9 +216,10 @@
       "badge": "Additional information about your certificate"
     },
     "css": {
-      "modules": "Levels",
-      "modules_completed": "levels completed",
-      "modules_completed_mandatory": "mandatory levels completed",
+      "modules": "{{count}} level",
+      "modules_plural": "{{count}} levels",
+      "modules_completed_mandatory": "<span data-name=\"progress-stats\" style=\"color=#515161;padding-right: 4px;\">{{count}}/{{total}}</span> mandatory level completed",
+      "modules_completed_mandatory_plural": "<span data-name=\"progress-stats\" style=\"color=#515161;padding-right: 4px;\">{{count}}/{{total}}</span> mandatory levels completed",
       "certification_module": "level to complete"
     }
   }

--- a/packages/@coorpacademy-components/src/molecule/progress-wrapper/index.js
+++ b/packages/@coorpacademy-components/src/molecule/progress-wrapper/index.js
@@ -114,7 +114,10 @@ const ProgressWrapper = (
   context
 ) => {
   const {translate} = context;
-  const mandatoryCompletedModulesLocale = translate('modules_completed_mandatory');
+  const mandatoryCompletedModulesLocale = translate('modules_completed_mandatory', {
+    total: mandatoryModules,
+    count: completedModules > mandatoryModules ? mandatoryModules : completedModules
+  });
   const isLocked = progression !== 100;
 
   return (
@@ -128,14 +131,10 @@ const ProgressWrapper = (
       </div>
       <div className={style.statscontainer}>
         <div className={style.stats}>
-          <div>
-            <span className={style.statsNumber} data-name="progress-stats">
-              {`${
-                completedModules > mandatoryModules ? mandatoryModules : completedModules
-              } / ${mandatoryModules}`}
-            </span>
-            {mandatoryCompletedModulesLocale}
-          </div>
+          <div
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{__html: mandatoryCompletedModulesLocale}}
+          />
         </div>
         <div className={style.progression}>
           <span className={style.statsNumber} data-name="progress-value">

--- a/packages/@coorpacademy-components/src/template/certification-detail/index.js
+++ b/packages/@coorpacademy-components/src/template/certification-detail/index.js
@@ -1,7 +1,7 @@
 import React, {useCallback, useEffect, useRef, useState, useMemo} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import {compact, lowerCase, round, isNil} from 'lodash/fp';
+import {compact, round, isNil} from 'lodash/fp';
 import Markdown from 'markdown-to-jsx';
 import Provider from '../../atom/provider';
 import Tag from '../../atom/tag';

--- a/packages/@coorpacademy-components/src/template/certification-detail/index.js
+++ b/packages/@coorpacademy-components/src/template/certification-detail/index.js
@@ -99,7 +99,7 @@ const CertificationDetail = (props, context) => {
               </>
             ) : null}
             <div className={style.contentStats}>
-              <span>{`${totalModules} ${lowerCase(translate('modules'))}`}</span>
+              <span>{`${translate('modules', {count: totalModules})}`}</span>
             </div>
             <ContinueLearningButton
               ongoingCoursesAvailable={ongoingCoursesAvailable}


### PR DESCRIPTION
[IDEA 6150 - All platforms - bug affichage en singulier page certification](https://app.prodpad.com/ideas/6150/canvas)
Hello,
Pouvez-vous svp ajouter l'affichage en singulier si le certificat est composé d'un seule cours ? merci bcp



**Detailed purpose of the PR**

<!--What existing problem does the PR solve?/
What is the current behavior? -->

**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
