### PR TITLE
Learning outcomes support on external course page

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/scope-content/index.js
+++ b/packages/@coorpacademy-components/src/molecule/scope-content/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {get, getOr} from 'lodash/fp';
+import {get, getOr, isEmpty} from 'lodash/fp';
 import Button from '../../atom/button';
 import Provider from '../../atom/provider';
 import Discussion from '../../organism/discussion';
@@ -56,7 +56,7 @@ const ScopeContent = (props, context) => {
   ) : null;
 
   return content && title ? (
-    <div data-name="scopeContent">
+    <div data-name="scopeContent" className={style.scopeContent}>
       <div data-name="description" className={style.desc}>
         <div className={style.infos}>
           <div className={style.title}>
@@ -73,19 +73,25 @@ const ScopeContent = (props, context) => {
           </div>
           {ctaView}
         </div>
-        <div className={style.skills}>
-          <div className={style.coltitle}>{skillsTitle}</div>
-          <ul className={style.dottedlist}>{skills}</ul>
-        </div>
-        <div className={style.column}>
-          <div className={style.coltitle}>{chaptersTitle}</div>
-          <div>
-            <ul className={style.roundedlist}>{chapters}</ul>
-          </div>
+        <div className={style.columnLayout}>
+          {isEmpty(skills) ? null : (
+            <div className={style.skills}>
+              <div className={style.coltitle}>{skillsTitle}</div>
+              <ul className={style.dottedlist}>{skills}</ul>
+            </div>
+          )}
+          {isEmpty(chapters) ? null : (
+            <div className={style.column}>
+              <div className={style.coltitle}>{chaptersTitle}</div>
+              <div>
+                <ul className={style.roundedlist}>{chapters}</ul>
+              </div>
+            </div>
+          )}
         </div>
       </div>
 
-      {_resources ? (
+      {!isEmpty(_resources) ? (
         <div data-name="description" className={style.bordered}>
           <ResourceBrowser resources={_resources} />
         </div>

--- a/packages/@coorpacademy-components/src/molecule/scope-content/style.css
+++ b/packages/@coorpacademy-components/src/molecule/scope-content/style.css
@@ -17,7 +17,16 @@
   border-right: solid 1px light;
   border-bottom: 1px solid light;
 }
+.scopeContent {
+  width: 100%;
+}
 
+.columnLayout {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: flex-start;
+}
 .infos {
   width: 100%;
   display: flex;
@@ -57,7 +66,7 @@
   box-sizing: border-box;
   display: inline-block;
   vertical-align: top;
-  width: 50%;
+  flex: 1 0 50%;
   font-family: "Gilroy";
   font-size: 12px;
   padding-right: 40px;

--- a/packages/@coorpacademy-components/src/molecule/scope-tabs/style.css
+++ b/packages/@coorpacademy-components/src/molecule/scope-tabs/style.css
@@ -25,7 +25,9 @@
   height: 50px;
   color: dark;
   background: xtraLightGrey;
-  border: 1px solid light;
+  border-bottom: 1px solid light;
+  border-right: 1px solid light;
+  border-left: 1px solid light;
   cursor: pointer;
   flex-direction: row;
   justify-content: center;

--- a/packages/@coorpacademy-components/src/template/common/discipline/index.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/index.js
@@ -11,6 +11,7 @@ import AddToMyList, {
   AddToMyListFeedback,
   AddToMyListStatusProvider
 } from '../../../molecule/add-to-my-list';
+import ScopeContent from '../../../molecule/scope-content';
 import style from './style.css';
 
 const Discipline = (props, context) => {
@@ -24,6 +25,7 @@ const Discipline = (props, context) => {
     video,
     authors = [],
     description = '',
+    content = null,
     start,
     buy,
     startLabel,
@@ -60,11 +62,20 @@ const Discipline = (props, context) => {
     />
   );
 
-  const disciplineContent = (
-    <div className={style.content}>
-      <DisciplineScope content={level} levels={levels} selected={selected} onClick={changeLevel} />
-    </div>
-  );
+  const disciplineContent =
+    content || !isEmpty(levels) ? (
+      <div className={style.content}>
+        {content ? <ScopeContent content={content} /> : null}
+        {!isEmpty(levels) ? (
+          <DisciplineScope
+            content={level}
+            levels={levels}
+            selected={selected}
+            onClick={changeLevel}
+          />
+        ) : null}
+      </div>
+    ) : null;
 
   const disciplineHeader = (
     <div className={style.header}>
@@ -192,6 +203,7 @@ Discipline.propTypes = {
   levels: DisciplineScope.propTypes.levels,
   selected: DisciplineScope.propTypes.selected,
   changeLevel: DisciplineScope.propTypes.onClick,
+  content: ScopeContent.propTypes.content,
   shareWording: Share.propTypes.wording,
   shareText: Share.propTypes.text,
   shareSuccessWording: ShareFeedback.propTypes.successWording,

--- a/packages/@coorpacademy-components/src/template/common/discipline/style.css
+++ b/packages/@coorpacademy-components/src/template/common/discipline/style.css
@@ -1,7 +1,9 @@
 @value breakpoints: "../../../variables/breakpoints.css";
+@value colors: "../../../variables/colors.css";
 @value desktop from breakpoints;
 @value mobile from breakpoints;
 @value wide from breakpoints;
+@value light from colors;
 
 .container {
   composes: wrapper from '../layout.css';
@@ -55,6 +57,10 @@
 .content {
   composes: column;
   width: 840px;
+}
+
+.content {
+  border-top: 1px solid light;
 }
 
 .cta,

--- a/packages/@coorpacademy-components/src/template/common/discipline/test/fixtures/external-course.js
+++ b/packages/@coorpacademy-components/src/template/common/discipline/test/fixtures/external-course.js
@@ -32,6 +32,14 @@ export default {
         locale: 'Skill 3'
       }
     ],
+    content: {
+      title: 'Les nouveaux business',
+      time: '2H20',
+      skills: [
+        'Connaître l’ensemble des leviers au service de la génération de trafic',
+        'Comprendre les différences entre les coûts media'
+      ]
+    },
     onSkillClick: () => console.log('skill clicked'),
     levels: [],
     level: {...props.content, title: null, discussion: {}}


### PR DESCRIPTION
[IDEA 6158 - Les objs pédagogiques des contenus externes peuvent-ils s'afficher dans la plateforme svp ?](https://app.prodpad.com/ideas/6158/canvas)
Tout est dans le titre hihi
<img width="1461" alt="Capture d’écran 2025-04-15 à 12 24 48" src="https://github.com/user-attachments/assets/f803eef6-1e44-4e6c-bfc9-013cbdc78bf2" />



**Result and observation**

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
