### PR TITLE
CLXP-302 - Modify the header for the skill edition page

### DIFF
--- a/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/custom-skill-draft.js
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/custom-skill-draft.js
@@ -27,11 +27,7 @@ export default {
         faIcon: {
           name: 'floppy-disk',
           color: 'white',
-          size: 14,
-          customStyle: {
-            padding: 0,
-            alignItems: 'baseline'
-          }
+          size: 14
         }
       },
       customStyle: {

--- a/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/custom-skill-draft.js
+++ b/packages/@coorpacademy-components/src/molecule/cm-popin/test/fixtures/custom-skill-draft.js
@@ -1,0 +1,42 @@
+export default {
+  props: {
+    content: 'Unsaved changes?',
+    descriptionText: 'Do you want to save in draft or discard before quitting?',
+    icon: {
+      iconName: 'circle-exclamation',
+      iconColor: '#A38300',
+      backgroundColor: '#FFF9D1',
+      preset: 'xl'
+    },
+    firstButton: {
+      label: 'Discard',
+      type: 'secondary',
+      'aria-label': 'Discard this operation',
+      handleOnClick: () => {},
+      customStyle: {
+        fontWeight: '600'
+      }
+    },
+    secondButton: {
+      label: 'Save in draft',
+      type: 'primary',
+      'aria-label': 'Save in draft this operation',
+      handleOnClick: () => {},
+      icon: {
+        position: 'left',
+        faIcon: {
+          name: 'floppy-disk',
+          color: 'white',
+          size: 14,
+          customStyle: {
+            padding: 0,
+            alignItems: 'baseline'
+          }
+        }
+      },
+      customStyle: {
+        fontWeight: '600'
+      }
+    }
+  }
+};

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
@@ -6,15 +6,93 @@ import ButtonLinkIcon from '../../atom/button-link-icon';
 import Tag from '../../atom/tag';
 import {ButtonLinkProps} from '../../atom/button-link/types';
 import BulletPointMenuButton from '../../molecule/bullet-point-menu-button';
-import headerWithActionsPropTypes, {HeaderWithActionsProps} from './types';
+import headerWithActionsPropTypes, {
+  HeaderWithActionsProps,
+  ButtonMenuProps,
+  ButtonActionProps
+} from './types';
 import style from './style.css';
 
 const getDataName = (suffix: string) => `header-with-actions-${suffix}`;
 // @ts-expect-error (need to get the index)
 const uncappedMap = map.convert({cap: false});
 
+const buildCloseButton = ({onClick, ariaLabel}: {onClick: () => void; ariaLabel: string}) => {
+  return {
+    size: 'default',
+    icon: 'close',
+    'data-name': 'close-button',
+    'aria-label': ariaLabel,
+    onClick
+  };
+};
+
+const buildButtonMenu = ({dataName, label, iconName, iconColor, onClick}: ButtonMenuProps) => {
+  return {
+    'data-name': dataName,
+    label,
+    buttonLinkType: 'tertiary',
+    icon: {
+      position: 'left' as const,
+      faIcon: {
+        name: iconName,
+        color: iconColor,
+        size: 14,
+        customStyle: {padding: 0}
+      }
+    },
+    onClick,
+    type: 'defaultLeft'
+  };
+};
+
+const buildActionButton = ({
+  type,
+  label,
+  onClick,
+  disabled,
+  iconName,
+  iconColor
+}: ButtonActionProps) => {
+  return {
+    type,
+    label,
+    onClick,
+    disabled,
+    icon: {
+      position: 'left' as const,
+      faIcon: {
+        name: iconName,
+        color: iconColor,
+        size: 14,
+        customStyle: {padding: 0}
+      }
+    },
+    customStyle: {
+      fontWeight: '600',
+      borderRadius: '12px',
+      padding: '0 8px 0 16px'
+    }
+  };
+};
+
+const isButtonActionProps = (action: any): action is ButtonActionProps => {
+  return typeof action.iconName === 'string' && typeof action.iconColor === 'string';
+};
+
 const HeaderWithActions = (props: HeaderWithActionsProps) => {
   const {closeButton, title, tag, saveStatus, bulletPointMenuButton, actionButtons} = props;
+
+  const renderedActionButtons = uncappedMap(
+    (action: ButtonLinkProps | ButtonActionProps, key: string) => {
+      return isButtonActionProps(action) ? (
+        <ButtonLink {...buildActionButton(action)} key={key} />
+      ) : (
+        <ButtonLink {...action} key={key} />
+      );
+    },
+    actionButtons
+  );
 
   return (
     <div className={style.headerWrapper} data-name={getDataName('wrapper')}>
@@ -22,7 +100,13 @@ const HeaderWithActions = (props: HeaderWithActionsProps) => {
         className={style.titleAndButtonWrapper}
         data-name={getDataName('title-and-button-wrapper')}
       >
-        <ButtonLinkIcon {...closeButton} className={style.button} />
+        <ButtonLinkIcon
+          {...buildCloseButton({
+            onClick: closeButton.onClick,
+            ariaLabel: closeButton['aria-label']
+          })}
+          className={style.button}
+        />
         <div className={style.titleWrapper}>
           <div className={style.statusWrapper}>
             <Tag {...tag} />
@@ -37,11 +121,12 @@ const HeaderWithActions = (props: HeaderWithActionsProps) => {
       </div>
       <div className={style.buttonsWrapper} data-name={getDataName('buttons-wrapper')}>
         {bulletPointMenuButton && !isEmpty(bulletPointMenuButton.buttons) ? (
-          <BulletPointMenuButton {...bulletPointMenuButton} buttonAriaLabel="More actions" />
+          <BulletPointMenuButton
+            {...bulletPointMenuButton}
+            buttons={uncappedMap(buildButtonMenu, bulletPointMenuButton.buttons)}
+          />
         ) : null}
-        {uncappedMap((action: ButtonLinkProps, key: string) => {
-          return <ButtonLink {...action} key={key} />;
-        }, actionButtons)}
+        {renderedActionButtons}
       </div>
     </div>
   );

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
@@ -42,7 +42,7 @@ const buildButtonMenu = ({dataName, label, iconName, iconColor, onClick}: Button
       }
     },
     onClick,
-    type: 'defaultLeft'
+    type: iconName === 'trash' ? 'dangerousLeft' : 'defaultLeft'
   };
 };
 

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
@@ -36,8 +36,7 @@ const buildButtonMenu = ({dataName, label, iconName, iconColor, onClick}: Button
       faIcon: {
         name: iconName,
         color: iconColor,
-        size: 14,
-        customStyle: {padding: 0}
+        size: 14
       }
     },
     onClick,
@@ -72,8 +71,7 @@ const buildActionButton = ({
         faIcon: {
           name: iconName,
           color: iconColor,
-          size: 14,
-          customStyle: {padding: 0}
+          size: 14
         }
       }
     };

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
@@ -4,7 +4,6 @@ import map from 'lodash/fp/map';
 import ButtonLink from '../../atom/button-link';
 import ButtonLinkIcon from '../../atom/button-link-icon';
 import Tag from '../../atom/tag';
-import {ButtonLinkProps} from '../../atom/button-link/types';
 import BulletPointMenuButton from '../../molecule/bullet-point-menu-button';
 import headerWithActionsPropTypes, {
   HeaderWithActionsProps,
@@ -54,45 +53,37 @@ const buildActionButton = ({
   iconName,
   iconColor
 }: ButtonActionProps) => {
-  return {
+  const base = {
     type,
     label,
     onClick,
     disabled,
-    icon: {
-      position: 'left' as const,
-      faIcon: {
-        name: iconName,
-        color: iconColor,
-        size: 14,
-        customStyle: {padding: 0}
-      }
-    },
     customStyle: {
       fontWeight: '600',
-      borderRadius: '12px',
-      padding: '0 8px 0 16px'
+      borderRadius: '12px'
     }
   };
-};
 
-const isButtonActionProps = (action: any): action is ButtonActionProps => {
-  return typeof action.iconName === 'string' && typeof action.iconColor === 'string';
+  if (iconName && iconColor) {
+    return {
+      ...base,
+      icon: {
+        position: 'left' as const,
+        faIcon: {
+          name: iconName,
+          color: iconColor,
+          size: 14,
+          customStyle: {padding: 0}
+        }
+      }
+    };
+  }
+
+  return base;
 };
 
 const HeaderWithActions = (props: HeaderWithActionsProps) => {
   const {closeButton, title, tag, saveStatus, bulletPointMenuButton, actionButtons} = props;
-
-  const renderedActionButtons = uncappedMap(
-    (action: ButtonLinkProps | ButtonActionProps, key: string) => {
-      return isButtonActionProps(action) ? (
-        <ButtonLink {...buildActionButton(action)} key={key} />
-      ) : (
-        <ButtonLink {...action} key={key} />
-      );
-    },
-    actionButtons
-  );
 
   return (
     <div className={style.headerWrapper} data-name={getDataName('wrapper')}>
@@ -126,7 +117,9 @@ const HeaderWithActions = (props: HeaderWithActionsProps) => {
             buttons={uncappedMap(buildButtonMenu, bulletPointMenuButton.buttons)}
           />
         ) : null}
-        {renderedActionButtons}
+        {uncappedMap((action: ButtonActionProps, key: string) => {
+          return <ButtonLink {...buildActionButton(action)} key={key} />;
+        }, actionButtons)}
       </div>
     </div>
   );

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
@@ -5,7 +5,7 @@ import ButtonLink from '../../atom/button-link';
 import ButtonLinkIcon from '../../atom/button-link-icon';
 import Tag from '../../atom/tag';
 import BulletPointMenuButton from '../../molecule/bullet-point-menu-button';
-import headerWithActionsPropTypes, {
+import HeaderWithActionsPropTypes, {
   HeaderWithActionsProps,
   ButtonMenuProps,
   ButtonActionProps
@@ -123,6 +123,6 @@ const HeaderWithActions = (props: HeaderWithActionsProps) => {
   );
 };
 
-HeaderWithActions.propTypes = headerWithActionsPropTypes;
+HeaderWithActions.propTypes = HeaderWithActionsPropTypes;
 
 export default HeaderWithActions;

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
@@ -113,6 +113,7 @@ const HeaderWithActions = (props: HeaderWithActionsProps) => {
           <BulletPointMenuButton
             {...bulletPointMenuButton}
             buttons={uncappedMap(buildButtonMenu, bulletPointMenuButton.buttons)}
+            data-name={getDataName('bullet-point-menu-button')}
           />
         ) : null}
         {uncappedMap((action: ButtonActionProps, key: string) => {

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/action-without-icon.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/action-without-icon.ts
@@ -6,6 +6,7 @@ const actionWithoutIconFixture: HeaderWithActionsPropsFixture = {
     ...singleActionFixture.props,
     actionButtons: [
       {
+        type: 'secondary',
         label: 'Archive',
         onClick: () => console.log('click on Archive')
       }

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/default.ts
@@ -43,7 +43,6 @@ const defaultFixture: HeaderWithActionsPropsFixture = {
           onClick: () => console.log('click on Delete')
         }
       ],
-      onClick: () => console.log('click on bullet point menu'),
       buttonAriaLabel: 'More actions'
     },
     actionButtons: [

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/default.ts
@@ -43,7 +43,8 @@ const defaultFixture: HeaderWithActionsPropsFixture = {
           onClick: () => console.log('click on Delete')
         }
       ],
-      buttonAriaLabel: 'More actions'
+      buttonAriaLabel: 'More actions',
+      disabled: false
     },
     actionButtons: [
       {

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/default.ts
@@ -1,12 +1,9 @@
-import {HeaderWithActionsPropsFixture} from '../../types';
+import {ButtonActionProps, HeaderWithActionsPropsFixture} from '../../types';
 import {COLORS} from '../../../../variables/colors';
 
 const defaultFixture: HeaderWithActionsPropsFixture = {
   props: {
     closeButton: {
-      size: 'default',
-      icon: 'close',
-      'data-name': 'close-button',
       'aria-label': 'Close',
       onClick: () => {
         console.log('Close');
@@ -25,45 +22,29 @@ const defaultFixture: HeaderWithActionsPropsFixture = {
     bulletPointMenuButton: {
       buttons: [
         {
-          'data-name': 'discard-button',
+          dataName: 'discard-button',
           label: 'Discard changes',
-          buttonLinkType: 'tertiary',
-          icon: {
-            position: 'left',
-            faIcon: {
-              name: 'circle-xmark',
-              color: '#515161',
-              size: 14,
-              customStyle: {padding: 0}
-            }
-          },
-          onClick: () => console.log('click on Discard changes'),
-          type: 'defaultLeft'
+          iconName: 'circle-xmark',
+          iconColor: '#515161',
+          onClick: () => console.log('click on Discard changes')
         },
         {
-          'data-name': 'archive-button',
+          dataName: 'archive-button',
           label: 'Archive',
-          buttonLinkType: 'tertiary',
-          icon: {
-            position: 'left',
-            faIcon: {name: 'folder-open', color: '#515161', size: 14, customStyle: {padding: 0}}
-          },
-          onClick: () => console.log('click on Archive'),
-          type: 'defaultLeft'
+          iconName: 'folder-open',
+          iconColor: '#515161',
+          onClick: () => console.log('click on Archive')
         },
         {
-          'data-name': 'delete-button',
+          dataName: 'delete-button',
           label: 'Delete',
-          buttonLinkType: 'tertiary',
-          icon: {
-            position: 'left',
-            faIcon: {name: 'trash', color: '#B81400', size: 14, customStyle: {padding: 0}}
-          },
-          onClick: () => console.log('click on Delete'),
-          type: 'dangerousLeft'
+          iconName: 'trash',
+          iconColor: '#B81400',
+          onClick: () => console.log('click on Delete')
         }
       ],
-      onClick: () => console.log('click on bullet point menu')
+      onClick: () => console.log('click on bullet point menu'),
+      buttonAriaLabel: 'More actions'
     },
     actionButtons: [
       {
@@ -71,39 +52,17 @@ const defaultFixture: HeaderWithActionsPropsFixture = {
         type: 'secondary',
         onClick: () => console.log('click Save changes'),
         disabled: true,
-        icon: {
-          position: 'left',
-          faIcon: {
-            name: 'floppy-disk',
-            color: COLORS.cm_grey_700,
-            size: 14,
-            customStyle: {padding: 0}
-          }
-        },
-        customStyle: {
-          fontWeight: '600',
-          borderRadius: '12px'
-        }
+        iconName: 'floppy-disk',
+        iconColor: COLORS.cm_grey_700
       },
       {
         label: 'Publish changes',
         type: 'primary',
         onClick: () => console.log('click Publish changes'),
-        icon: {
-          position: 'left',
-          faIcon: {
-            name: 'circle-check',
-            color: COLORS.white,
-            size: 14,
-            customStyle: {padding: 0}
-          }
-        },
-        customStyle: {
-          fontWeight: '600',
-          borderRadius: '12px'
-        }
+        iconName: 'paper-plane',
+        iconColor: COLORS.white
       }
-    ]
+    ] as ButtonActionProps[]
   }
 };
 

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/default.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/default.ts
@@ -1,4 +1,4 @@
-import {ButtonActionProps, HeaderWithActionsPropsFixture} from '../../types';
+import {HeaderWithActionsPropsFixture} from '../../types';
 import {COLORS} from '../../../../variables/colors';
 
 const defaultFixture: HeaderWithActionsPropsFixture = {
@@ -62,7 +62,7 @@ const defaultFixture: HeaderWithActionsPropsFixture = {
         iconName: 'paper-plane',
         iconColor: COLORS.white
       }
-    ] as ButtonActionProps[]
+    ]
   }
 };
 

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/single-action.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/single-action.ts
@@ -1,12 +1,9 @@
-import {HeaderWithActionsPropsFixture} from '../../types';
+import {ButtonActionProps, HeaderWithActionsPropsFixture} from '../../types';
 import {COLORS} from '../../../../variables/colors';
 
 const singleActionFixture: HeaderWithActionsPropsFixture = {
   props: {
     closeButton: {
-      size: 'default',
-      icon: 'close',
-      'data-name': 'close-button',
       'aria-label': 'Close',
       onClick: () => {
         console.log('Close');
@@ -26,21 +23,10 @@ const singleActionFixture: HeaderWithActionsPropsFixture = {
         label: 'Archive',
         type: 'secondary',
         onClick: () => console.log('click on Archive'),
-        icon: {
-          position: 'left',
-          faIcon: {
-            name: 'folder-open',
-            color: COLORS.cm_grey_700,
-            size: 14,
-            customStyle: {padding: 0}
-          }
-        },
-        customStyle: {
-          fontWeight: '600',
-          borderRadius: '12px'
-        }
+        iconName: 'folder-open',
+        iconColor: COLORS.cm_grey_700
       }
-    ]
+    ] as ButtonActionProps[]
   }
 };
 

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/single-action.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/test/fixtures/single-action.ts
@@ -1,4 +1,4 @@
-import {ButtonActionProps, HeaderWithActionsPropsFixture} from '../../types';
+import {HeaderWithActionsPropsFixture} from '../../types';
 import {COLORS} from '../../../../variables/colors';
 
 const singleActionFixture: HeaderWithActionsPropsFixture = {
@@ -26,7 +26,7 @@ const singleActionFixture: HeaderWithActionsPropsFixture = {
         iconName: 'folder-open',
         iconColor: COLORS.cm_grey_700
       }
-    ] as ButtonActionProps[]
+    ]
   }
 };
 

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/types.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/types.ts
@@ -35,7 +35,6 @@ const HeaderWithActionsPropTypes = {
   actionButtons: PropTypes.arrayOf(PropTypes.shape(ButtonActionPropTypes)).isRequired,
   bulletPointMenuButton: PropTypes.shape({
     buttons: PropTypes.arrayOf(PropTypes.shape(ButtonMenuPropTypes)).isRequired,
-    onClick: PropTypes.func.isRequired,
     buttonAriaLabel: PropTypes.string
   })
 };
@@ -68,7 +67,6 @@ export type ButtonMenuProps = {
 
 type BulletPointMenuButtonProps = {
   buttons: ButtonMenuProps[];
-  onClick: () => void;
   buttonAriaLabel: string;
 };
 

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/types.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/types.ts
@@ -9,7 +9,7 @@ const ButtonMenuPropTypes = {
 };
 
 const ButtonActionPropTypes = {
-  type: PropTypes.oneOf(['primary', 'secondary']),
+  type: PropTypes.oneOf(['primary', 'secondary']).isRequired,
   label: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
@@ -17,7 +17,7 @@ const ButtonActionPropTypes = {
   iconColor: PropTypes.string
 };
 
-const headerWithActionsPropTypes = {
+const HeaderWithActionsPropTypes = {
   closeButton: PropTypes.shape({
     'aria-label': PropTypes.string,
     onClick: PropTypes.func.isRequired
@@ -33,14 +33,14 @@ const headerWithActionsPropTypes = {
     label: PropTypes.oneOf(['Unsaved changes', 'Saved'])
   }).isRequired,
   actionButtons: PropTypes.arrayOf(PropTypes.shape(ButtonActionPropTypes)).isRequired,
-  bulletPointMenuButtonPropTypes: PropTypes.shape({
+  bulletPointMenuButton: PropTypes.shape({
     buttons: PropTypes.arrayOf(PropTypes.shape(ButtonMenuPropTypes)).isRequired,
     onClick: PropTypes.func.isRequired,
     buttonAriaLabel: PropTypes.string
   })
 };
 
-export default headerWithActionsPropTypes;
+export default HeaderWithActionsPropTypes;
 
 type TagProps = {
   label: 'Published' | 'Ongoing changes' | 'Draft' | 'Archived';
@@ -73,7 +73,7 @@ type BulletPointMenuButtonProps = {
 };
 
 export type ButtonActionProps = {
-  type?: 'primary' | 'secondary';
+  type: 'primary' | 'secondary';
   label: string;
   onClick: () => void;
   disabled?: boolean;

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/types.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/types.ts
@@ -5,12 +5,27 @@ import bulletPointMenuButtonPropTypes, {
 import ButtonLinkPropTypes, {ButtonLinkProps} from '../../atom/button-link/types';
 
 const closeButtonPropTypes = {
-  size: PropTypes.oneOf(['default', 'small', 'responsive']).isRequired,
-  icon: PropTypes.string.isRequired,
-  'data-name': PropTypes.string.isRequired,
-  'aria-label': PropTypes.string.isRequired,
+  'aria-label': PropTypes.string,
   onClick: PropTypes.func.isRequired
 };
+
+const ButtonMenuPropTypes = {
+  dataName: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  iconName: PropTypes.string.isRequired,
+  iconColor: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired
+};
+
+const ButtonActionPropTypes = {
+  type: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  iconName: PropTypes.string.isRequired,
+  iconColor: PropTypes.string.isRequired
+};
+
 const headerWithActionsPropTypes = {
   closeButton: PropTypes.shape(closeButtonPropTypes),
   title: PropTypes.string.isRequired,
@@ -23,8 +38,18 @@ const headerWithActionsPropTypes = {
     display: PropTypes.bool.isRequired,
     label: PropTypes.oneOf(['Unsaved changes', 'Saved'])
   }).isRequired,
-  bulletPointMenuButton: PropTypes.shape(bulletPointMenuButtonPropTypes),
-  actionButtons: PropTypes.arrayOf(PropTypes.shape(ButtonLinkPropTypes)).isRequired
+  bulletPointMenuButtonPropTypes: PropTypes.oneOfType([
+    PropTypes.shape(bulletPointMenuButtonPropTypes),
+    PropTypes.shape({
+      buttons: PropTypes.arrayOf(PropTypes.shape(ButtonMenuPropTypes)).isRequired,
+      onClick: PropTypes.func.isRequired,
+      buttonAriaLabel: PropTypes.string
+    })
+  ]),
+  actionButtons: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.shape(ButtonLinkPropTypes)),
+    PropTypes.arrayOf(PropTypes.shape(ButtonActionPropTypes))
+  ]).isRequired
 };
 
 export default headerWithActionsPropTypes;
@@ -41,11 +66,31 @@ type SaveStatusProps = {
 };
 
 type CloseButtonProps = {
-  size: 'default' | 'small' | 'responsive';
-  icon: string;
-  'data-name': string;
   'aria-label': string;
   onClick: () => void;
+};
+
+export type ButtonMenuProps = {
+  dataName: string;
+  label: string;
+  iconName: string;
+  iconColor: string;
+  onClick: () => void;
+};
+
+type BulletPointMenuButtonCustomProps = {
+  buttons: ButtonMenuProps[];
+  onClick: () => void;
+  buttonAriaLabel: string;
+};
+
+export type ButtonActionProps = {
+  type: 'primary' | 'secondary';
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  iconName: string;
+  iconColor: string;
 };
 
 export type HeaderWithActionsProps = {
@@ -53,8 +98,8 @@ export type HeaderWithActionsProps = {
   title: string;
   tag: TagProps;
   saveStatus: SaveStatusProps;
-  actionButtons: ButtonLinkProps[];
-  bulletPointMenuButton?: BulletPointMenuButtonProps;
+  actionButtons: ButtonLinkProps[] | ButtonActionProps[];
+  bulletPointMenuButton?: BulletPointMenuButtonProps | BulletPointMenuButtonCustomProps;
 };
 
 export type HeaderWithActionsPropsFixture = {props: HeaderWithActionsProps};

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/types.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/types.ts
@@ -35,7 +35,8 @@ const HeaderWithActionsPropTypes = {
   actionButtons: PropTypes.arrayOf(PropTypes.shape(ButtonActionPropTypes)).isRequired,
   bulletPointMenuButton: PropTypes.shape({
     buttons: PropTypes.arrayOf(PropTypes.shape(ButtonMenuPropTypes)).isRequired,
-    buttonAriaLabel: PropTypes.string
+    buttonAriaLabel: PropTypes.string,
+    disabled: PropTypes.bool.isRequired
   })
 };
 
@@ -67,7 +68,8 @@ export type ButtonMenuProps = {
 
 type BulletPointMenuButtonProps = {
   buttons: ButtonMenuProps[];
-  buttonAriaLabel: string;
+  buttonAriaLabel?: string;
+  disabled: boolean;
 };
 
 export type ButtonActionProps = {

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/types.ts
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/types.ts
@@ -1,13 +1,4 @@
 import PropTypes from 'prop-types';
-import bulletPointMenuButtonPropTypes, {
-  BulletPointMenuButtonProps
-} from '../../molecule/bullet-point-menu-button/types';
-import ButtonLinkPropTypes, {ButtonLinkProps} from '../../atom/button-link/types';
-
-const closeButtonPropTypes = {
-  'aria-label': PropTypes.string,
-  onClick: PropTypes.func.isRequired
-};
 
 const ButtonMenuPropTypes = {
   dataName: PropTypes.string,
@@ -18,16 +9,19 @@ const ButtonMenuPropTypes = {
 };
 
 const ButtonActionPropTypes = {
-  type: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(['primary', 'secondary']),
   label: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
-  iconName: PropTypes.string.isRequired,
-  iconColor: PropTypes.string.isRequired
+  iconName: PropTypes.string,
+  iconColor: PropTypes.string
 };
 
 const headerWithActionsPropTypes = {
-  closeButton: PropTypes.shape(closeButtonPropTypes),
+  closeButton: PropTypes.shape({
+    'aria-label': PropTypes.string,
+    onClick: PropTypes.func.isRequired
+  }),
   title: PropTypes.string.isRequired,
   tag: PropTypes.shape({
     label: PropTypes.oneOf(['Published', 'Ongoing changes', 'Draft', 'Archived']).isRequired,
@@ -38,18 +32,12 @@ const headerWithActionsPropTypes = {
     display: PropTypes.bool.isRequired,
     label: PropTypes.oneOf(['Unsaved changes', 'Saved'])
   }).isRequired,
-  bulletPointMenuButtonPropTypes: PropTypes.oneOfType([
-    PropTypes.shape(bulletPointMenuButtonPropTypes),
-    PropTypes.shape({
-      buttons: PropTypes.arrayOf(PropTypes.shape(ButtonMenuPropTypes)).isRequired,
-      onClick: PropTypes.func.isRequired,
-      buttonAriaLabel: PropTypes.string
-    })
-  ]),
-  actionButtons: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.shape(ButtonLinkPropTypes)),
-    PropTypes.arrayOf(PropTypes.shape(ButtonActionPropTypes))
-  ]).isRequired
+  actionButtons: PropTypes.arrayOf(PropTypes.shape(ButtonActionPropTypes)).isRequired,
+  bulletPointMenuButtonPropTypes: PropTypes.shape({
+    buttons: PropTypes.arrayOf(PropTypes.shape(ButtonMenuPropTypes)).isRequired,
+    onClick: PropTypes.func.isRequired,
+    buttonAriaLabel: PropTypes.string
+  })
 };
 
 export default headerWithActionsPropTypes;
@@ -78,19 +66,19 @@ export type ButtonMenuProps = {
   onClick: () => void;
 };
 
-type BulletPointMenuButtonCustomProps = {
+type BulletPointMenuButtonProps = {
   buttons: ButtonMenuProps[];
   onClick: () => void;
   buttonAriaLabel: string;
 };
 
 export type ButtonActionProps = {
-  type: 'primary' | 'secondary';
+  type?: 'primary' | 'secondary';
   label: string;
   onClick: () => void;
   disabled?: boolean;
-  iconName: string;
-  iconColor: string;
+  iconName?: string;
+  iconColor?: string;
 };
 
 export type HeaderWithActionsProps = {
@@ -98,8 +86,8 @@ export type HeaderWithActionsProps = {
   title: string;
   tag: TagProps;
   saveStatus: SaveStatusProps;
-  actionButtons: ButtonLinkProps[] | ButtonActionProps[];
-  bulletPointMenuButton?: BulletPointMenuButtonProps | BulletPointMenuButtonCustomProps;
+  actionButtons: ButtonActionProps[];
+  bulletPointMenuButton?: BulletPointMenuButtonProps;
 };
 
 export type HeaderWithActionsPropsFixture = {props: HeaderWithActionsProps};

--- a/packages/@coorpacademy-components/src/organism/skill-edition/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/skill-edition/index.tsx
@@ -83,7 +83,6 @@ const SkillInformations = (skillInformations: SkillInformationsProps) => {
             onClick: iconEditor.buttonLink.onClick,
             customStyle: {
               borderRadius: '12px',
-              padding: '0 8px 0 16px',
               fontWeight: '500'
             }
           }

--- a/packages/@coorpacademy-components/src/organism/skill-edition/test/fixtures/draft-deletable-content-items.ts
+++ b/packages/@coorpacademy-components/src/organism/skill-edition/test/fixtures/draft-deletable-content-items.ts
@@ -61,7 +61,7 @@ export default {
         }
       },
       iconEditor: {
-        ...Default.props.skillInformations.iconEditor,
+        title: 'Skill icon',
         iconPreview: {
           title: 'Cloud computing technology',
           icon: {color: COLORS.cm_turquoise_strong, name: 'globe-pointer'}

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
@@ -107,19 +107,14 @@ const buildNotifications = notifications => {
   );
 };
 
-const buildHeader = header => {
-  return (
-    <div className={style.header}>
-      {header.type === 'header-with-actions' ? (
-        <HeaderWithActions {...header} />
-      ) : (
-        <div className={style.headerStickyDefault}>
-          <Header {...header} />
-        </div>
-      )}
+const buildHeader = header =>
+  header.type === 'header-with-actions' ? (
+    <HeaderWithActions {...header} />
+  ) : (
+    <div className={style.headerDefault}>
+      <Header {...header} />
     </div>
   );
-};
 
 const buildDefaultPopin = popin => {
   const {theme, icon: popinIcon, secondButton: popinSecondButton} = popin;

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
@@ -409,7 +409,7 @@ BrandUpdate.propTypes = {
   popin: PropTypes.oneOfType([
     PropTypes.shape({
       ...CmPopin.propTypes,
-      theme: PropTypes.oneOf(['published', 'archived', 'deleted'])
+      theme: PropTypes.oneOf(['published', 'archived', 'deleted', 'draft'])
     }),
     PropTypes.shape({
       ...IconPickerModal.propTypes,

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/index.js
@@ -113,7 +113,9 @@ const buildHeader = header => {
       {header.type === 'header-with-actions' ? (
         <HeaderWithActions {...header} />
       ) : (
-        <Header {...header} />
+        <div className={style.headerStickyDefault}>
+          <Header {...header} />
+        </div>
       )}
     </div>
   );

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/style.css
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/style.css
@@ -41,11 +41,14 @@
 }
 
 .headerSticky {
-  overflow: hidden;
   background-color: white;
   position: fixed;
   width: calc(100% - 351px);
   z-index: 999;
+}
+
+.headerStickyDefault {
+  overflow: hidden;
   pointer-events: none;
 }
 

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/style.css
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/style.css
@@ -41,19 +41,16 @@
 }
 
 .headerSticky {
+  padding: 24px 0 5px 0;
   background-color: white;
   position: fixed;
   width: calc(100% - 351px);
   z-index: 999;
 }
 
-.headerStickyDefault {
+.headerDefault {
   overflow: hidden;
   pointer-events: none;
-}
-
-.header {
-  padding: 24px 0 5px 0;
 }
 
 .tabs {

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/custom-skill-edition-draft-popin.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/test/fixtures/custom-skill-edition-draft-popin.js
@@ -1,0 +1,9 @@
+import customSkillDraftPopinProps from '../../../../../molecule/cm-popin/test/fixtures/custom-skill-draft';
+import customSkillEditionProps from './custom-skill-edition';
+
+export default {
+  props: {
+    ...customSkillEditionProps.props,
+    popin: {...customSkillDraftPopinProps.props}
+  }
+};

--- a/packages/@coorpacademy-components/src/template/back-office/brand-update/utils.js
+++ b/packages/@coorpacademy-components/src/template/back-office/brand-update/utils.js
@@ -34,6 +34,12 @@ const ICON_PROPS = {
     iconColor: COLORS.red_700,
     backgroundColor: COLORS.red_100,
     preset: 'xl'
+  },
+  draft: {
+    iconName: 'circle-exclamation',
+    iconColor: COLORS.yellow_700,
+    backgroundColor: COLORS.yellow_100,
+    preset: 'xl'
   }
 };
 
@@ -57,6 +63,19 @@ export const POPIN_THEMES = {
         }
       },
       type: 'dangerous'
+    }
+  },
+  draft: {
+    icon: ICON_PROPS.draft,
+    actionButton: {
+      ...COMMUN_ACTION_BUTTON_PROPS,
+      icon: {
+        position: 'left',
+        faIcon: {
+          ...COMMUN_ACTION_BUTTON_PROPS.icon.faIcon,
+          name: 'floppy-disk'
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
**Detailed purpose of the PR**
Jira [ticket](https://go1web.atlassian.net/jira/software/projects/CLXP/boards/626?selectedIssue=CLXP-302)

- to avoid exposing too many props in `app-backoffice`, this update refactors the `HeaderWithActions`  component accordingly.
- fix style and increase coverage of `SkillEdition` component.
- update `BrandUpdate` component to use  `HeaderWithActions`.
- add draft popin (dispatched when the user clicks the close button in the header).


**Result and observation**
-> https://6622682e70ecd8ecf5027fa1-mmbkdasokb.chromatic.com/?path=/story/template-backoffice-brandupdate--custom-skill-edition-draft-popin


**Testing Strategy**

- [x] Already covered by tests
- [x] Manual testing
- [ ] Unit testing