### PR TITLE
add new default review confifiguration

### DIFF
--- a/packages/@coorpacademy-progression-engine/src/config/review.js
+++ b/packages/@coorpacademy-progression-engine/src/config/review.js
@@ -21,10 +21,14 @@ const configurations: Array<Config> = [
   assign(CURRENT_BASE_CONFIGURATION, {
     version: '2',
     starsPerCorrectAnswer: 12
+  }),
+  assign(CURRENT_BASE_CONFIGURATION, {
+    version: '3',
+    starsPerCorrectAnswer: 4
   })
 ];
 
 export default {
   configurations,
-  defaultConfiguration: CURRENT_BASE_CONFIGURATION
+  defaultConfiguration: configurations[2]
 };

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.js
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config-for-progression.js
@@ -84,6 +84,19 @@ test('should return the configuration with the given version if it exists', t =>
     starsPerResourceViewed: 0,
     remainingLifeRequests: 0
   });
+  t.deepEqual(getConfigForProgression(createProgression({ref: 'review', version: '1'})), {
+    version: '1',
+    lives: 0,
+    livesDisabled: true,
+    maxTypos: 2,
+    slidesToComplete: 5,
+    shuffleChoices: true,
+    answerBoundaryLimit: 5,
+    starsPerAskingClue: 0,
+    starsPerCorrectAnswer: 8,
+    starsPerResourceViewed: 0,
+    remainingLifeRequests: 0
+  });
 });
 
 test('should merge the engineOptions values from the progression into the resulting configuration', t => {

--- a/packages/@coorpacademy-progression-engine/src/config/test/get-config.js
+++ b/packages/@coorpacademy-progression-engine/src/config/test/get-config.js
@@ -88,4 +88,17 @@ test('should return the default configuration if the engine does not have the gi
     starsPerResourceViewed: 4,
     remainingLifeRequests: 1
   });
+  t.deepEqual(getConfig({ref: 'review', version: 'foobar'}), {
+    version: '3',
+    lives: 0,
+    livesDisabled: true,
+    maxTypos: 2,
+    slidesToComplete: 5,
+    shuffleChoices: true,
+    answerBoundaryLimit: 5,
+    starsPerAskingClue: 0,
+    starsPerCorrectAnswer: 4,
+    starsPerResourceViewed: 0,
+    remainingLifeRequests: 0
+  });
 });


### PR DESCRIPTION
[IDEA 6172 - Réduire le nombre d'étoiles obtenues par batch de mode révision](https://app.prodpad.com/ideas/6172/canvas)
Hello,
A date, je crois qu'un apprenant gagne 40 étoiles par batch de mode révision, ce qui est autant voire plus qu'un niveau de cours (donc 8 étoiles par slide). Nous souhaitons réduire les 40 étoiles vers 20 (donc 4 étoiles par slide). Est-ce possible ?

<!--Please describe the new behaviour you’ve introduced. -->
<!-- Add some screenshots or a good gif of the new behavior, if you’ve introduced UI change -->

- [ ] **Breaking changes ?**  
       If checked, what have you broken ?

- [ ] **Extra lib ?**
      If checked, Which extra lib did you add ? (name, purpose, link ...).

**Testing Strategy**

- [ ] Already covered by tests
- [ ] Manual testing
- [ ] Unit testing
