### PR TITLE
[codex] Fix SCORM player contrast

### DIFF
--- a/packages/@coorpacademy-components/src/atom/provider/index.js
+++ b/packages/@coorpacademy-components/src/atom/provider/index.js
@@ -4,7 +4,7 @@ import {defaultsDeep, get, getOr} from 'lodash/fp';
 import {SrcPropType, ColorPropType, HexPropType} from '../../util/proptypes';
 import WebContext, {useWebContext} from './web-context';
 
-const DEFAULT_SKIN = {
+export const DEFAULT_SKIN = {
   common: {
     good: '#24b694',
     bad: '#ed1c24',

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-drag/style.css
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-drag/style.css
@@ -56,7 +56,7 @@
   font-family: 'Gilroy';
   font-size: 13px;
   font-weight: 600;
-  color: medium;
+  color: dark;
 }
 
 .choice {

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/footer/index.js
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/footer/index.js
@@ -79,6 +79,7 @@ class Button extends React.Component {
     const {hovered} = this.state;
     const grey = get('common.grey', skin);
     const primaryColor = get('common.primary', skin);
+    const positiveColor = get('common.positive', skin);
     const {disabled, notify, selected, highlighted, title, type, onClick} = this.props;
     const colorIcon = selected ? primaryColor : grey;
     const selectedColor = (selected && {borderTopColor: primaryColor}) || {};
@@ -114,7 +115,10 @@ class Button extends React.Component {
           ...selectedColor
         }}
       >
-        <div className={highlighted ? style.highlighted : style.logo}>
+        <div
+          className={highlighted ? style.highlighted : style.logo}
+          style={highlighted ? {backgroundColor: positiveColor} : null}
+        >
           {notifyView}
           <IconType
             style={{

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/footer/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/footer/style.css
@@ -5,7 +5,6 @@
 @value light from colors;
 @value orangeAdd from colors;
 @value grey from colors;
-@value positive from colors;
 @value black from colors;
 @value medium from colors;
 @value white from colors;
@@ -92,7 +91,6 @@
 
 .highlighted {
   composes: logo;
-  background-color: positive;
 }
 
 .title {

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/header/learner.css
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/header/learner.css
@@ -4,7 +4,7 @@
 @value xtraLightGrey from colors;
 @value dark from colors;
 @value light from colors;
-@value medium from colors;
+@value grey from colors;
 
 .wrapper {
   min-width: 0;
@@ -31,8 +31,8 @@
 }
 
 .contentWrapper:hover {
-  color: medium;
-  stroke: medium;
+  color: grey;
+  stroke: grey;
 }
 
 .content {

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/header/microlearning.css
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/header/microlearning.css
@@ -2,7 +2,7 @@
 @value mobile from breakpoints;
 @value colors: "../../../../../variables/colors.css";
 @value dark from colors;
-@value medium from colors;
+@value grey from colors;
 
 .content {
   min-width: 0;
@@ -17,8 +17,8 @@
 }
 
 .content:hover {
-  color: medium;
-  stroke: medium;
+  color: grey;
+  stroke: grey;
 }
 
 .contentScorm {

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/index.js
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/index.js
@@ -410,14 +410,17 @@ LoadedLayout.propTypes = {
  * Errors
  */
 
-const ErrorMessage = ({errorMsg}) => (
+const ErrorMessage = ({errorMsg, color}) => (
   <div className={style.contentWrapper}>
-    <div className={style.error}>{errorMsg}</div>
+    <div className={style.error} style={{color, borderColor: color}}>
+      {errorMsg}
+    </div>
   </div>
 );
 
 ErrorMessage.propTypes = {
-  errorMsg: PropTypes.string
+  errorMsg: PropTypes.string,
+  color: PropTypes.string
 };
 
 const Content = ({error, ...props}) =>
@@ -435,6 +438,7 @@ const SlidesPlayer = (props, context) => {
   const {header, step, buttons, showNewMedia = false, showReviewLesson = false} = props;
   const {skin} = context;
   const stepColor = get('common.primary', skin);
+  const negativeColor = get('common.negative', skin);
   const mediaButton = find({type: 'media'}, buttons) || {};
   const {onClick = identity} = mediaButton;
   return (
@@ -444,7 +448,7 @@ const SlidesPlayer = (props, context) => {
         {step ? <Step step={step} color={stepColor} /> : null}
         {showNewMedia && !showReviewLesson ? <NewMedia onClick={onClick} step={step} /> : null}
         {showReviewLesson && !showNewMedia ? <ReviewLesson onClick={onClick} /> : null}
-        <Content {...props} />
+        <Content {...props} color={negativeColor} />
       </div>
       <Footer buttons={buttons} />
     </div>

--- a/packages/@coorpacademy-components/src/template/app-player/player/slides/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/player/slides/style.css
@@ -7,7 +7,6 @@
 @value black from colors;
 @value grey from colors;
 @value brand from colors;
-@value negative from colors;
 @value orangeAdd from colors;
 @value white from colors; 
 
@@ -53,9 +52,8 @@
 }
 
 .error {
-  color: negative;
   text-align: center;
-  border: solid 2px negative;
+  border: solid 2px;
   padding: 36px 32px 32px;
   box-sizing: border-box;
   width: 80%;
@@ -183,7 +181,7 @@
   font-family: "Gilroy";
   font-size: 15px;
   font-weight: 500;
-  color: medium;
+  color: dark;
   flex-grow: 0.1;
   margin: 4px 0 10px;
   text-align: center;

--- a/packages/@coorpacademy-components/src/template/app-player/player/tourguide/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/player/tourguide/style.css
@@ -1,6 +1,6 @@
 @value colors: "../../../../variables/colors.css";
-@value cm_primary_blue from colors;
 @value cm_blue_50 from colors;
+@value cm_blue_700 from colors;
 @value cm_grey_75 from colors;
 @value cm_grey_400 from colors;
 @value cm_grey_500 from colors;
@@ -302,7 +302,7 @@
   cursor: pointer;
   border-color: transparent;
   vertical-align: middle;
-  color: cm_primary_blue;
+  color: cm_blue_700;
   background-color: cm_blue_50;
   font-family: Gilroy;
   font-weight: 900;
@@ -329,12 +329,12 @@
 }
 
 :global(.coorp-tourguide-dialog #tg-dialog-next-btn:hover) {
-  color: color(cm_primary_blue a(75%));
+  color: cm_blue_700;
   background-color: color(cm_blue_50 a(75%));
 }
 
 :global(.coorp-tourguide-dialog #tg-dialog-prev-btn:hover) {
-  color: color(cm_grey_500 a(75%));
+  color: cm_grey_500;
   background-color: color(cm_grey_75 a(75%));
 }
 

--- a/packages/@coorpacademy-components/src/template/app-player/popin-correction/index.js
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-correction/index.js
@@ -72,29 +72,37 @@ AssistanceLink.propTypes = {
   onClick: PropTypes.func
 };
 
-const Question = ({header, answer, answerPrefix}) => (
-  <div className={style.question}>
-    <p
-      className={classnames(style.questionHeader, style.innerHTML)}
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{__html: header}}
-    />
-    <div className={style.answerWrapper}>
-      <CheckIcon className={style.checkIcon} />
-      {answerPrefix ? <span className={style.answerPrefix}>{answerPrefix}</span> : null}
-      <span
-        className={classnames(style.answer, style.innerHTML)}
+const Question = ({header, answer, answerPrefix}, {skin}) => {
+  const positive = get('common.positive', skin);
+
+  return (
+    <div className={style.question}>
+      <p
+        className={classnames(style.questionHeader, style.innerHTML)}
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{__html: answer}}
+        dangerouslySetInnerHTML={{__html: header}}
       />
+      <div className={style.answerWrapper} style={{color: positive}}>
+        <CheckIcon className={style.checkIcon} />
+        {answerPrefix ? <span className={style.answerPrefix}>{answerPrefix}</span> : null}
+        <span
+          className={classnames(style.answer, style.innerHTML)}
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{__html: answer}}
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 Question.propTypes = {
   header: PropTypes.string,
   answerPrefix: PropTypes.string,
   answer: PropTypes.string
+};
+
+Question.contextTypes = {
+  skin: Provider.childContextTypes.skin
 };
 
 class PopinCorrection extends Component {

--- a/packages/@coorpacademy-components/src/template/app-player/popin-correction/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-correction/style.css
@@ -2,10 +2,7 @@
 @value dark from colors;
 @value grey from colors;
 @value xtraLightGrey from colors;
-@value medium from colors;
-@value positive from colors;
 @value white from colors;
-@value brand from colors;
 @value tablet, mobile from "../../../variables/breakpoints.css";
 
 @keyframes fadeInBackground {
@@ -113,14 +110,13 @@
 
 .questionHeader {
   composes: text;
-  color: medium;
+  color: dark;
   padding: 5px 22px;
 }
 
 .answerWrapper {
   display: flex;
   flex-flow: row;
-  color: positive;
   justify-content: flex-start;
   align-items: flex-start;
   min-height: 25px;

--- a/packages/@coorpacademy-components/src/template/app-player/popin-end/summary.css
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-end/summary.css
@@ -8,7 +8,6 @@
 @value medium from colors;
 @value white from colors;
 @value light from colors;
-@value positive from colors;
 @value dark from colors;
 
 .summaryWrapper {
@@ -176,7 +175,6 @@
 }
 
 .subscribeButton {
-  background-color: positive;
   border-radius: 30px;
   text-transform: none;
   width: auto;
@@ -360,7 +358,7 @@
 }
 
 .commentSectionLink:hover {
-  color: medium;
+  color: grey;
 }
 
 .innerHTML {

--- a/packages/@coorpacademy-components/src/template/app-player/popin-end/summary.js
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-end/summary.js
@@ -72,8 +72,9 @@ NextCourse.propTypes = {
   card: PropTypes.shape(cardPropTypes)
 };
 
-const Subscribe = ({title, description, button, card}) => {
+const Subscribe = ({title, description, button, card}, {skin}) => {
   const {title: buttonTitle, ...linkProps} = button;
+  const positive = get('common.positive', skin);
   return (
     <div className={style.subscribeWrapper}>
       <div className={style.subscribeTexts}>
@@ -88,6 +89,7 @@ const Subscribe = ({title, description, button, card}) => {
             {...linkProps}
             type="link"
             className={style.subscribeButton}
+            style={{backgroundColor: positive}}
             submitValue={buttonTitle}
           />
         </div>
@@ -102,6 +104,10 @@ const Subscribe = ({title, description, button, card}) => {
 Subscribe.propTypes = {
   ...Button.propTypes.propTypes,
   title: Button.propTypes.submitValue
+};
+
+Subscribe.contextTypes = {
+  skin: Provider.childContextTypes.skin
 };
 
 const actions = {

--- a/packages/@coorpacademy-components/src/template/app-player/popin-header/index.js
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-header/index.js
@@ -200,10 +200,17 @@ const getLinkStyle = ({gameOver, extraLifeGranted}) => {
     return null;
   }
 };
-const renderIconStatusScorm = failed => {
+const renderIconStatusScorm = (failed, {positive, negative, white}) => {
   return (
-    <div className={failed ? style.iconCloseContainer : style.iconSuccessContainer}>
-      {failed ? <Close className={style.failIcon} /> : <CheckIcon className={style.checkIcon} />}
+    <div
+      className={failed ? style.iconCloseContainer : style.iconSuccessContainer}
+      style={{backgroundColor: failed ? negative : positive}}
+    >
+      {failed ? (
+        <Close className={style.failIcon} style={{color: white}} />
+      ) : (
+        <CheckIcon className={style.checkIcon} style={{color: white}} />
+      )}
     </div>
   );
 };
@@ -218,8 +225,19 @@ const buildDefaultOrScormStyle = (
   if (mode === 'scorm') return styleScorm;
   return defaultStyle;
 };
-const CorrectionPart = props => {
+
+const getScormSubtitleStyle = ({mode, failed, positive, negative}) => {
+  if (mode !== 'scorm') return null;
+  return {
+    color: failed ? negative : positive
+  };
+};
+
+const CorrectionPart = (props, {skin}) => {
   const {failed, corrections, title, subtitle, stars, rank, gameOver, mode = 'default'} = props;
+  const positive = get('common.positive', skin);
+  const negative = get('common.negative', skin);
+  const white = get('common.white', skin);
   const isLoading = isNil(failed);
   const className = buildClass(
     failed,
@@ -229,9 +247,19 @@ const CorrectionPart = props => {
     style.resultContenantContainerScorm,
     mode
   );
+  const statusStyle =
+    mode === 'scorm' || isLoading
+      ? null
+      : {
+          backgroundColor: failed ? negative : positive
+        };
+  const scormSubtitleStyle = getScormSubtitleStyle({mode, failed, positive, negative});
+
   return (
-    <div data-name="correctionSection" className={className}>
-      {mode === 'scorm' && !isLoading && renderIconStatusScorm(failed)}
+    <div data-name="correctionSection" className={className} style={statusStyle}>
+      {mode === 'scorm' && !isLoading
+        ? renderIconStatusScorm(failed, {positive, negative, white})
+        : null}
       <div
         className={buildDefaultOrScormStyle(
           style.titlesWrapper,
@@ -253,6 +281,7 @@ const CorrectionPart = props => {
           dangerouslySetInnerHTML={{__html: title}}
         />
         <h2
+          style={scormSubtitleStyle}
           className={buildDefaultOrScormStyle(
             style.subtitle,
             style.resultSubtitleScorm,
@@ -271,6 +300,10 @@ const CorrectionPart = props => {
   );
 };
 
+CorrectionPart.contextTypes = {
+  skin: Provider.childContextTypes.skin
+};
+
 CorrectionPart.propTypes = {
   ...IconsPart.propTypes,
   failed: PropTypes.bool,
@@ -284,6 +317,8 @@ CorrectionPart.propTypes = {
 
 const NextQuestionPart = (props, context) => {
   const {cta, type, extraLifeGranted, gameOver, failed = false, lives = 0, mode} = props;
+  const {skin} = context;
+  const negative = get('common.negative', skin);
   const {title, nextStepTitle, showNextLevel = false, ...linkProps} = cta || {};
   let dataNext;
 
@@ -329,6 +364,7 @@ const NextQuestionPart = (props, context) => {
     <Link
       {...linkProps}
       className={classnames(style.nextSection, getLinkStyle({gameOver, extraLifeGranted}))}
+      style={gameOver ? {backgroundColor: negative} : null}
       data-name="nextLink"
       data-popin={type}
       data-next={dataNext}
@@ -342,6 +378,10 @@ const NextQuestionPart = (props, context) => {
       </div>
     </Link>
   ) : null;
+};
+
+NextQuestionPart.contextTypes = {
+  skin: Provider.childContextTypes.skin
 };
 
 NextQuestionPart.propTypes = {

--- a/packages/@coorpacademy-components/src/template/app-player/popin-header/style.css
+++ b/packages/@coorpacademy-components/src/template/app-player/popin-header/style.css
@@ -2,19 +2,13 @@
 @value mobile from breakpoints;
 @value tablet from breakpoints;
 @value colors: '../../../variables/colors.css';
-@value negative from colors;
 @value light from colors;
 @value grey from colors;
-@value positive from colors;
 @value medium from colors;
 @value dark from colors;
 @value black from colors;
 @value transparent from colors;
 @value cm_grey_75 from colors;
-@value lightGreen from colors;
-@value cm_green_50 from colors;
-@value cm_negative_100 from colors;
-@value cm_negative_50 from colors;
 @value white from colors;
 
 .header {
@@ -59,12 +53,10 @@
 
 .correctionSectionSuccess {
   composes: correctionSectionLoading;
-  background-color: positive;
 }
 
 .correctionSectionEndSuccess {
   composes: correctionSectionLoading;
-  background-color: positive;
 }
 
 .correctionSectionEndSuccess .titleElement {
@@ -73,12 +65,10 @@
 
 .correctionSectionFail {
   composes: correctionSectionLoading;
-  background-color: negative;
 }
 
 .correctionSectionFailGameOver {
   composes: correctionSectionFail;
-  background-color: negative;
 }
 
 .wrapper {
@@ -219,7 +209,6 @@
   font-weight: 700;
   font-size: 42px;
   line-height: 52px;
-  color: lightGreen;
   margin-bottom: 0px;
   margin-top: 0px;
 }
@@ -238,7 +227,6 @@
   font-weight: 700;
   font-size: 42px;
   line-height: 52px;
-  color: cm_negative_100;
   margin-top: 0px;
   margin-bottom: 0px;
 }
@@ -247,7 +235,6 @@
   height: 60px;
   width: 60px;
   border-radius: 50%;
-  background-color: cm_negative_50;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -257,19 +244,16 @@
   height: 60px;
   width: 60px;
   border-radius: 50%;
-  background-color: cm_green_50;
   display: flex;
   justify-content: center;
   align-items: center;
   margin: 0 24px 0 40px
 }
 .failIcon {
-  color: cm_negative_100;
   height: 22px;
   width: 22px;
 }
 .checkIcon {
-  color: lightGreen;
   height: 22px;
   width: 22px;
 }
@@ -299,7 +283,7 @@
   background-color: light;
   animation: showNextButton 0.6s;
   text-decoration: none;
-  color: medium;
+  color: dark;
   border-left: solid 1px light;
 }
 
@@ -309,7 +293,6 @@
 }
 
 .gameOver {
-  background-color: negative;
 }
 
 .gameOver .nextButton {
@@ -322,7 +305,7 @@
 
 .oneMoreLife {
   background-color: light;
-  color: medium;
+  color: dark;
   transition: background 0.6s linear 1.6s, color 0.3s linear 1.6s;
 }
 
@@ -371,7 +354,7 @@
   font-size: 12px;
   font-weight: 600;
   text-align: center;
-  color: medium;
+  color: dark;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Fix SCORM player contrast by updating component styles and `DEFAULT_SKIN` defaults.
- Replace low-contrast secondary text colors with darker palette colors in question/help headers, empty drag placeholders, open/tips/KLF headings, and header hovers.
- Update `DEFAULT_SKIN.common.positive` from `#3EC483` to `#04713D` and `DEFAULT_SKIN.common.negative` from `#F73F52` to `#B81400`, so components that consume non-brand-overridden status colors inherit AA-safe defaults.
- Make the app-player consume `skin.common.positive` / `skin.common.negative` for its success/failure UI instead of importing positive/negative variants from `colors.css`.
- Keep explicit brand colors untouched at runtime: `skin.common.primary`, `good`, `bad`, `life`, etc. are still consumed as configured by the brand/back office. Brand-driven surfaces such as clue backs, PDF open button, range controls, and CTA/link colors therefore depend on accessible brand configuration rather than component-side color overrides.

## Validation
- `npm run eslint -- src/template/app-player/popin-correction/index.js src/template/app-player/player/slides/footer/index.js src/template/app-player/popin-end/summary.js src/template/app-player/popin-header/index.js src/template/app-player/player/slides/index.js` (0 errors, existing unrelated warnings)
- `npm run ava -- src/template/app-player/popin-correction/test/index.js src/template/app-player/player/slides/footer/test/slides-footer.test.js src/template/app-player/player/test/validate-button-events.tsx`
- `npm run typecheck`

Note: full broader AVA batches timed out in this environment while other validations were running; the focused impacted tests above passed.