### PR TITLE
[codex] fix aria prohibited attributes

### DIFF
--- a/packages/@coorpacademy-components/src/atom/chip/index.js
+++ b/packages/@coorpacademy-components/src/atom/chip/index.js
@@ -17,6 +17,14 @@ const LUMINOSITY_DELTA = 0.08;
 const {cm_primary_blue: DEFAULT_BACKGROUND_COLOR} = COLORS;
 const ICON_SIZE = '12px';
 
+const handleChipKeyDown = onClick => event => {
+  if (!onClick) return;
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    onClick(event);
+  }
+};
+
 export const calculateHoveredSelectedBgColor = (
   selectedBgColor,
   luminosityDelta = LUMINOSITY_DELTA
@@ -72,6 +80,9 @@ const Chip = (props, context) => {
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      role={onClick ? 'button' : 'group'}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={handleChipKeyDown(onClick)}
       aria-label={text}
       data-name={`chip-${text}`}
     >

--- a/packages/@coorpacademy-components/src/atom/chips/index.js
+++ b/packages/@coorpacademy-components/src/atom/chips/index.js
@@ -9,6 +9,13 @@ import {
 } from '@coorpacademy/nova-icons';
 import style from './style.css';
 
+const handleChipKeyDown = onClick => event => {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    onClick();
+  }
+};
+
 const Chips = props => {
   const {text, information, selected = false, onClick} = props;
 
@@ -18,6 +25,9 @@ const Chips = props => {
     <div
       className={classnames(style.container, selected ? style.selected : style.unselected)}
       onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={handleChipKeyDown(onClick)}
       aria-label={`${text} ${information}`}
       data-name={text}
     >

--- a/packages/@coorpacademy-components/src/atom/circular-progress-bar/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/circular-progress-bar/index.tsx
@@ -43,7 +43,15 @@ const CircularProgressBar = ({
   );
 
   return (
-    <div className={style.container} aria-label={ariaLabel} data-name={dataName}>
+    <div
+      className={style.container}
+      role="progressbar"
+      aria-label={ariaLabel}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={progression}
+      data-name={dataName}
+    >
       <svg className={style.svg} width={size} height={size}>
         <ProgressionGradient />
         <circle

--- a/packages/@coorpacademy-components/src/atom/input-select/index.tsx
+++ b/packages/@coorpacademy-components/src/atom/input-select/index.tsx
@@ -100,11 +100,12 @@ const InputSelect = (props: InputSelectProps, context: WebContextValues) => {
           [style.open]: open
         })}
       />
-      <div className={classnames(style.wrapper, className)} aria-label={ariaLabel}>
+      <div className={classnames(style.wrapper, className)}>
         <button
           type="button"
           className={style.display}
           onClick={handleToggle}
+          aria-label={ariaLabel}
           aria-haspopup="listbox"
           aria-expanded={open}
           aria-controls={open ? `${componentId}-listbox` : undefined}

--- a/packages/@coorpacademy-components/src/atom/input-text-with-title/index.js
+++ b/packages/@coorpacademy-components/src/atom/input-text-with-title/index.js
@@ -8,7 +8,7 @@ const InputTextWithTitle = props => {
   const inputTextClass = inputText.size === 'small' ? style.smallInputText : style.defaultInputText;
 
   return (
-    <div className={style.container} data-name={dataName} aria-label={ariaLabel}>
+    <div className={style.container} data-name={dataName} role="group" aria-label={ariaLabel}>
       {title ? <span className={style.title}>{title}</span> : null}
       <div className={inputTextClass}>
         <InputText {...inputText} />

--- a/packages/@coorpacademy-components/src/atom/review-presentation/index.js
+++ b/packages/@coorpacademy-components/src/atom/review-presentation/index.js
@@ -49,7 +49,7 @@ const ReviewPresentation = props => {
   const {'aria-label': ariaLabel, reviewTitle, reviewText, labelsList} = props;
 
   return (
-    <div className={style.reviewWrapper} aria-label={ariaLabel}>
+    <div className={style.reviewWrapper} role="group" aria-label={ariaLabel}>
       <div
         className={style.reviewTitle}
         // eslint-disable-next-line react/no-danger

--- a/packages/@coorpacademy-components/src/atom/title/index.js
+++ b/packages/@coorpacademy-components/src/atom/title/index.js
@@ -82,7 +82,7 @@ const Title = props => {
       {icon ? <Icon {...icon} className={style.icon} /> : null}
       <div className={style.titleContainer}>
         <div className={style.titleContent}>
-          <div className={titleStyle} data-name={dataName} aria-label={ariaLabel}>
+          <div className={titleStyle} data-name={dataName} role="group" aria-label={ariaLabel}>
             {title}
             {required ? <span className={style.required}>*</span> : null}
             {tag ? <Tag {...tag} /> : null}

--- a/packages/@coorpacademy-components/src/atom/tooltip/index.js
+++ b/packages/@coorpacademy-components/src/atom/tooltip/index.js
@@ -55,6 +55,7 @@ const ToolTipWrapper = ({
       <div
         className={coorpToolTipClasses}
         data-testid="tooltip"
+        role="group"
         aria-label={closeToolTipInformationTextAriaLabel}
         onMouseOver={handleContentMouseOver}
       >

--- a/packages/@coorpacademy-components/src/molecule/base-modal/index.js
+++ b/packages/@coorpacademy-components/src/molecule/base-modal/index.js
@@ -184,7 +184,7 @@ const BaseModal = (props, context) => {
             </div>
           ) : null}
           <div className={style.headerContent}>
-            <div className={style.headerTitle} aria-label={titleAriaLabel}>
+            <div className={style.headerTitle} role="group" aria-label={titleAriaLabel}>
               {title}
             </div>
             {description ? <div className={style.headerDescription}>{description}</div> : null}

--- a/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/bullet-point-menu-button/index.tsx
@@ -92,7 +92,13 @@ const BulletPointMenuButton = (props: BulletPointMenuButtonProps) => {
   );
 
   const menu = visible ? (
-    <div className={menuStyle} data-name="menu-wrapper" aria-label={menuAriaLabel} ref={wrapperRef}>
+    <div
+      className={menuStyle}
+      data-name="menu-wrapper"
+      role="group"
+      aria-label={menuAriaLabel}
+      ref={wrapperRef}
+    >
       <ButtonMenu {...menuProps} />
     </div>
   ) : null;

--- a/packages/@coorpacademy-components/src/molecule/button-menu-action/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/button-menu-action/index.tsx
@@ -65,6 +65,7 @@ const ButtonMenuAction = (props: ButtonMenuActionProps) => {
     <div
       className={menuWrapperClass}
       data-name="menu-wrapper"
+      role="group"
       aria-label={menuWrapper?.ariaLabel}
       style={menuWrapper?.customStyle}
     >

--- a/packages/@coorpacademy-components/src/molecule/card-content/index.js
+++ b/packages/@coorpacademy-components/src/molecule/card-content/index.js
@@ -106,6 +106,7 @@ const AuthorName = ({author, empty, courseContent, certifiedAuthor, 'aria-label'
     <div
       data-name="author"
       title={author}
+      role="group"
       aria-label={ariaLabel}
       className={classnames(
         style.author,

--- a/packages/@coorpacademy-components/src/molecule/card/customer.js
+++ b/packages/@coorpacademy-components/src/molecule/card/customer.js
@@ -18,7 +18,7 @@ const Customer = props => {
   );
 
   return (
-    <div className={className} disabled={disabled} aria-label={ariaLabel}>
+    <div className={className} disabled={disabled} role="group" aria-label={ariaLabel}>
       <div className={style.content}>
         {coorpOriginal ? <span className={style.coorp}>Coorp </span> : null}
         {coorpOriginal ? <span className={style.original}>Original </span> : null}

--- a/packages/@coorpacademy-components/src/molecule/card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/card/index.js
@@ -76,6 +76,7 @@ const CardBackground = ({type, image, empty, 'aria-label': ariaLabel}, {skin}) =
         <div className={style.imageWrapper}>
           <div
             data-name="cover"
+            role="img"
             aria-label={ariaLabel}
             style={{
               backgroundColor: iconColor,
@@ -92,6 +93,7 @@ const CardBackground = ({type, image, empty, 'aria-label': ariaLabel}, {skin}) =
       <div className={style.imageWrapper}>
         <div
           data-name="cover"
+          role="img"
           aria-label={ariaLabel}
           style={{
             backgroundColor: iconColor
@@ -111,6 +113,7 @@ const CardBackground = ({type, image, empty, 'aria-label': ariaLabel}, {skin}) =
     <div className={style.imageWrapper}>
       <div
         data-name="cover"
+        role="img"
         aria-label={ariaLabel}
         className={style.image}
         style={{
@@ -183,6 +186,7 @@ const Card = memo(function Card(props, context) {
     <div className={style.lockContent}>
       <LockIcon className={style.lockIcon} height={48} />
       <span
+        role="group"
         aria-label={disabledArialabel}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{__html: disabledContent}}
@@ -208,6 +212,7 @@ const Card = memo(function Card(props, context) {
       data-type={getType(type)}
       disabled={disabled}
       onClick={handleClick}
+      role="group"
       aria-label={cardArialabel}
     >
       <CardBackground type={type} image={image} empty={empty} aria-label={backgroundAriaLabel} />
@@ -249,12 +254,17 @@ const Card = memo(function Card(props, context) {
         aria-label={cardContentLabelAriaLabel}
       />
       {badge ? (
-        <div className={style.badge} style={inlineBadgeStyle} aria-label={badgeAriaLabel}>
+        <div
+          className={style.badge}
+          style={inlineBadgeStyle}
+          role="group"
+          aria-label={badgeAriaLabel}
+        >
           {badge}
         </div>
       ) : null}
       {disabled ? (
-        <div className={style.lockWrapper} aria-label={disabledArialabel}>
+        <div className={style.lockWrapper} role="group" aria-label={disabledArialabel}>
           {lock}
         </div>
       ) : null}

--- a/packages/@coorpacademy-components/src/molecule/course-section/index.js
+++ b/packages/@coorpacademy-components/src/molecule/course-section/index.js
@@ -22,9 +22,19 @@ const CourseSection = props => {
   } = props;
 
   return (
-    <div className={style.container} aria-label={ariaLabelTitle} data-name={`course-section-${id}`}>
+    <div
+      className={style.container}
+      role="group"
+      aria-label={ariaLabelTitle}
+      data-name={`course-section-${id}`}
+    >
       <div className={style.wrapper}>
-        <span className={style.position} aria-label={coursePosition} data-name="position">
+        <span
+          className={style.position}
+          role="group"
+          aria-label={coursePosition}
+          data-name="position"
+        >
           {position}
         </span>
         <div className={style.containerImage}>
@@ -32,7 +42,7 @@ const CourseSection = props => {
         </div>
         <div className={style.containerInfos}>
           <div className={style.title}>{title}</div>
-          <span className={style.author} aria-label={ariaLabelAuthor}>
+          <span className={style.author} role="group" aria-label={ariaLabelAuthor}>
             {author}
           </span>
         </div>

--- a/packages/@coorpacademy-components/src/molecule/dashboard/learning-profile-banner/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/learning-profile-banner/index.js
@@ -22,18 +22,10 @@ const LearningProfileBanner = React.memo(function LearningProfileBanner(props) {
             <img className={style.image} src={BOOK_IMG_URL} alt="Notebook image" />
           </div>
           <div className={style.middle}>
-            <span
-              className={style.title}
-              data-name="learning-profile-banner-title"
-              aria-label="{title}"
-            >
+            <span className={style.title} data-name="learning-profile-banner-title">
               {title}
             </span>
-            <span
-              className={style.subtitle}
-              data-name="learning-profile-banner-subtitle"
-              aria-label="{subtitle}"
-            >
+            <span className={style.subtitle} data-name="learning-profile-banner-subtitle">
               {subtitle}
             </span>
             <ButtonLink {...buttonProps} className={style.cta} />

--- a/packages/@coorpacademy-components/src/molecule/dashboard/review-banner/index.js
+++ b/packages/@coorpacademy-components/src/molecule/dashboard/review-banner/index.js
@@ -23,14 +23,10 @@ const ReviewBanner = React.memo(function ReviewBanner(props) {
             />
           </div>
           <div className={style.middle}>
-            <span className={style.title} data-name="review-banner-title" aria-label="{title}">
+            <span className={style.title} data-name="review-banner-title">
               {title}
             </span>
-            <span
-              className={style.subtitle}
-              data-name="review-banner-subtitle"
-              aria-label="{subtitle}"
-            >
+            <span className={style.subtitle} data-name="review-banner-subtitle">
               {subtitle}
             </span>
             <ButtonLink {...buttonProps} className={style.cta} />

--- a/packages/@coorpacademy-components/src/molecule/learner-skill-card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/learner-skill-card/index.js
@@ -14,6 +14,15 @@ export const updateBackgroundImage = (ref, background) => {
     ref.current.style.backgroundImage = background;
   }
 };
+
+const handleCardKeyDown = onClick => event => {
+  if (!onClick) return;
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    onClick(event);
+  }
+};
+
 const LearnerSkillCard = (props, context) => {
   const {
     'aria-label': ariaLabel,
@@ -46,6 +55,9 @@ const LearnerSkillCard = (props, context) => {
       data-testid={`learner-skill-card-wrapper-${cardIndex}`}
       data-name={`skill-card-${label}`}
       onClick={onClick}
+      role={onClick ? 'button' : 'group'}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={handleCardKeyDown(onClick)}
       className={style.learnerSkillCardContainer}
       aria-label={ariaLabel}
       onMouseEnter={handleMouseEnter}
@@ -99,6 +111,7 @@ const LearnerSkillCard = (props, context) => {
             <div
               data-name="skill-card-title"
               className={style.skillTitle}
+              role="group"
               aria-label={ariaLabel || title}
             >
               {title}

--- a/packages/@coorpacademy-components/src/molecule/learning-priority-card/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/learning-priority-card/index.tsx
@@ -42,6 +42,7 @@ const LearningPriorityCard = (props: LearningPriorityCardPropTypes, context: Web
   return (
     <div
       className={style.container}
+      role="group"
       aria-label={`learning priority card ${title}`}
       data-name={`learning-priority-card-${title}`}
     >

--- a/packages/@coorpacademy-components/src/molecule/learning-priority-setup-item/index.js
+++ b/packages/@coorpacademy-components/src/molecule/learning-priority-setup-item/index.js
@@ -29,6 +29,7 @@ const LearningPrioritySetupItem = (props, context) => {
   return (
     <div
       className={style.container}
+      role="group"
       aria-label={ariaLabel}
       data-name={`learning-priority-setup-item-${id}`}
     >

--- a/packages/@coorpacademy-components/src/molecule/progress-wrapper/index.js
+++ b/packages/@coorpacademy-components/src/molecule/progress-wrapper/index.js
@@ -53,6 +53,7 @@ const DetailSection = ({index, type, isLocked, downloadUrl, stars}, context) => 
     <div
       className={style[`detailsSection${index}`]}
       data-name={type}
+      role="group"
       aria-label={`${type} informations`}
     >
       <div className={style.detailsInfo}>
@@ -69,6 +70,7 @@ const DetailSection = ({index, type, isLocked, downloadUrl, stars}, context) => 
     <div
       className={style[`detailsSection${index}`]}
       data-name={type}
+      role="group"
       aria-label={`${type} informations`}
     >
       <img
@@ -114,6 +116,7 @@ const ProgressWrapper = (
     <div
       className={style.container}
       data-name="prgress-wrapper"
+      role="group"
       aria-label="progress wrapper section"
     >
       <div className={style.titleContainer}>

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/index.js
@@ -39,6 +39,7 @@ const QCMImage = (props, legacyContext) => {
           <div
             className={style.imageWrapper}
             data-name="answerImage"
+            role="img"
             aria-label={ariaLabel || title}
             title={ariaLabel || title}
             style={{

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/qcm-graphic.tsx
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm-graphic/test/qcm-graphic.tsx
@@ -9,7 +9,7 @@ import defaultFixture from './fixtures/default';
 browserEnv();
 
 test('onClick should be reachable, should match given aria-label', t => {
-  t.plan(5);
+  t.plan(6);
   let answerWasClicked = false;
   defaultFixture.props.answers[1] = {
     ...defaultFixture.props.answers[1],
@@ -23,6 +23,7 @@ test('onClick should be reachable, should match given aria-label', t => {
     '[data-name="answerGraphic"]:nth-child(2) :nth-child(2) :nth-child(1)'
   ) as Element;
   t.truthy(secondAnswer);
+  t.is(secondAnswer.getAttribute('role'), 'img');
   t.is(
     secondAnswer.getAttribute('aria-label'),
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sut labore et dolore magna aliqua.'

--- a/packages/@coorpacademy-components/src/molecule/questions/qcm/index.js
+++ b/packages/@coorpacademy-components/src/molecule/questions/qcm/index.js
@@ -7,6 +7,14 @@ import Provider, {GetSkinFromContext} from '../../../atom/provider';
 import {getShadowBoxColorFromPrimary} from '../../../util/get-shadow-box-color-from-primary';
 import style from './style.css';
 
+const handleAnswerKeyDown = onClick => event => {
+  if (!onClick) return;
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    onClick(event);
+  }
+};
+
 const QCM = (props, legacyContext) => {
   const {answers, groupAriaLabel} = props;
   const longestAnswer = maxBy(({title}) => title.length, answers);
@@ -23,10 +31,13 @@ const QCM = (props, legacyContext) => {
         return (
           <div
             data-name="answer"
+            role="button"
+            tabIndex={0}
             aria-label={ariaLabel || title}
             title={ariaLabel || title}
             className={classnames(longAnswerClass, style.innerHTML, selectedAnswerClass)}
             onClick={onClick}
+            onKeyDown={handleAnswerKeyDown(onClick)}
             style={{
               ...(selected && {
                 boxShadow: `0 4px 16px ${getShadowBoxColorFromPrimary(primarySkinColor)}`

--- a/packages/@coorpacademy-components/src/molecule/quick-filters/index.tsx
+++ b/packages/@coorpacademy-components/src/molecule/quick-filters/index.tsx
@@ -120,6 +120,7 @@ const QuickFilters = (
         className={style.filtersList}
         ref={filtersListRef}
         data-testid="filters-options-list"
+        role="group"
         aria-label={filterOptionsAriaLabel}
       >
         <div

--- a/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
+++ b/packages/@coorpacademy-components/src/molecule/review-correction-popin/index.js
@@ -105,14 +105,15 @@ const ReviewCorrectionPopin = props => {
           </div>
         </div>
         <div className={style.feedbackSection}>
-          <div className={style.information} aria-label="answer-information">
+          <div className={style.information} role="group" aria-label="answer-information">
             <div className={style.labelContainer}>
-              <span className={style.label} aria-label={information.label}>
+              <span className={style.label} role="group" aria-label={information.label}>
                 {information.label}
               </span>
             </div>
             <span
               className={style.message}
+              role="group"
               aria-label={information.message}
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{__html: information.message}}

--- a/packages/@coorpacademy-components/src/molecule/search-form/index.js
+++ b/packages/@coorpacademy-components/src/molecule/search-form/index.js
@@ -37,6 +37,13 @@ const SearchForm = (props, context) => {
     },
     [onReset]
   );
+  const handleResetKeyDown = useMemo(
+    () => evt => {
+      if (evt.key !== 'Enter' && evt.key !== ' ') return;
+      return handleReset(evt);
+    },
+    [handleReset]
+  );
 
   const isMooc = theme === 'mooc';
 
@@ -65,8 +72,11 @@ const SearchForm = (props, context) => {
       />
       <div
         data-name="search-form-reset"
+        role="button"
+        tabIndex={0}
         aria-label={searchResetAriaLabel}
         onMouseDown={handleReset}
+        onKeyDown={handleResetKeyDown}
         className={clearClassName}
       >
         <Icon iconName="xmark" className={style.clearIcon} aria-label={searchResetAriaLabel} />

--- a/packages/@coorpacademy-components/src/molecule/skill-card/index.js
+++ b/packages/@coorpacademy-components/src/molecule/skill-card/index.js
@@ -62,10 +62,16 @@ const SkillCard = (props, context) => {
   );
 
   return (
-    <div className={style.skillCardWrapper} data-name="skill-card-wrapper" aria-label={ariaLabel}>
+    <div
+      className={style.skillCardWrapper}
+      data-name="skill-card-wrapper"
+      role="group"
+      aria-label={ariaLabel}
+    >
       <div
         data-name="skill-title"
         className={style.skillTitle}
+        role="group"
         aria-label={skillAriaLabel || skillTitle}
         style={{
           background: titleBackground
@@ -77,6 +83,7 @@ const SkillCard = (props, context) => {
         <div
           className={style.questionReviseText}
           data-name="questions-to-revise-label"
+          role="group"
           aria-label={reviseAriaLabel || reviseLabel}
         >
           <QuestionIcon className={style.questionReviseIcon} width={16} height={16} />

--- a/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
+++ b/packages/@coorpacademy-components/src/organism/header-with-actions/index.tsx
@@ -111,7 +111,7 @@ const HeaderWithActions = (props: HeaderWithActionsProps) => {
               <p className={style.saveStatus}>{saveStatus.label}</p>
             ) : null}
           </div>
-          <h3 className={style.title} aria-label={title} data-name={getDataName('title')}>
+          <h3 className={style.title} data-name={getDataName('title')}>
             {title}
           </h3>
         </div>

--- a/packages/@coorpacademy-components/src/organism/list-item/index.js
+++ b/packages/@coorpacademy-components/src/organism/list-item/index.js
@@ -77,7 +77,7 @@ const ListItem = (
 
   const orderView =
     order !== null && order !== undefined ? (
-      <div className={style.order} aria-label={ariaLabel}>
+      <div className={style.order} role="group" aria-label={ariaLabel}>
         {order + 1}
       </div>
     ) : null;

--- a/packages/@coorpacademy-components/src/organism/mooc-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/mooc-header/index.js
@@ -744,6 +744,7 @@ class MoocHeader extends React.Component {
                 data-name={`setting-${settingName}`}
                 className={classnames(style.setting, disabled && style.disabled)}
                 key={settingName}
+                role="group"
                 aria-label={ariaLabel || title}
               >
                 <InputSwitch {...switchProps} aria-labelledby={`title-id-${settingName}`} />
@@ -831,6 +832,7 @@ class MoocHeader extends React.Component {
               style.logoWrapper,
               this.isMobile && isFocus && style.logoWrapperMobileHidden
             )}
+            role="group"
             aria-label={toolTipText}
             onMouseOver={this.handleOnMouseOver}
             onMouseLeave={this.handleOnMouseLeave}
@@ -866,7 +868,7 @@ class MoocHeader extends React.Component {
             >
               <Picture src={logoUrl} alt={logoAriaLabel} />
               {isToolTipOpen ? (
-                <div aria-label={toolTipText} tabIndex={0} data-testid="home-tooltip">
+                <div role="group" aria-label={toolTipText} tabIndex={0} data-testid="home-tooltip">
                   <div
                     aria-label={`${toolTipText} ${closeToolTipInformationTextAriaLabel}`}
                     role="tooltip"

--- a/packages/@coorpacademy-components/src/organism/review-congrats/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-congrats/index.js
@@ -35,6 +35,7 @@ const ReviewCongrats = props => {
   return (
     <div
       className={style.mainContainer}
+      role="group"
       aria-label={ariaLabel}
       data-name={dataName}
       data-testid="congrats"

--- a/packages/@coorpacademy-components/src/organism/review-header/index.js
+++ b/packages/@coorpacademy-components/src/organism/review-header/index.js
@@ -29,9 +29,20 @@ const ReviewHeader = (props, legacyContext) => {
   );
 
   return (
-    <div className={style.headerWrapper} data-name="review-header" aria-label={ariaLabel}>
+    <div
+      className={style.headerWrapper}
+      data-name="review-header"
+      role="group"
+      aria-label={ariaLabel}
+    >
       <div className={style.titlesWrapper}>
-        <div className={style.title} title={mode} aria-label={mode} data-name="review-header-mode">
+        <div
+          className={style.title}
+          title={mode}
+          role="group"
+          aria-label={mode}
+          data-name="review-header-mode"
+        >
           {mode}
         </div>
         <div
@@ -40,6 +51,7 @@ const ReviewHeader = (props, legacyContext) => {
             color: primarySkinColor
           }}
           title={skillName}
+          role="group"
           aria-label={skillName}
           data-name="review-header-skill-name"
         >

--- a/packages/@coorpacademy-components/src/template/app-review/skills/index.js
+++ b/packages/@coorpacademy-components/src/template/app-review/skills/index.js
@@ -19,7 +19,7 @@ const ReviewSkills = props => {
   } = props;
 
   return (
-    <div className={style.containerReviewSkill} aria-label={ariaLabel}>
+    <div className={style.containerReviewSkill} role="group" aria-label={ariaLabel}>
       <div className={style.title}>{title}</div>
       {isLoading ? (
         <div className={style.loaderContainer}>

--- a/packages/@coorpacademy-components/src/template/review-dashboard-skills/index.js
+++ b/packages/@coorpacademy-components/src/template/review-dashboard-skills/index.js
@@ -8,7 +8,7 @@ const ReviewDashboardSkills = props => {
   const {'aria-label': ariaLabel, reviewPresentation, reviewSkills} = props;
 
   return (
-    <div className={style.reviewDashboardContainer} aria-label={ariaLabel}>
+    <div className={style.reviewDashboardContainer} role="group" aria-label={ariaLabel}>
       <div className={style.reviewPresentationContainer}>
         <ReviewPresentation {...reviewPresentation} />
       </div>


### PR DESCRIPTION
## What changed

- Adds compatible roles to components that expose `aria-label` on generic wrappers, including CSS-backed images, grouped containers, and custom controls.
- Moves the custom select accessible label from the visual wrapper to the actual button.
- Adds keyboard activation for clickable `div` controls such as QCM answers, chips, search reset, and learner skill cards.
- Removes literal dashboard banner labels such as `{title}` and `{subtitle}` where visible text already provides the accessible name.

## Why

Axe reports `aria-prohibited-attr` when ARIA naming attributes are used on elements whose role does not permit them. Several components were applying `aria-label` to generic `div`/`span` wrappers, which can trigger WCAG 4.1.2 failures.